### PR TITLE
add receipt address warning to reimbursement forms

### DIFF
--- a/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReceiptUploadExternal } from "@/components/Reimbursements/ReceiptUploadExternal";
+import { ReceiptAddressNotice } from "@/components/Reimbursements/ReceiptAddressNotice";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -49,6 +50,7 @@ export function SimpleReceiptsSection(props: Props) {
       <p className="text-sm text-muted-foreground">
         Füge alle Belege hinzu, die du einreichen möchtest.
       </p>
+      <ReceiptAddressNotice />
 
       <div className="border rounded-lg p-4 space-y-4">
         <div className="grid grid-cols-2 gap-4">

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReceiptUploadExternal } from "@/components/Reimbursements/ReceiptUploadExternal";
+import { ReceiptAddressNotice } from "@/components/Reimbursements/ReceiptAddressNotice";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -129,7 +130,8 @@ export function TravelReceiptCard(props: Props) {
       </div>
 
       {receipt.grossAmount > 0 && (
-        <div>
+        <div className="space-y-3">
+          {!isCar ? <ReceiptAddressNotice /> : null}
           <Label>Beleg *</Label>
           <ReceiptUploadExternal
             onUploadComplete={(storageId) =>

--- a/app/components/Reimbursements/ReceiptAddressNotice.tsx
+++ b/app/components/Reimbursements/ReceiptAddressNotice.tsx
@@ -1,0 +1,25 @@
+import { TriangleAlert } from "lucide-react";
+
+export function ReceiptAddressNotice() {
+  return (
+    <aside
+      aria-label="Hinweis zur Rechnungsadresse"
+      className="flex gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3"
+    >
+      <TriangleAlert
+        aria-hidden="true"
+        className="mt-0.5 size-5 shrink-0 text-amber-700 dark:text-amber-400"
+      />
+      <div className="space-y-1 text-sm">
+        <p className="font-semibold text-foreground">
+          Rechnung auf den Verein ausstellen
+        </p>
+        <p className="leading-relaxed text-muted-foreground">
+          Auf dem Beleg muss die vollständige Vereinsadresse als
+          Rechnungsadresse stehen. Prüfe das besonders bei Rechnungen der
+          Deutschen Bahn.
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
@@ -14,6 +14,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { toNet } from "@/lib/bank-utils";
 import { Plus } from "lucide-react";
+import { ReceiptAddressNotice } from "../ReceiptAddressNotice";
 import { ReceiptUpload } from "../ReceiptUpload";
 import type { Draft } from "./types";
 
@@ -41,6 +42,7 @@ export function ReceiptDraftFields({
         Du kannst mehrere Belege hinzufügen, um sie in einer Erstattung
         einzureichen.
       </p>
+      <ReceiptAddressNotice />
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Label>Name/Firma *</Label>

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReceiptUpload } from "@/components/Reimbursements/ReceiptUpload";
+import { ReceiptAddressNotice } from "@/components/Reimbursements/ReceiptAddressNotice";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -137,7 +138,8 @@ export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
       </div>
 
       {receipt.grossAmount > 0 && (
-        <div>
+        <div className="space-y-3">
+          {receipt.costType !== "car" ? <ReceiptAddressNotice /> : null}
           <Label>Beleg *</Label>
           <ReceiptUpload
             onUploadComplete={(id) =>


### PR DESCRIPTION
## Summary

- add a prominent invoice-address warning to internal and public reimbursement forms
- reuse one accessible notice across expense and travel flows
- omit the notice for mileage-only reimbursements

## Validation

- TypeScript check
- production build on the complete workspace
- diff check

Linear: [YFN-174](https://linear.app/youngfoundersnetwork/issue/YFN-174/warnhinweis-belege-mussen-auf-die-vereinsadresse-ausgestellt-sein)