### PR TITLE
fix(dev): preserve local database across restarts

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,7 +1,18 @@
 import { spawn } from "node:child_process";
+import dotenv from "dotenv";
 import { MongoMemoryServer } from "mongodb-memory-server";
 
 const env = { ...process.env };
+const hasExplicitMongoUri = Boolean(env.MONGODB_URI);
+const nodeEnv = env.NODE_ENV ?? "development";
+const envFiles = [
+  `.env.${nodeEnv}.local`,
+  ...(nodeEnv === "test" ? [] : [".env.local"]),
+  `.env.${nodeEnv}`,
+  ".env",
+];
+dotenv.config({ path: envFiles, processEnv: env, quiet: true });
+
 const nextArgs = process.argv.slice(2);
 let mongo;
 
@@ -14,11 +25,12 @@ if (
   nextArgs.push("--port", env.CONDUCTOR_PORT);
 }
 
-if (!env.MONGODB_URI) {
+const shouldStartTemporaryDatabase =
+  !env.MONGODB_URI || (env.IS_TEST === "true" && !hasExplicitMongoUri);
+
+if (shouldStartTemporaryDatabase) {
   const dbName = env.MONGODB_DB ?? "ybudget_dev";
-  console.info(
-    `MONGODB_URI is not set; starting temporary database "${dbName}".`,
-  );
+  console.info(`Starting temporary database "${dbName}".`);
   mongo = await MongoMemoryServer.create({ instance: { dbName } });
   env.MONGODB_URI = mongo.getUri();
   env.MONGODB_DB = dbName;


### PR DESCRIPTION
## summary

- load Next-style local env files before choosing the development database so users and organizations persist across Conductor restarts
- preserve isolated temporary databases for local Playwright runs while respecting explicit CI database configuration

## validation

- pnpm exec prettier --check scripts/dev.mjs
- pnpm exec biome lint scripts/dev.mjs
- node --check scripts/dev.mjs
- pnpm exec tsc --noEmit
- pnpm lint:lines
- pnpm exec vitest run (48 passed)
- verified normal dev startup uses .env and IS_TEST startup uses MongoMemoryServer
- pnpm exec playwright test --reporter=list (fails on existing origin/main mismatch: test expects “Projekt erstellt!” while the UI emits “Projekt erstellt”)