### PR TITLE
restrict project creation and renaming to admins

### DIFF
--- a/app/components/Selectors/SelectProject.tsx
+++ b/app/components/Selectors/SelectProject.tsx
@@ -3,6 +3,7 @@
 import { CreateProjectDialog } from "@/components/Dialogs/CreateProjectDialog";
 import type { Project } from "@/lib/db/types";
 import { focusNextInput } from "@/lib/focusNextInput";
+import { useIsAdmin } from "@/lib/hooks/useCurrentUserRole";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -20,6 +21,7 @@ export function SelectProject({
   projects,
   autoFocus,
 }: Props) {
+  const isAdmin = useIsAdmin();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -130,26 +132,30 @@ export function SelectProject({
                 {value === project._id && <Check className="h-4 w-4" />}
               </button>
             ))}
-            <button
-              type="button"
-              className="w-full text-left px-3 py-2 text-sm text-foreground flex items-center gap-2 border-t hover:bg-accent"
-              onClick={() => {
-                setDialogOpen(true);
-                close();
-              }}
-            >
-              <Plus className="h-4 w-4" />
-              Neues Projekt erstellen
-            </button>
+            {isAdmin ? (
+              <button
+                type="button"
+                className="w-full text-left px-3 py-2 text-sm text-foreground flex items-center gap-2 border-t hover:bg-accent"
+                onClick={() => {
+                  setDialogOpen(true);
+                  close();
+                }}
+              >
+                <Plus className="h-4 w-4" />
+                Neues Projekt erstellen
+              </button>
+            ) : null}
           </div>
         )}
       </div>
 
-      <CreateProjectDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        onProjectCreated={onValueChange}
-      />
+      {isAdmin ? (
+        <CreateProjectDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onProjectCreated={onValueChange}
+        />
+      ) : null}
     </>
   );
 }

--- a/app/lib/server/projects/actions.ts
+++ b/app/lib/server/projects/actions.ts
@@ -11,7 +11,7 @@ import { newId } from "../../db/ids";
 import { addLog } from "../logs";
 
 export async function createProject(input: { name: string }): Promise<string> {
-  const user = await requireRole("lead");
+  const user = await requireRole("admin");
   const { name } = z.object({ name: z.string().min(1) }).parse(input);
 
   const _id = newId();
@@ -31,7 +31,7 @@ export async function renameProject(input: {
   projectId: string;
   name: string;
 }): Promise<void> {
-  const user = await requireRole("lead");
+  const user = await requireRole("admin");
   const { projectId, name } = z
     .object({ projectId: z.string(), name: z.string().min(1) })
     .parse(input);

--- a/app/lib/server/projects/projects.test.ts
+++ b/app/lib/server/projects/projects.test.ts
@@ -38,6 +38,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await (await getDb()).dropDatabase();
+  vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
@@ -57,6 +58,7 @@ beforeEach(async () => {
 
 test("createProject + getAllProjects stay scoped to the caller's org", async () => {
   await createProject({ name: "Projekt A1" });
+  expect(requireRole).toHaveBeenCalledWith("admin");
   await (await projects()).insertOne({
     _id: newId(),
     _creationTime: Date.now(),
@@ -73,6 +75,7 @@ test("createProject + getAllProjects stay scoped to the caller's org", async () 
 test("renameProject updates the name", async () => {
   const id = await createProject({ name: "Alt" });
   await renameProject({ projectId: id, name: "Neu" });
+  expect(requireRole).toHaveBeenLastCalledWith("admin");
   expect((await getAllProjects())[0]?.name).toBe("Neu");
 });
 


### PR DESCRIPTION
## Summary

- require admin authorization for project creation and renaming server actions
- hide the create-project control from non-admin users
- keep existing admin guards for archive and delete operations

Donors and categories no longer exist in the current reimbursement-only app.

## Validation

- TypeScript check
- project integration tests: 5 passed
- production build on the complete workspace
- diff check

Linear: [YFN-188](https://linear.app/youngfoundersnetwork/issue/YFN-188/only-admins-should-be-able-to-create-projects-donors-and-categories)