### PR TITLE
feat(reimbursements): prioritize travel reimbursement creation

### DIFF
--- a/app/(protected)/reimbursements/new/NewReimbursementUI.tsx
+++ b/app/(protected)/reimbursements/new/NewReimbursementUI.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export function NewReimbursementUI({ defaultBankDetails, projects }: Props) {
-  const [type, setType] = useState<ReimbursementType>("expense");
+  const [type, setType] = useState<ReimbursementType>("travel");
 
   return (
     <div>
@@ -28,8 +28,8 @@ export function NewReimbursementUI({ defaultBankDetails, projects }: Props) {
           onValueChange={(value) => setType(value as ReimbursementType)}
         >
           <TabsList>
-            <TabsTrigger value="expense">Auslagenerstattung</TabsTrigger>
             <TabsTrigger value="travel">Reisekostenerstattung</TabsTrigger>
+            <TabsTrigger value="expense">Auslagenerstattung</TabsTrigger>
             <TabsTrigger value="volunteerAllowance">
               Ehrenamtspauschale
             </TabsTrigger>

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -67,6 +67,17 @@ test.describe.serial("reimbursement flow", () => {
   test("1. Create expense reimbursement with JPG receipt", async () => {
     await page.getByRole("link", { name: "Erstattungen" }).click();
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
+    const reimbursementTabs = page.getByRole("tab");
+    await expect(reimbursementTabs).toHaveCount(3);
+    expect(await reimbursementTabs.allTextContents()).toEqual([
+      "Reisekostenerstattung",
+      "Auslagenerstattung",
+      "Ehrenamtspauschale",
+    ]);
+    await expect(
+      page.getByRole("tab", { name: "Reisekostenerstattung" }),
+    ).toHaveAttribute("data-state", "active");
+    await page.getByRole("tab", { name: "Auslagenerstattung" }).click();
 
     await page.getByRole("textbox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Neues Projekt erstellen" }).click();
@@ -74,7 +85,7 @@ test.describe.serial("reimbursement flow", () => {
       .getByRole("textbox", { name: "Projektname*" })
       .fill("Test Projekt");
     await page.getByRole("button", { name: "Projekt erstellen" }).click();
-    await expect(page.getByText("Projekt erstellt!")).toBeVisible();
+    await expect(page.getByText("Projekt erstellt")).toBeVisible();
 
     await page
       .getByRole("textbox", {
@@ -126,7 +137,6 @@ test.describe.serial("reimbursement flow", () => {
 
   test("3. Create travel reimbursement with PDF receipt", async () => {
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
-    await page.getByRole("tab", { name: "Reisekostenerstattung" }).click();
 
     await page.getByRole("textbox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Test Projekt" }).click();


### PR DESCRIPTION
## summary

- show travel reimbursement first and select it by default when creating a reimbursement
- cover tab order and default selection in the reimbursement E2E flow, and align its stale project toast assertion

## validation

- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint app/(protected)/reimbursements/new/NewReimbursementUI.tsx e2e/reimbursements.spec.ts`
- `pnpm vitest run` (48 tests passed)
- `pnpm lint:lines`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (4 tests passed)