### PR TITLE
fix(reimbursements): align edit button with bank inputs

### DIFF
--- a/app/components/BankDetailsEditor.tsx
+++ b/app/components/BankDetailsEditor.tsx
@@ -98,7 +98,7 @@ export function BankDetailsEditor({ value, onChange }: Props) {
         </div>
         <Button
           variant={editing ? "default" : "outline"}
-          size="sm"
+          className="h-[52px] min-w-[52px] border-input px-4 hover:border-ring focus-visible:border-foreground focus-visible:ring-0 md:h-12 md:min-w-12"
           onClick={toggle}
           disabled={isSaving}
           aria-label={editing ? "Speichern" : "Bearbeiten"}


### PR DESCRIPTION
## summary

- align the bank details edit button height and minimum width with the surrounding inputs
- match the input border, hover, and focus treatment across mobile and desktop

## validation

- `pnpm exec prettier --check app/components/BankDetailsEditor.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm vitest run`
- `pnpm build`
- `git diff --check`