### PR TITLE
feat(reimbursements): improve list information hierarchy

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -76,14 +76,14 @@ export function ReimbursementTable({
                 aria-label="Alle auswählen"
               />
             </TableHead>
-            <TableHead className="w-[30px]" />
-            <TableHead>Datum</TableHead>
+            <TableHead>Antrag</TableHead>
+            {canManageReimbursements ? (
+              <TableHead>Antragsteller</TableHead>
+            ) : null}
             <TableHead>Projekt</TableHead>
-            <TableHead>Beschreibung</TableHead>
-            {canManageReimbursements ? <TableHead>Ersteller</TableHead> : null}
+            <TableHead>Erstellt</TableHead>
             <TableHead className="text-right">Betrag</TableHead>
             <TableHead>Status</TableHead>
-            <TableHead>Geprüft von</TableHead>
             <TableHead className="text-right" />
           </TableRow>
         </TableHeader>
@@ -98,27 +98,26 @@ export function ReimbursementTable({
                   checked={selected.has(`r:${item._id}`)}
                   onCheckedChange={() => onToggleSelect(`r:${item._id}`)}
                   onClick={(e) => e.stopPropagation()}
+                  aria-label="Antrag auswählen"
                 />
               }
-              description={
-                item.type === "travel" ? (
-                  <div>
-                    <span>{item.projectName}</span>
-                    <span className="block text-xs text-muted-foreground">
-                      Reisekostenerstattung
-                      {item.travelDetails?.destination &&
-                        ` - ${item.travelDetails.destination}`}
-                    </span>
-                  </div>
-                ) : (
-                  <div>
-                    <span>{item.projectName}</span>
-                    <span className="block text-xs text-muted-foreground">
-                      Auslagenerstattung
-                    </span>
-                  </div>
-                )
+              kind={item.type}
+              title={
+                item.type === "travel"
+                  ? "Reisekostenerstattung"
+                  : "Auslagenerstattung"
               }
+              detail={
+                item.type === "travel"
+                  ? [
+                      item.travelDetails?.purpose,
+                      item.travelDetails?.destination,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")
+                  : item.description?.trim() || item.receiptSummary
+              }
+              applicantName={item.submitterName || item.creatorName}
               onClick={() => onRowClick(item._id)}
               onApprove={() => onApproveReimbursement(item._id)}
               onReject={() => onOpenRejectDialog("reimbursement", item._id)}
@@ -137,16 +136,13 @@ export function ReimbursementTable({
                   checked={selected.has(`a:${item._id}`)}
                   onCheckedChange={() => onToggleSelect(`a:${item._id}`)}
                   onClick={(e) => e.stopPropagation()}
+                  aria-label="Antrag auswählen"
                 />
               }
-              description={
-                <div>
-                  <span>{item.projectName}</span>
-                  <span className="block text-xs text-muted-foreground">
-                    Ehrenamtspauschale
-                  </span>
-                </div>
-              }
+              kind="allowance"
+              title="Ehrenamtspauschale"
+              detail={item.activityDescription}
+              applicantName={item.volunteerName || item.creatorName}
               onApprove={() => onApproveAllowance(item._id)}
               onReject={() => onOpenRejectDialog("allowance", item._id)}
               onDownload={() => onDownloadAllowance(item)}

--- a/app/(protected)/reimbursements/types.ts
+++ b/app/(protected)/reimbursements/types.ts
@@ -7,6 +7,7 @@ import type {
 export type Reimbursement = ReimbursementDoc & {
   creatorName: string;
   projectName: string;
+  receiptSummary?: string;
   travelDetails?: TravelDetails;
   reviewedByName?: string;
 };

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Check, Download, Trash2, X } from "lucide-react";
+import {
+  Check,
+  Download,
+  HandHeart,
+  ReceiptText,
+  Route,
+  Trash2,
+  X,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,12 +27,15 @@ interface ReimbursementRowProps {
     status: Status;
     rejectionNote?: string;
     projectName: string;
-    creatorName: string;
     amount: number;
     reviewedByName?: string;
+    reviewedAt?: number;
   };
   canManageReimbursements: boolean;
-  description: ReactNode;
+  kind: "expense" | "travel" | "allowance";
+  title: string;
+  detail?: string;
+  applicantName: string;
   selectionCheckbox?: ReactNode;
   onClick?: () => void;
   onApprove: () => void;
@@ -36,7 +47,10 @@ interface ReimbursementRowProps {
 export function ReimbursementRow({
   item,
   canManageReimbursements,
-  description,
+  kind,
+  title,
+  detail,
+  applicantName,
   selectionCheckbox,
   onClick,
   onApprove,
@@ -46,10 +60,18 @@ export function ReimbursementRow({
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
   const isPending = item.status === "pending";
+  const KindIcon =
+    kind === "travel" ? Route : kind === "allowance" ? HandHeart : ReceiptText;
+  const reviewDetails = [
+    item.reviewedByName ? `von ${item.reviewedByName}` : undefined,
+    item.reviewedAt ? formatDate(item.reviewedAt) : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <TableRow
-      className={onClick ? "cursor-pointer" : undefined}
+      className={onClick ? "group cursor-pointer" : undefined}
       onClick={onClick}
     >
       {selectionCheckbox !== undefined && (
@@ -57,34 +79,50 @@ export function ReimbursementRow({
           {selectionCheckbox}
         </TableCell>
       )}
-      <TableCell className="px-1">
-        <div className="flex items-center justify-center">
-          <div className={`w-2 h-2 rounded-full ${display.dot}`} />
+      <TableCell className="min-w-56 py-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground transition-colors group-hover:border-primary/20 group-hover:bg-primary/5 group-hover:text-primary">
+            <KindIcon className="size-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <div className="font-medium text-foreground">{title}</div>
+            {detail ? (
+              <div className="max-w-72 truncate text-xs text-muted-foreground">
+                {detail}
+              </div>
+            ) : null}
+          </div>
         </div>
       </TableCell>
-      <TableCell>{formatDate(new Date(item._creationTime))}</TableCell>
-      <TableCell>{item.projectName}</TableCell>
-      <TableCell className="text-muted-foreground">
-        {description}
-        {item.rejectionNote && (
-          <span className="block text-xs text-red-600">
-            Ablehnungsgrund: {item.rejectionNote}
-          </span>
-        )}
-      </TableCell>
       {canManageReimbursements ? (
-        <TableCell>{item.creatorName}</TableCell>
+        <TableCell className="max-w-48 truncate">{applicantName}</TableCell>
       ) : null}
+      <TableCell className="max-w-48 truncate">{item.projectName}</TableCell>
+      <TableCell className="text-muted-foreground">
+        {formatDate(item._creationTime)}
+      </TableCell>
       <TableCell className="text-right font-medium">
         {formatCurrency(item.amount)}
       </TableCell>
-      <TableCell>
-        <Badge variant={display.variant} className={display.className}>
-          {display.label}
-        </Badge>
-      </TableCell>
-      <TableCell className="text-muted-foreground">
-        {!isPending && item.reviewedByName ? item.reviewedByName : "–"}
+      <TableCell className="min-w-40">
+        <div className="flex flex-col items-start gap-1">
+          <Badge variant={display.variant} className={display.className}>
+            {display.label}
+          </Badge>
+          {!isPending && reviewDetails ? (
+            <span className="text-xs text-muted-foreground">
+              {reviewDetails}
+            </span>
+          ) : null}
+          {item.rejectionNote ? (
+            <span
+              className="max-w-56 truncate text-xs text-red-700"
+              title={`Ablehnungsgrund: ${item.rejectionNote}`}
+            >
+              Grund: {item.rejectionNote}
+            </span>
+          ) : null}
+        </div>
       </TableCell>
       <TableCell onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-end gap-0.5">

--- a/app/lib/server/reimbursements/data.ts
+++ b/app/lib/server/reimbursements/data.ts
@@ -79,6 +79,7 @@ export async function getAllReimbursements(): Promise<
     Reimbursement & {
       creatorName: string;
       projectName: string;
+      receiptSummary?: string;
       travelDetails?: TravelDetails;
       reviewedByName?: string;
     }
@@ -105,14 +106,18 @@ export async function getAllReimbursements(): Promise<
     .filter((item) => item.type === "travel")
     .map((item) => item._id);
 
-  const [creators, projectList, reviewers, travelList] = await Promise.all([
-    (await users()).find({ _id: { $in: creatorIds } }).toArray(),
-    (await projects()).find({ _id: { $in: projectIds } }).toArray(),
-    (await users()).find({ _id: { $in: reviewerIds } }).toArray(),
-    (await travelDetails())
-      .find({ reimbursementId: { $in: travelIds } })
-      .toArray(),
-  ]);
+  const [creators, projectList, reviewers, travelList, receiptList] =
+    await Promise.all([
+      (await users()).find({ _id: { $in: creatorIds } }).toArray(),
+      (await projects()).find({ _id: { $in: projectIds } }).toArray(),
+      (await users()).find({ _id: { $in: reviewerIds } }).toArray(),
+      (await travelDetails())
+        .find({ reimbursementId: { $in: travelIds } })
+        .toArray(),
+      (await receipts())
+        .find({ reimbursementId: { $in: list.map((item) => item._id) } })
+        .toArray(),
+    ]);
 
   const creatorMap = new Map(creators.map((item) => [item._id, item.name]));
   const projectMap = new Map(projectList.map((item) => [item._id, item.name]));
@@ -120,14 +125,32 @@ export async function getAllReimbursements(): Promise<
   const travelMap = new Map(
     travelList.map((item) => [item.reimbursementId, item]),
   );
+  const receiptsByReimbursement = new Map<string, Receipt[]>();
+  for (const receipt of receiptList) {
+    const reimbursementReceipts =
+      receiptsByReimbursement.get(receipt.reimbursementId) ?? [];
+    reimbursementReceipts.push(receipt);
+    receiptsByReimbursement.set(receipt.reimbursementId, reimbursementReceipts);
+  }
 
-  return list.map((item) => ({
-    ...item,
-    creatorName: creatorMap.get(item.createdBy) || "Unknown",
-    projectName: projectMap.get(item.projectId) || "Unbekanntes Projekt",
-    travelDetails: travelMap.get(item._id),
-    reviewedByName: item.reviewedBy
-      ? reviewerMap.get(item.reviewedBy)
-      : undefined,
-  }));
+  return list.map((item) => {
+    const itemReceipts = receiptsByReimbursement.get(item._id) ?? [];
+    const firstReceipt = itemReceipts[0];
+    const receiptLabel = firstReceipt?.description || firstReceipt?.companyName;
+    const receiptSummary =
+      receiptLabel && itemReceipts.length > 1
+        ? `${receiptLabel} + ${itemReceipts.length - 1} weitere`
+        : receiptLabel;
+
+    return {
+      ...item,
+      creatorName: creatorMap.get(item.createdBy) || "Unbekannt",
+      projectName: projectMap.get(item.projectId) || "Unbekanntes Projekt",
+      receiptSummary,
+      travelDetails: travelMap.get(item._id),
+      reviewedByName: item.reviewedBy
+        ? reviewerMap.get(item.reviewedBy)
+        : undefined,
+    };
+  });
 }

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -171,6 +171,9 @@ test("getAllReimbursements stays scoped to the caller's org", async () => {
   expect(list).toHaveLength(2);
   expect(list.every((item) => item.organizationId === orgA)).toBe(true);
   expect(list.every((item) => item.projectName === "Projekt A")).toBe(true);
+  expect(list.find((item) => item.createdBy === userA)?.receiptSummary).toBe(
+    "Material",
+  );
 });
 
 test("members only see their own reimbursements", async () => {
@@ -251,7 +254,9 @@ test("deleteReimbursement removes receipts and deletes the stored files", async 
 
 test("finance can delete another member's reimbursement", async () => {
   const reimbursementId = newId();
-  await (await reimbursements()).insertOne({
+  await (
+    await reimbursements()
+  ).insertOne({
     _id: reimbursementId,
     _creationTime: Date.now(),
     organizationId: orgA,

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -195,8 +195,12 @@ test.describe.serial("reimbursement flow", () => {
     await expect(
       page.getByText("Reisekostenerstattung eingereicht"),
     ).toBeVisible();
+    const travelRow = page.locator("table tbody tr").first();
     await expect(
-      page.getByText("Reisekostenerstattung - Berlin"),
+      travelRow.getByText("Reisekostenerstattung", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      travelRow.getByText("Event · Berlin", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });
@@ -212,9 +216,7 @@ test.describe.serial("reimbursement flow", () => {
       .fill("Falsche Angaben");
     await page.getByRole("button", { name: "Ablehnen" }).click();
 
-    await expect(
-      page.getByText("Ablehnungsgrund: Falsche Angaben"),
-    ).toBeVisible({
+    await expect(page.getByText("Grund: Falsche Angaben")).toBeVisible({
       timeout: 10000,
     });
     await expect(


### PR DESCRIPTION
## summary

- Reorganize the reimbursement list around request type, actual applicant, project, creation date, amount, and consolidated review status.
- Surface receipt, travel, and allowance context while removing duplicated project and status information.

## validation

- `pnpm vitest run app/lib/server/reimbursements/reimbursements.test.ts`; `pnpm vitest run`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --reporter=line`; `pnpm build`
- `pnpm exec tsc --noEmit`; `pnpm exec biome lint .`; `pnpm exec prettier --check <changed files>`; `pnpm run lint:lines`; `git diff --check`