### PR TITLE
Rename YBudget to YBase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-YBudget is an open-source budget management application for German non-profit associations. It provides budget tracking, reimbursement workflows, and CSV import from German banks (Sparkasse, Volksbank, Moss).
+YBase is an open-source budget management application for German non-profit associations. It provides budget tracking, reimbursement workflows, and CSV import from German banks (Sparkasse, Volksbank, Moss).
 
 ## Commands
 

--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@ whose value derives, entirely or substantially, from the functionality of the
 Software. Any license notice or attribution required by the License must also
 include this Commons Clause License Condition notice.
 
-Software: YBudget
+Software: YBase
 License: MIT License
 Licensor: Joël Heil Escobar
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# YBudget
+# YBase
 
 > Free, open-source budget management for German non-profit associations.
 
-YBudget helps German (non-profit) associations manage their budgets when Excel gets too complicated.
+YBase helps German (non-profit) associations manage their budgets when Excel gets too complicated.
 
 ## Free for Associations
-We believe every association deserves proper budget tools. That's why we cover all hosting and server costs—so you can use yBudget at no charge. No hidden fees, no premium tiers, just free budget management for the nonprofit community.
+We believe every association deserves proper budget tools. That's why we cover all hosting and server costs—so you can use YBase at no charge. No hidden fees, no premium tiers, just free budget management for the nonprofit community.
 
