### PR TITLE
Skip storage delete when file is already missing

### DIFF
--- a/convex/reimbursements/functions.ts
+++ b/convex/reimbursements/functions.ts
@@ -129,7 +129,10 @@ export const deleteReimbursement = mutation({
       .collect();
 
     for (const receipt of receipts) {
-      await ctx.storage.delete(receipt.fileStorageId);
+      const fileExists = await ctx.storage.getUrl(receipt.fileStorageId);
+      if (fileExists) {
+        await ctx.storage.delete(receipt.fileStorageId);
+      }
       await ctx.db.delete(receipt._id);
     }
 

--- a/convex/signatures/functions.ts
+++ b/convex/signatures/functions.ts
@@ -79,7 +79,10 @@ export const cleanupExpired = internalMutation({
 
 		for (const token of expired) {
 			if (token.signatureStorageId) {
-				await ctx.storage.delete(token.signatureStorageId);
+				const fileExists = await ctx.storage.getUrl(token.signatureStorageId);
+				if (fileExists) {
+					await ctx.storage.delete(token.signatureStorageId);
+				}
 			}
 			await ctx.db.delete(token._id);
 		}

--- a/convex/volunteerAllowance/functions.ts
+++ b/convex/volunteerAllowance/functions.ts
@@ -239,7 +239,10 @@ export const remove = mutation({
     }
 
     if (doc.signatureStorageId) {
-      await ctx.storage.delete(doc.signatureStorageId);
+      const fileExists = await ctx.storage.getUrl(doc.signatureStorageId);
+      if (fileExists) {
+        await ctx.storage.delete(doc.signatureStorageId);
+      }
     }
 
     await ctx.db.delete(args.id);


### PR DESCRIPTION
Deleting a reimbursement, volunteer allowance, or expired signature token failed with a "storage id not found" error whenever the referenced file no longer existed in object storage, leaving the record permanently undeletable. Each `ctx.storage.delete` now checks file existence via `getUrl` first, matching the pattern already used for reimbursement signatures. This makes deletion robust against missing files from concurrent deletes, external bucket cleanup, or storage backend migrations.