### PR TITLE
feat(projects): add reusable travel defaults

### DIFF
--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -17,6 +17,7 @@ const ACTION_LABELS: Record<string, string> = {
   "organization.update": "Organisation aktualisiert",
   "project.create": "Projekt erstellt",
   "project.rename": "Projekt umbenannt",
+  "project.update": "Projekt aktualisiert",
   "project.archive": "Projekt archiviert",
   "project.unarchive": "Projekt wiederhergestellt",
   "project.delete": "Projekt gelöscht",

--- a/app/(protected)/settings/projects/ProjectRow.tsx
+++ b/app/(protected)/settings/projects/ProjectRow.tsx
@@ -4,28 +4,34 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TableCell, TableRow } from "@/components/ui/table";
 import type { Project } from "@/lib/db/types";
-import { Archive, Trash2 } from "lucide-react";
+import { Archive, Check, Pencil, Trash2, X } from "lucide-react";
+
+type EditValues = {
+  name: string;
+  travelDestination: string;
+  travelPurpose: string;
+};
 
 export function ProjectRow({
   project,
   isEditing,
-  editName,
+  editValues,
   isArchiving,
-  onEditNameChange,
+  onEditValuesChange,
   onStartEdit,
   onCancelEdit,
-  onRename,
+  onUpdate,
   onArchive,
   onDelete,
 }: {
   project: Project;
   isEditing: boolean;
-  editName: string;
+  editValues: EditValues;
   isArchiving: boolean;
-  onEditNameChange: (name: string) => void;
+  onEditValuesChange: (values: Partial<EditValues>) => void;
   onStartEdit: () => void;
   onCancelEdit: () => void;
-  onRename: () => void;
+  onUpdate: () => void;
   onArchive: () => void;
   onDelete: () => void;
 }) {
@@ -35,11 +41,11 @@ export function ProjectRow({
         {isEditing ? (
           <Input
             autoFocus
-            value={editName}
-            onChange={(e) => onEditNameChange(e.target.value)}
-            onBlur={onRename}
+            aria-label="Projektname"
+            value={editValues.name}
+            onChange={(e) => onEditValuesChange({ name: e.target.value })}
             onKeyDown={(e) => {
-              if (e.key === "Enter") onRename();
+              if (e.key === "Enter") onUpdate();
               if (e.key === "Escape") onCancelEdit();
             }}
           />
@@ -49,29 +55,107 @@ export function ProjectRow({
           </button>
         )}
       </TableCell>
+      <TableCell>
+        {isEditing ? (
+          <Input
+            aria-label="Reiseziel"
+            placeholder="z.B. Hamburg"
+            value={editValues.travelDestination}
+            onChange={(e) =>
+              onEditValuesChange({ travelDestination: e.target.value })
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onUpdate();
+              if (e.key === "Escape") onCancelEdit();
+            }}
+          />
+        ) : (
+          <span className="text-muted-foreground">
+            {project.travelDestination || "–"}
+          </span>
+        )}
+      </TableCell>
+      <TableCell>
+        {isEditing ? (
+          <Input
+            aria-label="Reisezweck"
+            placeholder="z.B. Team-Wochenende"
+            value={editValues.travelPurpose}
+            onChange={(e) =>
+              onEditValuesChange({ travelPurpose: e.target.value })
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onUpdate();
+              if (e.key === "Escape") onCancelEdit();
+            }}
+          />
+        ) : (
+          <span className="text-muted-foreground">
+            {project.travelPurpose || "–"}
+          </span>
+        )}
+      </TableCell>
       <TableCell className="pr-6">
         <div className="flex items-center justify-end gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            title="Archivieren"
-            aria-label="Archivieren"
-            disabled={isArchiving}
-            onClick={onArchive}
-          >
-            <Archive className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-destructive"
-            title="Löschen"
-            aria-label="Löschen"
-            onClick={onDelete}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
+          {isEditing ? (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title="Speichern"
+                aria-label="Speichern"
+                disabled={!editValues.name.trim()}
+                onClick={onUpdate}
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title="Abbrechen"
+                aria-label="Abbrechen"
+                onClick={onCancelEdit}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title="Bearbeiten"
+                aria-label="Bearbeiten"
+                onClick={onStartEdit}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                title="Archivieren"
+                aria-label="Archivieren"
+                disabled={isArchiving}
+                onClick={onArchive}
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive"
+                title="Löschen"
+                aria-label="Löschen"
+                onClick={onDelete}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </>
+          )}
         </div>
       </TableCell>
     </TableRow>

--- a/app/(protected)/settings/projects/ProjectsClient.tsx
+++ b/app/(protected)/settings/projects/ProjectsClient.tsx
@@ -24,28 +24,43 @@ import { ProjectRow } from "./ProjectRow";
 export function ProjectsClient() {
   const { projects, isLoading } = useProjects();
   const { projects: archivedProjects } = useProjects(true);
-  const { rename, archive, remove } = useProjectMutations();
+  const { update, archive, remove } = useProjectMutations();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [archivedOpen, setArchivedOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editName, setEditName] = useState("");
+  const [editValues, setEditValues] = useState({
+    name: "",
+    travelDestination: "",
+    travelPurpose: "",
+  });
   const [deleteProject, setDeleteProject] = useState<Project | null>(null);
-  const isRenaming = useRef(false);
+  const isUpdating = useRef(false);
 
-  const handleRename = async (project: Project) => {
-    if (isRenaming.current) return;
-    const name = editName.trim();
+  const handleUpdate = async (project: Project) => {
+    if (isUpdating.current) return;
+    const values = {
+      name: editValues.name.trim(),
+      travelDestination: editValues.travelDestination.trim(),
+      travelPurpose: editValues.travelPurpose.trim(),
+    };
+    if (!values.name) return;
+
+    const isUnchanged =
+      values.name === project.name &&
+      values.travelDestination === (project.travelDestination ?? "") &&
+      values.travelPurpose === (project.travelPurpose ?? "");
     setEditingId(null);
-    if (!name || name === project.name) return;
-    isRenaming.current = true;
+    if (isUnchanged) return;
+
+    isUpdating.current = true;
     try {
-      await rename.mutateAsync({ projectId: project._id, name });
-      toast.success("Projekt umbenannt");
+      await update.mutateAsync({ projectId: project._id, ...values });
+      toast.success("Projekt aktualisiert");
     } catch {
-      toast.error("Fehler beim Umbenennen");
+      toast.error("Fehler beim Aktualisieren");
     } finally {
-      isRenaming.current = false;
+      isUpdating.current = false;
     }
   };
 
@@ -129,6 +144,8 @@ export function ProjectsClient() {
                       </Button>
                     </div>
                   </TableHead>
+                  <TableHead>Reiseziel</TableHead>
+                  <TableHead>Reisezweck</TableHead>
                   <TableHead className="w-px" />
                 </TableRow>
               </TableHeader>
@@ -138,15 +155,21 @@ export function ProjectsClient() {
                     key={project._id}
                     project={project}
                     isEditing={editingId === project._id}
-                    editName={editName}
+                    editValues={editValues}
                     isArchiving={archive.isPending}
-                    onEditNameChange={setEditName}
+                    onEditValuesChange={(values) =>
+                      setEditValues((current) => ({ ...current, ...values }))
+                    }
                     onStartEdit={() => {
                       setEditingId(project._id);
-                      setEditName(project.name);
+                      setEditValues({
+                        name: project.name,
+                        travelDestination: project.travelDestination ?? "",
+                        travelPurpose: project.travelPurpose ?? "",
+                      });
                     }}
                     onCancelEdit={() => setEditingId(null)}
-                    onRename={() => handleRename(project)}
+                    onUpdate={() => handleUpdate(project)}
                     onArchive={() => handleArchive(project._id)}
                     onDelete={() => setDeleteProject(project)}
                   />

--- a/app/(public)/_lib/publicApi.ts
+++ b/app/(public)/_lib/publicApi.ts
@@ -35,7 +35,13 @@ export type ReimbursementLink =
       organizationName: string;
       projectName: string;
       description?: string;
-      travelDetails: { allowFoodAllowance?: boolean } | null;
+      travelDetails: {
+        destination: string;
+        purpose: string;
+        startDate: string;
+        endDate: string;
+        allowFoodAllowance?: boolean;
+      } | null;
     };
 
 export async function validateReimbursementLink(

--- a/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
@@ -40,7 +40,23 @@ export function useReimbursementForm(id: string) {
   const receiptState = useReceipts(startDate);
 
   useEffect(() => {
-    validateReimbursementLink(id).then(setLink);
+    let ignoreResult = false;
+
+    void validateReimbursementLink(id).then((result) => {
+      if (ignoreResult) return;
+      setLink(result);
+      if (!result.valid || result.type !== "travel" || !result.travelDetails) {
+        return;
+      }
+      setDestination(result.travelDetails.destination);
+      setPurpose(result.travelDetails.purpose);
+      setStartDate(result.travelDetails.startDate);
+      setEndDate(result.travelDetails.endDate);
+    });
+
+    return () => {
+      ignoreResult = true;
+    };
   }, [id]);
 
   const isTravel = link?.valid === true && link.type === "travel";

--- a/app/components/Dialogs/CreateProjectDialog.tsx
+++ b/app/components/Dialogs/CreateProjectDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import type { ProjectTravelDefaults } from "@/lib/db/types";
 import { createProject } from "@/lib/server/projects/actions";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
@@ -21,7 +22,10 @@ import toast from "react-hot-toast";
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onProjectCreated?: (projectId: string) => void;
+  onProjectCreated?: (
+    projectId: string,
+    travelDefaults: ProjectTravelDefaults,
+  ) => void;
 }
 
 export function CreateProjectDialog({
@@ -30,13 +34,19 @@ export function CreateProjectDialog({
   onProjectCreated,
 }: Props) {
   const [name, setName] = useState("");
+  const [travelDestination, setTravelDestination] = useState("");
+  const [travelPurpose, setTravelPurpose] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
   const queryClient = useQueryClient();
 
   const handleOpenChange = (value: boolean) => {
     if (isSubmitting) return;
-    if (!value) setName("");
+    if (!value) {
+      setName("");
+      setTravelDestination("");
+      setTravelPurpose("");
+    }
     onOpenChange(value);
   };
 
@@ -46,13 +56,20 @@ export function CreateProjectDialog({
 
     setIsSubmitting(true);
     try {
-      const projectId = await createProject({ name: name.trim() });
+      const project = {
+        name: name.trim(),
+        travelDestination: travelDestination.trim(),
+        travelPurpose: travelPurpose.trim(),
+      };
+      const projectId = await createProject(project);
       router.refresh();
       queryClient.invalidateQueries({ queryKey: ["projects"] });
       toast.success("Projekt erstellt");
-      onProjectCreated?.(projectId);
+      onProjectCreated?.(projectId, project);
       onOpenChange(false);
       setName("");
+      setTravelDestination("");
+      setTravelPurpose("");
     } catch {
       toast.error("Fehler beim Erstellen");
     } finally {
@@ -81,6 +98,27 @@ export function CreateProjectDialog({
               onChange={(e) => setName(e.target.value)}
               autoFocus
             />
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="project-travel-destination">Reiseziel</Label>
+              <Input
+                id="project-travel-destination"
+                placeholder="z.B. Hamburg"
+                value={travelDestination}
+                onChange={(e) => setTravelDestination(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="project-travel-purpose">Reisezweck</Label>
+              <Input
+                id="project-travel-purpose"
+                placeholder="z.B. Team-Wochenende"
+                value={travelPurpose}
+                onChange={(e) => setTravelPurpose(e.target.value)}
+              />
+            </div>
           </div>
 
           <DialogFooter>

--- a/app/components/Reimbursements/TravelReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/TravelReimbursementFormUI.tsx
@@ -2,7 +2,7 @@
 
 import { SelectProject } from "@/components/Selectors/SelectProject";
 import { Label } from "@/components/ui/label";
-import type { Project } from "@/lib/db/types";
+import type { Project, ProjectTravelDefaults } from "@/lib/db/types";
 import { ReceiptsSection } from "./travelForm/ReceiptsSection";
 import { SummarySection } from "./travelForm/SummarySection";
 import { TravelDetailsSection } from "./travelForm/TravelDetailsSection";
@@ -20,13 +20,27 @@ export function TravelReimbursementFormUI({
 }: Props) {
   const form = useTravelForm(defaultBankDetails);
 
+  const handleProjectChange = (
+    value: string,
+    selectedProject: ProjectTravelDefaults | undefined = projects.find(
+      (project) => project._id === value,
+    ),
+  ) => {
+    form.setProjectId(value || null);
+    if (!value) return;
+    form.update({
+      destination: selectedProject?.travelDestination ?? "",
+      purpose: selectedProject?.travelPurpose ?? "",
+    });
+  };
+
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
-      <div className="w-[200px]">
+      <div className="w-full sm:w-[260px]">
         <Label>Projekt *</Label>
         <SelectProject
           value={form.projectId || ""}
-          onValueChange={(value) => form.setProjectId(value || null)}
+          onValueChange={handleProjectChange}
           projects={projects}
         />
       </div>

--- a/app/components/Reimbursements/VolunteerAllowanceFormUI.tsx
+++ b/app/components/Reimbursements/VolunteerAllowanceFormUI.tsx
@@ -35,7 +35,7 @@ export function VolunteerAllowanceFormUI({
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
-      <div className="w-[200px]">
+      <div className="w-full sm:w-[260px]">
         <Label>Projekt *</Label>
         <SelectProject
           value={projectId || ""}

--- a/app/components/Reimbursements/reimbursementForm/ProjectCurrencyFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ProjectCurrencyFields.tsx
@@ -28,8 +28,8 @@ export function ProjectCurrencyFields({
   onCurrencyChange,
 }: Props) {
   return (
-    <div className="flex items-end gap-4">
-      <div className="w-[200px]">
+    <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-end">
+      <div className="w-full sm:w-[260px]">
         <Label>Projekt *</Label>
         <SelectProject
           value={projectId || ""}
@@ -37,7 +37,7 @@ export function ProjectCurrencyFields({
           projects={projects}
         />
       </div>
-      <div className="w-[120px]">
+      <div className="w-full sm:w-[120px]">
         <Label>Währung</Label>
         <Select value={currency} onValueChange={onCurrencyChange}>
           <SelectTrigger>

--- a/app/components/Reimbursements/shareModal/ShareForm.tsx
+++ b/app/components/Reimbursements/shareModal/ShareForm.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import type { ProjectTravelDefaults } from "@/lib/db/types";
 import { Copy, Loader2 } from "lucide-react";
 import { TYPE_LABELS } from "./constants";
 import type { LinkType, ShareModalUIProps } from "./types";
@@ -31,6 +32,19 @@ export function ShareForm({
   onFormUpdate,
   onCopy,
 }: ShareFormProps) {
+  const handleProjectChange = (
+    value: string,
+    selectedProject: ProjectTravelDefaults | undefined = projects.find(
+      (project) => project._id === value,
+    ),
+  ) => {
+    onFormUpdate({
+      projectId: value || null,
+      destination: selectedProject?.travelDestination ?? "",
+      purpose: selectedProject?.travelPurpose ?? "",
+    });
+  };
+
   return (
     <div className="space-y-4 py-4">
       <div className="flex gap-2">
@@ -52,7 +66,7 @@ export function ShareForm({
         <Label>Projekt</Label>
         <SelectProject
           value={form.projectId ?? ""}
-          onValueChange={(value) => onFormUpdate({ projectId: value || null })}
+          onValueChange={handleProjectChange}
           projects={projects}
         />
       </div>

--- a/app/components/Selectors/SelectProject.tsx
+++ b/app/components/Selectors/SelectProject.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CreateProjectDialog } from "@/components/Dialogs/CreateProjectDialog";
-import type { Project } from "@/lib/db/types";
+import type { Project, ProjectTravelDefaults } from "@/lib/db/types";
 import { focusNextInput } from "@/lib/focusNextInput";
 import { useIsAdmin } from "@/lib/hooks/useCurrentUserRole";
 import { cn } from "@/lib/utils";
@@ -10,7 +10,10 @@ import { useEffect, useRef, useState } from "react";
 
 interface Props {
   value: string | undefined;
-  onValueChange: (value: string) => void;
+  onValueChange: (
+    value: string,
+    travelDefaults?: ProjectTravelDefaults,
+  ) => void;
   projects: Project[];
   autoFocus?: boolean;
 }
@@ -58,7 +61,9 @@ export function SelectProject({
   };
 
   const handleSelect = (id: string) => {
-    onValueChange(id === value ? "" : id);
+    const nextId = id === value ? "" : id;
+    const project = projects.find((item) => item._id === nextId);
+    onValueChange(nextId, project);
     close();
     setTimeout(() => focusNextInput(inputRef.current), 0);
   };
@@ -114,7 +119,7 @@ export function SelectProject({
         <ChevronsUpDown className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50 pointer-events-none" />
 
         {open && (
-          <div className="absolute mt-1 w-full bg-background border rounded-md shadow-lg z-50 max-h-64 overflow-auto">
+          <div className="absolute z-50 mt-1 max-h-64 min-w-full w-max max-w-[calc(100vw-3rem)] overflow-auto rounded-md border bg-background shadow-lg">
             {filtered.length === 0 && (
               <div className="px-3 py-2 text-sm text-muted-foreground">
                 Keine Projekte gefunden
@@ -125,20 +130,20 @@ export function SelectProject({
                 key={project._id}
                 type="button"
                 className={cn(
-                  "w-full text-left px-3 py-2 text-sm flex items-center justify-between",
+                  "flex w-full min-w-0 items-center justify-between gap-3 px-3 py-2 text-left text-sm",
                   index === highlightedIndex && "bg-accent",
                 )}
                 onClick={() => handleSelect(project._id)}
                 onMouseEnter={() => setHighlightedIndex(index)}
               >
-                {project.name}
+                <span className="truncate">{project.name}</span>
                 {value === project._id && <Check className="h-4 w-4" />}
               </button>
             ))}
             {isAdmin ? (
               <button
                 type="button"
-                className="w-full text-left px-3 py-2 text-sm text-foreground flex items-center gap-2 border-t hover:bg-accent"
+                className="flex w-full items-center gap-2 whitespace-nowrap border-t px-3 py-2 text-left text-sm text-foreground hover:bg-accent"
                 onClick={() => {
                   setDialogOpen(true);
                   close();

--- a/app/lib/client/projects/hooks/useProjectMutations.ts
+++ b/app/lib/client/projects/hooks/useProjectMutations.ts
@@ -2,8 +2,8 @@ import {
   archiveProject,
   createProject,
   deleteProject,
-  renameProject,
   unarchiveProject,
+  updateProject,
 } from "@/lib/server/projects/actions";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -14,7 +14,7 @@ export function useProjectMutations() {
 
   return {
     create: useMutation({ mutationFn: createProject, onSuccess }),
-    rename: useMutation({ mutationFn: renameProject, onSuccess }),
+    update: useMutation({ mutationFn: updateProject, onSuccess }),
     archive: useMutation({ mutationFn: archiveProject, onSuccess }),
     unarchive: useMutation({ mutationFn: unarchiveProject, onSuccess }),
     remove: useMutation({ mutationFn: deleteProject, onSuccess }),

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -46,10 +46,17 @@ export interface Project {
   _id: string;
   _creationTime: number;
   name: string;
+  travelDestination?: string;
+  travelPurpose?: string;
   organizationId: string;
   isArchived: boolean;
   createdBy: string;
 }
+
+export type ProjectTravelDefaults = Pick<
+  Project,
+  "travelDestination" | "travelPurpose"
+>;
 
 export interface Reimbursement {
   _id: string;

--- a/app/lib/server/projects/actions.ts
+++ b/app/lib/server/projects/actions.ts
@@ -10,15 +10,30 @@ import {
 import { newId } from "../../db/ids";
 import { addLog } from "../logs";
 
-export async function createProject(input: { name: string }): Promise<string> {
+const projectFieldsSchema = z.object({
+  name: z.string().trim().min(1),
+  travelDestination: z.string().trim().optional(),
+  travelPurpose: z.string().trim().optional(),
+});
+
+export async function createProject(input: {
+  name: string;
+  travelDestination?: string;
+  travelPurpose?: string;
+}): Promise<string> {
   const user = await requireRole("admin");
-  const { name } = z.object({ name: z.string().min(1) }).parse(input);
+  const { name, travelDestination, travelPurpose } =
+    projectFieldsSchema.parse(input);
 
   const _id = newId();
-  await (await projects()).insertOne({
+  await (
+    await projects()
+  ).insertOne({
     _id,
     _creationTime: Date.now(),
     name,
+    ...(travelDestination ? { travelDestination } : {}),
+    ...(travelPurpose ? { travelPurpose } : {}),
     organizationId: user.organizationId,
     isArchived: false,
     createdBy: user._id,
@@ -27,23 +42,36 @@ export async function createProject(input: { name: string }): Promise<string> {
   return _id;
 }
 
-export async function renameProject(input: {
+export async function updateProject(input: {
   projectId: string;
   name: string;
+  travelDestination?: string;
+  travelPurpose?: string;
 }): Promise<void> {
   const user = await requireRole("admin");
-  const { projectId, name } = z
-    .object({ projectId: z.string(), name: z.string().min(1) })
+  const { projectId, name, travelDestination, travelPurpose } = z
+    .object({ projectId: z.string(), ...projectFieldsSchema.shape })
     .parse(input);
 
-  const project = await requireOwnedProject(projectId, user.organizationId);
-  await (await projects()).updateOne({ _id: projectId }, { $set: { name } });
+  await requireOwnedProject(projectId, user.organizationId);
+  await (
+    await projects()
+  ).updateOne(
+    { _id: projectId },
+    {
+      $set: {
+        name,
+        travelDestination: travelDestination ?? "",
+        travelPurpose: travelPurpose ?? "",
+      },
+    },
+  );
   await addLog(
     user.organizationId,
     user._id,
-    "project.rename",
+    "project.update",
     projectId,
-    `${project.name} → ${name}`,
+    name,
   );
 }
 
@@ -80,7 +108,10 @@ export async function deleteProject(input: {
 }): Promise<void> {
   const user = await requireRole("admin");
   const { projectId, mergeIntoProjectId } = z
-    .object({ projectId: z.string(), mergeIntoProjectId: z.string().optional() })
+    .object({
+      projectId: z.string(),
+      mergeIntoProjectId: z.string().optional(),
+    })
     .parse(input);
 
   const project = await requireOwnedProject(projectId, user.organizationId);
@@ -89,7 +120,9 @@ export async function deleteProject(input: {
     if (mergeIntoProjectId === projectId) {
       throw new Error("Zielprojekt darf nicht das gleiche Projekt sein");
     }
-    const target = await (await projects()).findOne({ _id: mergeIntoProjectId });
+    const target = await (
+      await projects()
+    ).findOne({ _id: mergeIntoProjectId });
     if (!target || target.organizationId !== user.organizationId) {
       throw new Error("Zielprojekt nicht gefunden");
     }

--- a/app/lib/server/projects/projects.test.ts
+++ b/app/lib/server/projects/projects.test.ts
@@ -14,8 +14,8 @@ import {
   archiveProject,
   createProject,
   deleteProject,
-  renameProject,
   unarchiveProject,
+  updateProject,
 } from "./actions";
 import { getAllProjects, getArchivedProjects } from "./data";
 
@@ -42,9 +42,23 @@ beforeEach(async () => {
   orgA = newId();
   orgB = newId();
   userA = newId();
-  await (await organizations()).insertMany([
-    { _id: orgA, _creationTime: Date.now(), name: "A", domain: "a.org", createdBy: userA },
-    { _id: orgB, _creationTime: Date.now(), name: "B", domain: "b.org", createdBy: newId() },
+  await (
+    await organizations()
+  ).insertMany([
+    {
+      _id: orgA,
+      _creationTime: Date.now(),
+      name: "A",
+      domain: "a.org",
+      createdBy: userA,
+    },
+    {
+      _id: orgB,
+      _creationTime: Date.now(),
+      name: "B",
+      domain: "b.org",
+      createdBy: newId(),
+    },
   ]);
   const actor = {
     _id: userA,
@@ -59,7 +73,9 @@ beforeEach(async () => {
 test("createProject + getAllProjects stay scoped to the caller's org", async () => {
   await createProject({ name: "Projekt A1" });
   expect(requireRole).toHaveBeenCalledWith("admin");
-  await (await projects()).insertOne({
+  await (
+    await projects()
+  ).insertOne({
     _id: newId(),
     _creationTime: Date.now(),
     name: "Projekt B1",
@@ -72,11 +88,24 @@ test("createProject + getAllProjects stay scoped to the caller's org", async () 
   expect(list.map((p) => p.name)).toEqual(["Projekt A1"]);
 });
 
-test("renameProject updates the name", async () => {
-  const id = await createProject({ name: "Alt" });
-  await renameProject({ projectId: id, name: "Neu" });
+test("updateProject updates the name and travel defaults", async () => {
+  const id = await createProject({
+    name: "Alt",
+    travelDestination: "Köln",
+    travelPurpose: "Workshop",
+  });
+  await updateProject({
+    projectId: id,
+    name: "Neu",
+    travelDestination: "Hamburg",
+    travelPurpose: "Team-Wochenende",
+  });
   expect(requireRole).toHaveBeenLastCalledWith("admin");
-  expect((await getAllProjects())[0]?.name).toBe("Neu");
+  expect((await getAllProjects())[0]).toMatchObject({
+    name: "Neu",
+    travelDestination: "Hamburg",
+    travelPurpose: "Team-Wochenende",
+  });
 });
 
 test("archive moves a project out of the active list and back", async () => {
@@ -91,7 +120,9 @@ test("archive moves a project out of the active list and back", async () => {
 test("deleteProject with merge reassigns reimbursements and removes the project", async () => {
   const source = await createProject({ name: "Quelle" });
   const target = await createProject({ name: "Ziel" });
-  await (await reimbursements()).insertOne({
+  await (
+    await reimbursements()
+  ).insertOne({
     _id: newId(),
     _creationTime: Date.now(),
     organizationId: orgA,
@@ -112,7 +143,9 @@ test("deleteProject with merge reassigns reimbursements and removes the project"
 
 test("cannot touch a project from another org", async () => {
   const foreign = newId();
-  await (await projects()).insertOne({
+  await (
+    await projects()
+  ).insertOne({
     _id: foreign,
     _creationTime: Date.now(),
     name: "Fremd",

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -27,6 +27,8 @@ erDiagram
 
     projects {
         string name
+        string travelDestination
+        string travelPurpose
         id organizationId FK
         id parentId FK
         boolean isArchived

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -37,6 +37,8 @@ ALTER TABLE organizations
 CREATE TABLE projects (
   id VARCHAR(255) PRIMARY KEY,
   name VARCHAR(255) NOT NULL,
+  travel_destination VARCHAR(255),
+  travel_purpose VARCHAR(255),
   parent_id VARCHAR(255),
   organization_id VARCHAR(255) NOT NULL,
   is_archived BOOLEAN NOT NULL DEFAULT false,

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -79,11 +79,15 @@ test.describe.serial("reimbursement flow", () => {
     ).toHaveAttribute("data-state", "active");
     await page.getByRole("tab", { name: "Auslagenerstattung" }).click();
 
-    await page.getByRole("textbox", { name: "Projekt suchen..." }).click();
+    await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Neues Projekt erstellen" }).click();
     await page
       .getByRole("textbox", { name: "Projektname*" })
       .fill("Test Projekt");
+    await page.getByRole("textbox", { name: "Reiseziel" }).fill("Köln");
+    await page
+      .getByRole("textbox", { name: "Reisezweck" })
+      .fill("Team-Wochenende");
     await page.getByRole("button", { name: "Projekt erstellen" }).click();
     await expect(page.getByText("Projekt erstellt")).toBeVisible();
 
@@ -138,15 +142,19 @@ test.describe.serial("reimbursement flow", () => {
   test("3. Create travel reimbursement with PDF receipt", async () => {
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
 
-    await page.getByRole("textbox", { name: "Projekt suchen..." }).click();
+    await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Test Projekt" }).click();
 
-    await page
-      .getByRole("textbox", { name: "z.B. München, Berlin" })
-      .fill("Berlin");
-    await page
-      .getByRole("textbox", { name: "z.B. Kundentermin, Konferenz" })
-      .fill("Event");
+    const destination = page.getByRole("textbox", {
+      name: "z.B. München, Berlin",
+    });
+    const purpose = page.getByRole("textbox", {
+      name: "z.B. Kundentermin, Konferenz",
+    });
+    await expect(destination).toHaveValue("Köln");
+    await expect(purpose).toHaveValue("Team-Wochenende");
+    await destination.fill("Berlin");
+    await purpose.fill("Event");
     await page
       .getByRole("textbox", { name: "TT.MM.JJJJ" })
       .first()
@@ -173,7 +181,7 @@ test.describe.serial("reimbursement flow", () => {
       })
       .check();
     await page.getByPlaceholder("z.B. 2.5").fill("1.5");
-    await page.getByRole("combobox").click();
+    await page.getByRole("combobox").filter({ hasText: "Auswählen" }).click();
     await page.getByRole("option", { name: "28 € (24h+)" }).click();
 
     await expect(page.getByText("PKW500 km × 0,30 €")).toBeVisible();
@@ -204,7 +212,9 @@ test.describe.serial("reimbursement flow", () => {
       .fill("Falsche Angaben");
     await page.getByRole("button", { name: "Ablehnen" }).click();
 
-    await expect(page.getByText("Ablehnungsgrund: Falsche Angaben")).toBeVisible({
+    await expect(
+      page.getByText("Ablehnungsgrund: Falsche Angaben"),
+    ).toBeVisible({
       timeout: 10000,
     });
     await expect(


### PR DESCRIPTION
## summary

- let projects store editable travel destination and purpose defaults
- prefill internal and shared travel reimbursement forms while keeping values editable
- improve the responsive project selector and cover the defaulting flow end to end

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm run lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm build`
- repository-wide Prettier and Biome checks remain blocked by existing issues in unchanged files