- [Young Founders Network e.V.](https://youngfounders.network) provides yBudget **completely free** for other associations. We cover all server costs so you don't have to.
+ [Young Founders Network e.V.](https://youngfounders.network) provides YBase **completely free** for other associations. We cover all server costs so you don't have to.
 
 **The problem?**
 Most budget tools are too expensive or too complex for associations. Excel is flexible but keeping track of all expenses is plenty of work.
@@ -41,7 +41,7 @@ Simple, free, intuitive budget and reimbursement tracking for non-profits.
 
 ## Architecture
 
-YBudget uses Next.js App Router with protected and public routes:
+YBase uses Next.js App Router with protected and public routes:
 
 - `app/(public)/` → Login and public pages
 - `app/(protected)/` → Authenticated dashboard with sidebar navigation
@@ -66,8 +66,8 @@ Transactions are categorized by status for budget calculations:
 ### 1. Clone & Install
 
 ```bash
-git clone https://github.com/joelheile/ybudget.git
-cd ybudget
+git clone https://github.com/joelheile/ybase.git
+cd ybase
 pnpm install
 npx convex dev  # Creates .env.local with CONVEX_DEPLOYMENT and NEXT_PUBLIC_CONVEX_URL
 ```
@@ -137,7 +137,7 @@ We're building a tool to support NGOs by making budgeting as easy as possible.
 6. Open a Pull Request
 
 **Ideas, feedback, or questions?**
-[team@ybudget.de](mailto:team@ybudget.de) | [Open an issue](https://github.com/joelheile/ybudget/issues)
+[info@youngfounders.network](mailto:info@youngfounders.network) | [Open an issue](https://github.com/joelheile/ybase/issues)
 
 ## Testing
 

--- a/app/(public)/datenschutz/page.tsx
+++ b/app/(public)/datenschutz/page.tsx
@@ -163,7 +163,7 @@ export default function DatenschutzPage() {
       <p className="mb-4">
         Telefon: 01715871414
         <br />
-        E-Mail: team@ybudget.de
+        E-Mail: info@youngfounders.network
       </p>
       <p className="mb-4">
         Verantwortliche Stelle ist die natürliche oder juristische Person, die

--- a/app/(public)/impressum/page.tsx
+++ b/app/(public)/impressum/page.tsx
@@ -25,7 +25,8 @@ export default function ImpressumPage() {
         <br />
         Telefon: +49-01715871414
         <br />
-        E-Mail: <a href="mailto:team@ybudget.de">team@ybudget.de</a>
+        E-Mail:{" "}
+        <a href="mailto:info@youngfounders.network">info@youngfounders.network</a>
       </p>
 
       <p className="mb-4">

--- a/app/components/Auth/LoginForm.tsx
+++ b/app/components/Auth/LoginForm.tsx
@@ -12,14 +12,14 @@ export function LoginForm() {
     <div className="flex flex-col items-center gap-12 text-center">
       <Image
         src="/LoginIllustration.svg"
-        alt="YBudget"
+        alt="YBase"
         width={350}
         height={350}
         priority
       />
       <div className="space-y-3">
         <h1 className="text-3xl font-bold tracking-tight">
-          Willkommen bei <span className="text-primary">YBudget</span>
+          Willkommen bei <span className="text-primary">YBase</span>
         </h1>
         <p className="text-muted-foreground text-sm">
           Melde dich mit deinem Google Konto an, um direkt loszulegen.

--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -49,12 +49,12 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
               <Link href="/reimbursements">
                 <Image
                   src="/AppIcon.png"
-                  alt="YBudget"
+                  alt="YBase"
                   width={32}
                   height={32}
                 />
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">YBudget</span>
+                  <span className="truncate font-semibold">YBase</span>
                 </div>
               </Link>
             </SidebarMenuButton>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ const lexendDeca = Lexend_Deca({
 });
 
 export const metadata: Metadata = {
-  title: "yBudget",
+  title: "YBase",
   description: "Budget management for organizations",
 };
 

--- a/convex/invitations/functions.ts
+++ b/convex/invitations/functions.ts
@@ -26,14 +26,14 @@ export const sendInvitation = mutation({
     const senderName = escapeHtml(user.firstName ?? "");
 
     await resend.sendEmail(ctx, {
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: args.email,
-      subject: "Einladung zu YBudget",
+      subject: "Einladung zu YBase",
       html: `
       <p>Hey ${firstName},</p>
-      <p>Du wurdest von ${senderName} zu YBudget eingeladen :) </p>
+      <p>Du wurdest von ${senderName} zu YBase eingeladen :) </p>
       <p>Klicke auf den folgenden Link, um dich einzuloggen:</p>
-      <a href="https://ybudget.de/login">Login</a>
+      <a href="https://ybase.de/login">Login</a>
       <p>Viel Spaß beim Budgeting!</p>
       `,
     });

--- a/convex/reimbursements/sendApprovalEmail.ts
+++ b/convex/reimbursements/sendApprovalEmail.ts
@@ -30,7 +30,7 @@ export const sendApprovalEmail = internalAction({
     const resend = new Resend(process.env.RESEND_API_KEY);
 
     await resend.emails.send({
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: [data.organization.accountingEmail],
       cc: data.creator.email ? [data.creator.email] : [],
       subject: `Erstattung genehmigt: ${data.project.name} - ${data.amount.toFixed(2)}€`,
@@ -205,7 +205,7 @@ export const sendRejectionEmail = internalAction({
     const resend = new Resend(process.env.RESEND_API_KEY);
 
     await resend.emails.send({
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: [data.organization.accountingEmail],
       cc: data.creator.email ? [data.creator.email] : [],
       subject: `Erstattung abgelehnt: ${data.project.name} - ${data.amount.toFixed(2)}€`,

--- a/convex/reimbursements/sharing.ts
+++ b/convex/reimbursements/sharing.ts
@@ -157,14 +157,14 @@ export const sendReimbursementLink = mutation({
     const projectName = escapeHtml(args.projectName);
 
     await resend.sendEmail(ctx, {
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: args.email,
       subject: `${typeLabel} ausfüllen`,
       html: `
         <p>Hallo,</p>
         <p>${senderName} hat dir einen Link zum Ausfüllen der ${typeLabel} für das Projekt "${projectName}" gesendet.</p>
         <p><a href="${args.link}">Hier klicken zum Ausfüllen</a></p>
-        <p>Viele Grüße,<br/>Dein YBudget Team</p>
+        <p>Viele Grüße,<br/>Dein YBase Team</p>
       `,
     });
   },

--- a/convex/volunteerAllowance/functions.ts
+++ b/convex/volunteerAllowance/functions.ts
@@ -271,14 +271,14 @@ export const sendAllowanceLink = mutation({
     const projectName = escapeHtml(args.projectName);
 
     await resend.sendEmail(ctx, {
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: args.email,
       subject: "Ehrenamtspauschale ausfüllen",
       html: `
         <p>Hallo,</p>
         <p>${senderName} hat dir einen Link zum Ausfüllen der Ehrenamtspauschale für das Projekt "${projectName}" gesendet.</p>
         <p><a href="${args.link}">Hier klicken zum Ausfüllen</a></p>
-        <p>Viele Grüße,<br/>Dein YBudget Team</p>
+        <p>Viele Grüße,<br/>Dein YBase Team</p>
       `,
     });
   },

--- a/convex/volunteerAllowance/sendEmails.ts
+++ b/convex/volunteerAllowance/sendEmails.ts
@@ -16,7 +16,7 @@ export const sendApprovalEmail = internalAction({
     const resend = new Resend(process.env.RESEND_API_KEY);
 
     await resend.emails.send({
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: [data.organization.accountingEmail],
       cc: data.creator.email ? [data.creator.email] : [],
       subject: `Ehrenamtspauschale genehmigt: ${data.volunteerName} - ${data.amount.toFixed(2)}€`,
@@ -58,7 +58,7 @@ export const sendRejectionEmail = internalAction({
     const resend = new Resend(process.env.RESEND_API_KEY);
 
     await resend.emails.send({
-      from: "YBudget <team@ybudget.de>",
+      from: "YBase <info@youngfounders.network>",
       to: [data.organization.accountingEmail],
       cc: data.creator.email ? [data.creator.email] : [],
       subject: `Ehrenamtspauschale abgelehnt: ${data.volunteerName} - ${data.amount.toFixed(2)}€`,

--- a/deploy/convex-selfhosted/.env.example
+++ b/deploy/convex-selfhosted/.env.example
@@ -10,7 +10,7 @@ POSTGRES_URL=postgresql://convex:CHANGE_ME@<pg-container-name>:5432
 DO_NOT_REQUIRE_SSL=1
 
 # Instance identity — generate once, keep constant. INSTANCE_SECRET: openssl rand -hex 32
-INSTANCE_NAME=ybudget-prod
+INSTANCE_NAME=ybase-prod
 INSTANCE_SECRET=CHANGE_ME_openssl_rand_hex_32
 
 DISABLE_BEACON=true
@@ -21,11 +21,11 @@ AWS_REGION=nbg1
 AWS_ACCESS_KEY_ID=CHANGE_ME
 AWS_SECRET_ACCESS_KEY=CHANGE_ME
 S3_ENDPOINT_URL=https://nbg1.your-objectstorage.com
-S3_STORAGE_FILES_BUCKET=ybudget-convex-files
-S3_STORAGE_EXPORTS_BUCKET=ybudget-convex-exports
-S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET=ybudget-convex-imports
-S3_STORAGE_MODULES_BUCKET=ybudget-convex-modules
-S3_STORAGE_SEARCH_BUCKET=ybudget-convex-search
+S3_STORAGE_FILES_BUCKET=ybase-convex-files
+S3_STORAGE_EXPORTS_BUCKET=ybase-convex-exports
+S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET=ybase-convex-imports
+S3_STORAGE_MODULES_BUCKET=ybase-convex-modules
+S3_STORAGE_SEARCH_BUCKET=ybase-convex-search
 
 # Set on the deployment via `npx convex env set ...` after first deploy, NOT here:
 #   JWT_PRIVATE_KEY, JWKS (from generateKeys.mjs)

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,6 +1,6 @@
 # Security
 
-We take security seriously at YBudget. Here's how we protect your financial data.
+We take security seriously at YBase. Here's how we protect your financial data.
 
 ## Authentication & Authorization
 
@@ -79,4 +79,4 @@ For STRIDE analysis and data flow diagrams, see [ThreatModel.md](ThreatModel.md)
 
 ## Report an Issue
 
-Email team@ybudget.de with security concerns.
+Email info@youngfounders.network with security concerns.

--- a/docs/ThreatModel.md
+++ b/docs/ThreatModel.md
@@ -1,13 +1,13 @@
 ## Data Flow Diagram
 
-I've mapped out YBudget's security architecture using a Level 1 Data Flow Diagram to visualize how data moves through the system and where the critical trust boundaries are between services.
+I've mapped out YBase's security architecture using a Level 1 Data Flow Diagram to visualize how data moves through the system and where the critical trust boundaries are between services.
 
 **What are trust boundaries?**
 Trust boundaries highlight the points where data crosses between zones with different security levels. When data moves across these boundaries, it needs protection in form of validating and authenticating the data before it enters zones with a higher trust, and encrypting before going out to less trusted areas.
 
 ### Our Trust Zones
 
-I've organized YBudget into five security zones, each with different trust levels and protection mechanisms.
+I've organized YBase into five security zones, each with different trust levels and protection mechanisms.
 
 **Public Zone (Untrusted)**
 
@@ -34,7 +34,7 @@ _(Diagram was created in FigJam)_
 
 ## Trust Boundary Analysis using STRIDE
 
-I analyzed each trust boundary using the **STRIDE** framework, which was developed by Microsoft to identify YBudget's security strengths and weaknesses.
+I analyzed each trust boundary using the **STRIDE** framework, which was developed by Microsoft to identify YBase's security strengths and weaknesses.
 
 - **Spoofing:** Pretending to be someone else → Fake login, forged webhook (mitigated through OAuth, JWT verification, webhook signatures)
 - **Tampering:** Unauthorized data modification → Changing transaction amounts (Input validation, type-safe queries, digital signatures)

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,4 +1,4 @@
--- YBudget Schema DDL for DrawSQL
+-- YBase Schema DDL for DrawSQL
 -- Generated from convex/schema.ts
 
 CREATE TABLE organizations (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ybudget",
+  "name": "ybase",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Renames the app from **YBudget** to **YBase** across the UI (sidebar, login, page title), transactional emails, README, docs, LICENSE, the package name, and the self-hosted `.env.example` example IDs (instance name + S3 bucket names). All contact and email-sender addresses now use `info@youngfounders.network` (replacing `team@ybudget.de`), and the invitation login link points to `https://ybase.de/login`. The `mealAllowanceDailyBudget` field was deliberately left untouched (it only coincidentally contains the substring), TypeScript is clean, and all 154 unit/integration tests pass. Note: `youngfounders.network` must be verified as a Resend sending domain or outgoing emails will fail.