### PR TITLE
fix(dev): preserve local setup across server restarts

### DIFF
--- a/app/lib/auth/config.test.ts
+++ b/app/lib/auth/config.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureAppUser: vi.fn(),
+}));
+
+vi.mock("./environment", () => ({
+  isLocalCredentialsEnabled: () => true,
+}));
+vi.mock("./provisioning", () => ({
+  ensureAppUser: mocks.ensureAppUser,
+}));
+
+import { authConfig } from "./config";
+
+describe("auth config", () => {
+  beforeEach(() => {
+    mocks.ensureAppUser.mockReset();
+  });
+
+  it("refreshes a persisted local session against the current database", async () => {
+    mocks.ensureAppUser.mockResolvedValue({
+      _id: "new-user-id",
+      _creationTime: 1,
+      email: "local@example.com",
+      organizationId: "new-organization-id",
+      role: "admin",
+    });
+    const token = {
+      email: "local@example.com",
+      userId: "stale-user-id",
+      organizationId: "stale-organization-id",
+    };
+
+    // Auth.js omits user for persisted JWT sessions despite requiring it in the callback type.
+    const result = await authConfig.callbacks.jwt({
+      token,
+    } as unknown as Parameters<typeof authConfig.callbacks.jwt>[0]);
+
+    expect(mocks.ensureAppUser).toHaveBeenCalledWith({
+      email: "local@example.com",
+      name: undefined,
+      image: undefined,
+      firstName: undefined,
+      lastName: undefined,
+    });
+    expect(result).toMatchObject({
+      userId: "new-user-id",
+      organizationId: "new-organization-id",
+      role: "admin",
+    });
+  });
+});

--- a/app/lib/auth/config.ts
+++ b/app/lib/auth/config.ts
@@ -28,7 +28,9 @@ const google = Google({
       image: profile.picture,
       firstName: profile.given_name ?? profile.name?.split(" ")[0] ?? "",
       lastName:
-        profile.family_name ?? profile.name?.split(" ").slice(1).join(" ") ?? "",
+        profile.family_name ??
+        profile.name?.split(" ").slice(1).join(" ") ??
+        "",
     };
   },
 });
@@ -63,7 +65,9 @@ export const authConfig = {
     },
     async jwt({ token, user, trigger }) {
       const email = user?.email ?? (token.email as string | undefined);
-      if (email && (user || trigger === "update")) {
+      const shouldRefreshAppUser =
+        Boolean(user) || trigger === "update" || isLocalLoginEnabled;
+      if (email && shouldRefreshAppUser) {
         const appUser = await ensureAppUser({
           email,
           name: user?.name ?? (token.name as string | undefined),
@@ -81,7 +85,9 @@ export const authConfig = {
     session({ session, token }) {
       if (session.user) {
         session.user.id = (token.userId as string | undefined) ?? "";
-        session.user.organizationId = token.organizationId as string | undefined;
+        session.user.organizationId = token.organizationId as
+          | string
+          | undefined;
         session.user.role = token.role as UserRole | undefined;
       }
       return session;


### PR DESCRIPTION
## summary

- load Next-style local env files before choosing the development database so users and organizations persist across Conductor restarts
- refresh persisted local JWT claims against the active database while keeping Playwright on an isolated temporary database

## validation

- pnpm exec prettier --check app/lib/auth/config.ts app/lib/auth/config.test.ts
- pnpm exec prettier --check scripts/dev.mjs
- pnpm exec biome lint app/lib/auth/config.ts app/lib/auth/config.test.ts
- pnpm exec biome lint scripts/dev.mjs
- node --check scripts/dev.mjs
- pnpm exec tsc --noEmit
- pnpm lint:lines
- pnpm exec vitest run (48 passed)
- verified normal dev startup uses .env and IS_TEST startup uses MongoMemoryServer
- pnpm exec playwright test --reporter=list (fails on existing origin/main mismatch: test expects “Projekt erstellt!” while the UI emits “Projekt erstellt”)