### PR TITLE
Speed up and stabilize pull request checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,32 +6,50 @@ on:
   pull_request:
     branches: [main, master]
 
-jobs:
-  lint-lines:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - run: node scripts/check-file-lines.mjs
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-  vitest:
+jobs:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-      - run: npm install -g pnpm && pnpm install
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint:lines
+      - name: Cache MongoDB binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/mongodb-binaries
+          key: mongodb-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm vitest run
+        env:
+          MONGOMS_DOWNLOAD_DIR: ${{ runner.temp }}/mongodb-binaries
 
   playwright:
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:8
+        ports:
+          - 27017:27017
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-      - run: npm install -g pnpm && pnpm install
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(pnpm exec playwright --version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p \"require('@playwright/test/package.json').version\")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -42,14 +60,16 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Install Playwright deps only
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps
+        run: pnpm exec playwright install-deps chromium
 
       - name: Run Playwright tests
         run: pnpm exec playwright test --reporter=list
         env:
-          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.CONVEX_URL }}
+          AUTH_SECRET: ci-only-secret-ci-only-secret
+          MONGODB_URI: mongodb://localhost:27017
+          MONGODB_DB: ybase_e2e
           IS_TEST: "true"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -37,6 +37,6 @@ export default defineConfig({
     command: "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
-    timeout: 120000,
+    timeout: process.env.CI ? 30_000 : 120_000,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["app/**/*.test.ts"],
+    fileParallelism: !process.env.CI,
     env: {
       RESEND_API_KEY: "test-api-key",
     },


### PR DESCRIPTION
Combines the line-length check and Vitest into one cached unit job and cancels superseded workflow runs.
Stabilizes MongoDB-backed tests by serializing CI test files, caching the MongoDB binary, and giving Playwright an isolated MongoDB service with CI auth configuration.
Limits Playwright installation to Chromium and reduces retries and the CI web-server startup timeout.

Validated with `CI=true pnpm vitest run`, `pnpm lint:lines`, workflow YAML parsing, and `pnpm exec playwright test --list`.