### PR TITLE
fix(reimbursements): load private receipt media correctly

### DIFF
--- a/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
+++ b/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
@@ -2,17 +2,38 @@ import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
 import { formatDate } from "@/lib/formatters/formatDate";
 import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
+import { ExternalLink, FileText } from "lucide-react";
 import { COST_TYPE_LABELS } from "./constants";
 import type { ReceiptWithUrl } from "./types";
 
 export function ReceiptCard({ receipt }: { receipt: ReceiptWithUrl }) {
+  const isPdf = receipt.fileContentType === "application/pdf";
+
   return (
     <div className="border rounded-lg p-4 flex gap-4">
-      <img
-        src={receipt.fileUrl}
-        alt="Beleg"
-        className="w-32 h-32 object-cover rounded border"
-      />
+      <a
+        href={receipt.fileUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="group relative flex size-32 shrink-0 items-center justify-center overflow-hidden rounded border bg-muted/30"
+        aria-label="Beleg in neuem Tab öffnen"
+      >
+        {isPdf ? (
+          <div className="flex flex-col items-center gap-2 text-muted-foreground">
+            <FileText className="size-12" />
+            <span className="text-xs font-medium">PDF öffnen</span>
+          </div>
+        ) : (
+          <img
+            src={receipt.fileUrl}
+            alt="Beleg"
+            className="size-full object-cover"
+          />
+        )}
+        <span className="absolute right-1.5 top-1.5 rounded bg-background/90 p-1 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          <ExternalLink className="size-3.5" />
+        </span>
+      </a>
       <div className="flex-1 space-y-2">
         <div className="flex items-start justify-between">
           <div>

--- a/app/(protected)/reimbursements/[id]/_components/types.ts
+++ b/app/(protected)/reimbursements/[id]/_components/types.ts
@@ -9,4 +9,7 @@ export type Reimbursement = NonNullable<
 
 export type Receipt = Awaited<ReturnType<typeof getReceipts>>[number];
 
-export type ReceiptWithUrl = Receipt & { fileUrl: string };
+export type ReceiptWithUrl = Receipt & {
+  fileUrl: string;
+  fileContentType: string;
+};

--- a/app/(protected)/reimbursements/[id]/page.tsx
+++ b/app/(protected)/reimbursements/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { PageHeader } from "@/components/Layout/PageHeader";
 import {
-  getFileUrl,
+  getFileInfo,
   getReceipts,
   getReimbursement,
 } from "@/lib/server/reimbursements/data";
@@ -21,10 +21,14 @@ export default async function ReimbursementDetailPage({
   const reimbursement = await getReimbursement(id);
   const rawReceipts = reimbursement ? await getReceipts(id) : [];
   const receipts = await Promise.all(
-    rawReceipts.map(async (receipt) => ({
-      ...receipt,
-      fileUrl: await getFileUrl(receipt.fileStorageId),
-    })),
+    rawReceipts.map(async (receipt) => {
+      const file = await getFileInfo(receipt.fileStorageId);
+      return {
+        ...receipt,
+        fileUrl: file.url,
+        fileContentType: file.contentType,
+      };
+    }),
   );
 
   if (!reimbursement) {

--- a/app/components/Reimbursements/ReceiptUpload.tsx
+++ b/app/components/Reimbursements/ReceiptUpload.tsx
@@ -7,10 +7,10 @@ import {
 } from "@/lib/fileHandlers/fileConversion";
 import {
   generateUploadUrl,
-  getFileUrlAction,
+  getFileInfoAction,
 } from "@/lib/server/reimbursements/actions";
 import { FileText, Loader2, Upload } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import toast from "react-hot-toast";
 
 interface Props {
@@ -19,20 +19,29 @@ interface Props {
 }
 
 export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
+  const inputId = useId();
   const [isUploading, setIsUploading] = useState(false);
   const [isPdf, setIsPdf] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!storageId) {
       setPreviewUrl(null);
+      setIsPdf(false);
       return;
     }
     let active = true;
-    getFileUrlAction(storageId).then((url) => {
-      if (active) setPreviewUrl(url);
-    });
+    getFileInfoAction(storageId)
+      .then(({ url, contentType }) => {
+        if (!active) return;
+        setPreviewUrl(url);
+        setIsPdf(contentType === "application/pdf");
+      })
+      .catch(() => {
+        if (!active) return;
+        setPreviewUrl(null);
+        setIsPdf(false);
+      });
     return () => {
       active = false;
     };
@@ -71,7 +80,7 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
 
   const fileInput = (
     <input
-      ref={inputRef}
+      id={inputId}
       type="file"
       accept=".jpg,.jpeg,.png,.heic,.pdf"
       onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
@@ -81,9 +90,9 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
 
   if (previewUrl || isPdf) {
     return (
-      <div
-        className="border rounded-lg p-4 relative group cursor-pointer"
-        onClick={() => inputRef.current?.click()}
+      <label
+        htmlFor={inputId}
+        className="block border rounded-lg p-4 relative group cursor-pointer"
       >
         {isPdf ? (
           <div className="flex flex-col items-center gap-2 py-4">
@@ -104,13 +113,13 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
           </div>
         </div>
         {fileInput}
-      </div>
+      </label>
     );
   }
 
   return (
-    <div
-      onClick={() => inputRef.current?.click()}
+    <label
+      htmlFor={inputId}
       onDragOver={(e) => e.preventDefault()}
       onDrop={(e) => {
         e.preventDefault();
@@ -137,6 +146,6 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
         </div>
       )}
       {fileInput}
-    </div>
+    </label>
   );
 }

--- a/app/lib/s3/storage.ts
+++ b/app/lib/s3/storage.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
@@ -76,6 +77,20 @@ export function presignDownload(key: string): Promise<string> {
     new GetObjectCommand({ Bucket: bucket(), Key: key }),
     { expiresIn: 300 },
   );
+}
+
+export async function getDownloadInfo(
+  key: string,
+): Promise<{ url: string; contentType: string }> {
+  const [url, metadata] = await Promise.all([
+    presignDownload(key),
+    s3().send(new HeadObjectCommand({ Bucket: bucket(), Key: key })),
+  ]);
+
+  return {
+    url,
+    contentType: metadata.ContentType ?? "application/octet-stream",
+  };
 }
 
 export async function deleteObject(key: string): Promise<void> {

--- a/app/lib/server/reimbursements/actions.ts
+++ b/app/lib/server/reimbursements/actions.ts
@@ -14,7 +14,7 @@ import {
   insertTravelDetails,
   type ReimbursementPdfData,
 } from "./actionsHelpers";
-import { getFileUrl } from "./data";
+import { getFileInfo, getFileUrl } from "./data";
 import {
   insertReceipts,
   insertReimbursement,
@@ -86,6 +86,12 @@ export async function getFileUrlAction(key: string): Promise<string> {
     return "data:image/gif;base64,R0lGODlhAQABAAAAACw=";
   }
   return getFileUrl(key);
+}
+
+export async function getFileInfoAction(
+  key: string,
+): Promise<{ url: string; contentType: string }> {
+  return getFileInfo(key);
 }
 
 export async function getReimbursementPdfData(

--- a/app/lib/server/reimbursements/data.ts
+++ b/app/lib/server/reimbursements/data.ts
@@ -1,4 +1,5 @@
 import { hasMinimumRole } from "../../auth/roles";
+import { isTestMode } from "../../auth/environment";
 import { requireUser } from "../../auth/session";
 import {
   projects,
@@ -8,7 +9,7 @@ import {
   users,
 } from "../../db/collections";
 import type { Receipt, Reimbursement, TravelDetails } from "../../db/types";
-import { presignDownload } from "../../s3/storage";
+import { getDownloadInfo, presignDownload } from "../../s3/storage";
 
 export async function getUserBankDetails(): Promise<{
   iban: string;
@@ -72,6 +73,19 @@ export async function getReceipts(reimbursementId: string): Promise<Receipt[]> {
 export async function getFileUrl(storageId: string): Promise<string> {
   await requireUser();
   return presignDownload(storageId);
+}
+
+export async function getFileInfo(
+  storageId: string,
+): Promise<{ url: string; contentType: string }> {
+  await requireUser();
+  if (isTestMode()) {
+    return {
+      url: "data:image/gif;base64,R0lGODlhAQABAAAAACw=",
+      contentType: "image/gif",
+    };
+  }
+  return getDownloadInfo(storageId);
 }
 
 export async function getAllReimbursements(): Promise<

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -1,5 +1,13 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -9,6 +17,10 @@ vi.mock("../../auth/session", () => ({
 vi.mock("../../s3/storage", () => ({
   presignUpload: vi.fn(async () => ({ key: "key", url: "url" })),
   presignDownload: vi.fn(async () => "url"),
+  getDownloadInfo: vi.fn(async () => ({
+    url: "signed-url",
+    contentType: "application/pdf",
+  })),
   deleteObject: vi.fn(async () => {}),
   getObjectBuffer: vi.fn(async () => Buffer.from("file")),
 }));
@@ -23,9 +35,9 @@ import {
   users,
 } from "../../db/collections";
 import { newId } from "../../db/ids";
-import { deleteObject } from "../../s3/storage";
+import { deleteObject, getDownloadInfo } from "../../s3/storage";
 import { approve, createReimbursement, deleteReimbursement } from "./actions";
-import { getAllReimbursements, getReimbursement } from "./data";
+import { getAllReimbursements, getFileInfo, getReimbursement } from "./data";
 
 let mongod: MongoMemoryServer;
 let orgA: string;
@@ -44,6 +56,10 @@ afterAll(async () => {
   await client.close();
   await mongod.stop();
 }, 30_000);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 beforeEach(async () => {
   await (await getDb()).dropDatabase();
@@ -134,6 +150,16 @@ test("createReimbursement writes the reimbursement and receipts scoped to the or
     .toArray();
   expect(receiptList).toHaveLength(1);
   expect(receiptList[0]?.fileStorageId).toBe("receipt-key");
+});
+
+test("getFileInfo returns signed download metadata", async () => {
+  vi.stubEnv("IS_TEST", "false");
+
+  await expect(getFileInfo("receipt-key")).resolves.toEqual({
+    url: "signed-url",
+    contentType: "application/pdf",
+  });
+  expect(getDownloadInfo).toHaveBeenCalledWith("receipt-key");
 });
 
 test("getAllReimbursements stays scoped to the caller's org", async () => {


### PR DESCRIPTION
## summary

- keep receipt storage private while loading signed URLs together with object content types
- render images as previews and PDFs as openable cards, reset stale PDF state, and cover metadata loading with tests

## validation

- `pnpm lint`
- `pnpm run lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (passed on retry; the first combined `pnpm test` run hit a toast-overlay timeout)
- `pnpm build`