### PR TITLE
Fix mobile signing: portrait instead of forced landscape

### DIFF
--- a/app/(public)/sign/[token]/page.tsx
+++ b/app/(public)/sign/[token]/page.tsx
@@ -3,38 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";
-import {
-  AlertCircle,
-  CheckCircle2,
-  Loader2,
-  RotateCcw,
-  Signature,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2, RotateCcw } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useRef, useState } from "react";
 import SignaturePad from "react-signature-canvas";
 import toast from "react-hot-toast";
-
-async function enterLandscapeFullscreen() {
-  try {
-    await document.documentElement.requestFullscreen?.();
-  } catch {}
-  try {
-    const orientation = screen.orientation as ScreenOrientation & {
-      lock?: (orientation: string) => Promise<void>;
-    };
-    await orientation?.lock?.("landscape");
-  } catch {}
-}
-
-function exitLandscapeFullscreen() {
-  try {
-    screen.orientation?.unlock?.();
-  } catch {}
-  try {
-    if (document.fullscreenElement) document.exitFullscreen?.();
-  } catch {}
-}
 
 export default function SignaturePage() {
   const { token } = useParams<{ token: string }>();
@@ -46,14 +19,8 @@ export default function SignaturePage() {
   const submitSignature = useMutation(api.signatures.functions.submit);
 
   const signaturePadRef = useRef<SignaturePad>(null);
-  const [started, setStarted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-
-  const handleStart = async () => {
-    await enterLandscapeFullscreen();
-    setStarted(true);
-  };
 
   const handleSave = async () => {
     if (!signaturePadRef.current || signaturePadRef.current.isEmpty()) {
@@ -80,7 +47,6 @@ export default function SignaturePage() {
 
       const { storageId } = await result.json();
       await submitSignature({ token, signatureStorageId: storageId });
-      exitLandscapeFullscreen();
       setSubmitted(true);
     } catch {
       toast.error("Speichern fehlgeschlagen");
@@ -123,34 +89,22 @@ export default function SignaturePage() {
     );
   }
 
-  if (!started) {
-    return (
-      <div className="fixed inset-0 flex items-center justify-center bg-white p-8">
-        <div className="w-full max-w-xs text-center">
-          <Signature className="size-16 text-muted-foreground mx-auto mb-4" />
-          <h1 className="text-2xl font-bold mb-6">Unterschreiben</h1>
-          <Button size="lg" className="w-full h-14" onClick={handleStart}>
-            Unterschrift starten
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="signature-page fixed inset-0 flex flex-col bg-white">
-      <div className="flex-1 p-4 flex flex-col">
+    <div className="fixed inset-0 flex flex-col bg-white">
+      <div className="flex-1 p-4 flex flex-col min-h-0">
         <p className="text-center text-muted-foreground mb-2">
           Bitte hier unterschreiben
         </p>
         <div className="flex-1 border-2 border-dashed rounded-lg bg-gray-50 relative">
           <SignaturePad
             ref={signaturePadRef}
+            minWidth={2}
+            maxWidth={3}
             canvasProps={{
               className: "absolute inset-0 w-full h-full",
             }}
           />
-          <div className="absolute left-4 right-4 bottom-1/3 border-b border-gray-300 pointer-events-none" />
+          <div className="absolute left-4 right-4 bottom-1/4 border-b border-gray-300 pointer-events-none" />
         </div>
       </div>
       <div className="p-4 flex gap-4 border-t">
@@ -173,20 +127,6 @@ export default function SignaturePage() {
           Speichern
         </Button>
       </div>
-
-      <style jsx global>{`
-        @media screen and (orientation: portrait) {
-          .signature-page {
-            transform: rotate(90deg);
-            transform-origin: left top;
-            width: 100vh;
-            height: 100vw;
-            position: fixed;
-            top: 100%;
-            left: 0;
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/app/components/Reimbursements/SignatureField.tsx
+++ b/app/components/Reimbursements/SignatureField.tsx
@@ -56,19 +56,14 @@ export function SignatureField({
 }
 
 function SignaturePreview({ storageId }: { storageId: Id<"_storage"> }) {
-  const previewUrl = useQuery(
-    api.reimbursements.queries.getFileUrl,
-    { storageId },
-  );
+  const previewUrl = useQuery(api.reimbursements.queries.getFileUrl, {
+    storageId,
+  });
 
   return (
     <div className="border rounded-lg p-4">
       {previewUrl ? (
-        <img
-          src={previewUrl}
-          alt="Unterschrift"
-          className="max-h-24 mx-auto"
-        />
+        <img src={previewUrl} alt="Unterschrift" className="max-h-24 mx-auto" />
       ) : (
         <div className="h-24 flex items-center justify-center">
           <Loader2 className="size-5 animate-spin text-muted-foreground" />
@@ -129,9 +124,8 @@ function MobileCanvas({
 
   return (
     <div className="space-y-2">
-      <p className="text-sm text-muted-foreground flex items-center gap-2">
-        <RotateCcw className="size-4" />
-        Drehe dein Handy ins Querformat für mehr Platz.
+      <p className="text-sm text-muted-foreground">
+        Bitte hier unterschreiben.
       </p>
       <div className="border rounded-lg bg-white">
         <SignaturePad


### PR DESCRIPTION
The mobile signing page (`/sign/[token]`) used to force landscape via fullscreen + `screen.orientation.lock` with a `rotate(90deg)` CSS fallback, which fails on iOS Safari and misaligns the signature canvas (the library measures the canvas via `offsetWidth/offsetHeight`, which is wrong inside the rotated layout). This switches signing to a simple full-screen portrait layout that fills the screen, dropping the orientation lock, the rotation hack, and the now-unneeded "start" step. The inline `MobileCanvas` hint no longer tells users to rotate to landscape. Net result is 78 lines removed for 12 added. Please test on a real phone that the stroke now sits under the finger and the field fills the screen.