### PR TITLE
feat(reimbursements): highlight selected travel cost types

### DIFF
--- a/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
@@ -2,9 +2,9 @@
 
 import { Button } from "@/components/ui/button";
 import {
-  COST_LABELS as LABELS,
   COST_TYPES,
   type CostType,
+  COST_LABELS as LABELS,
 } from "@/lib/travel-costs";
 import { MealAllowanceSection } from "./MealAllowanceSection";
 import { ReceiptCard } from "./ReceiptCard";
@@ -45,7 +45,8 @@ export function ReceiptsSection({
             <Button
               key={type}
               type="button"
-              variant={hasReceipt(type) ? "default" : "outline"}
+              variant={hasReceipt(type) ? "primary" : "outline"}
+              aria-pressed={hasReceipt(type)}
               onClick={() => toggleType(type)}
             >
               {LABELS[type]}


### PR DESCRIPTION
## summary

- highlight selected travel cost types with the yellow YBase primary color
- expose the toggle state with `aria-pressed` for assistive technology

## validation

- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint app/components/Reimbursements/travelForm/ReceiptsSection.tsx`
- `pnpm vitest run`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (fails on an existing stale textbox selector before reaching this flow; the UI now exposes a combobox)