### PR TITLE
Beleg-Button: "Beleg hinzufügen" beim ersten Beleg

### DIFF
--- a/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
+++ b/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
@@ -484,7 +484,9 @@ export default function ExternalReimbursementPageUI(props: Props) {
 
               <Button onClick={props.onAddReceipt} variant="outline" className="w-full">
                 <Plus className="size-5 mr-2" />
-                Weiteren Beleg hinzufügen
+                {props.receipts.length === 0
+                  ? "Beleg hinzufügen"
+                  : "Weiteren Beleg hinzufügen"}
               </Button>
             </div>
 

--- a/app/components/Reimbursements/ReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/ReimbursementFormUI.tsx
@@ -249,7 +249,9 @@ export function ReimbursementFormUI({ defaultBankDetails }: Props) {
           size="lg"
         >
           <Plus className="size-5 mr-2" />
-          Weiteren Beleg hinzufügen
+          {receipts.length === 0
+            ? "Beleg hinzufügen"
+            : "Weiteren Beleg hinzufügen"}
         </Button>
       </div>
 


### PR DESCRIPTION
Im Auslagenerstattungs-Formular (geschützt und öffentlich) zeigt der Button zum Übernehmen eines Belegs jetzt „Beleg hinzufügen", solange die Liste leer ist, und wechselt erst danach zu „Weiteren Beleg hinzufügen". Das Reisekosten-Formular bleibt unverändert (Belege dort über Kostenart-Chips). Geprüft mit tsc; der E2E-Test (`reimbursements.spec.ts`) bleibt grün, da er den Button bereits über „Beleg hinzufügen" anspricht.