### PR TITLE
feat(reimbursements): require valid bank details

### DIFF
--- a/app/components/BankDetailsEditor.tsx
+++ b/app/components/BankDetailsEditor.tsx
@@ -3,7 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { BIC_REGEX, formatIban, IBAN_REGEX } from "@/lib/bank-utils";
+import {
+  formatIban,
+  getBankDetailsError,
+  normalizeIban,
+} from "@/lib/bank-utils";
 import { updateBankDetails } from "@/lib/server/users/actions";
 import { Loader2, Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -17,7 +21,7 @@ interface Props {
   onChange: (value: BankDetails) => void;
 }
 export function BankDetailsEditor({ value, onChange }: Props) {
-  const [editing, setEditing] = useState(false);
+  const [editing, setEditing] = useState(() => !!getBankDetailsError(value));
   const [isSaving, setIsSaving] = useState(false);
   const router = useRouter();
 
@@ -26,14 +30,11 @@ export function BankDetailsEditor({ value, onChange }: Props) {
       setEditing(true);
       return;
     }
-    const iban = value.iban.replace(/\s/g, "").toUpperCase();
+    const iban = normalizeIban(value.iban);
     const bic = value.bic.replace(/\s/g, "").toUpperCase();
-    if (!value.accountHolder.trim())
-      return toast.error("Bitte Kontoinhaber eingeben");
-    if (!IBAN_REGEX.test(iban)) return toast.error("Ungültige IBAN");
-    if (bic && !BIC_REGEX.test(bic)) return toast.error("Ungültige BIC");
-
-    const normalized = { ...value, iban, bic };
+    const normalized = { accountHolder: value.accountHolder.trim(), iban, bic };
+    const validationError = getBankDetailsError(normalized);
+    if (validationError) return toast.error(validationError);
     setIsSaving(true);
     try {
       await updateBankDetails(normalized);
@@ -54,6 +55,12 @@ export function BankDetailsEditor({ value, onChange }: Props) {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-medium">Bankverbindung</h2>
+      {editing && !!getBankDetailsError(value) && (
+        <p className="text-sm text-amber-700" aria-live="polite">
+          Bitte vervollständige deine Bankverbindung. Ohne gültige Bankdaten
+          kannst du den Antrag nicht einreichen.
+        </p>
+      )}
       <div className="flex items-end gap-4">
         <div className="grid grid-cols-[1fr_2fr_1fr] gap-4 flex-1">
           <div>
@@ -65,6 +72,7 @@ export function BankDetailsEditor({ value, onChange }: Props) {
               onChange={(e) => update("accountHolder", e.target.value)}
               disabled={!editing}
               placeholder="Vor- und Nachname"
+              required
             />
           </div>
           <div>
@@ -80,6 +88,7 @@ export function BankDetailsEditor({ value, onChange }: Props) {
               placeholder="DE12 3456 7890 0000 0000 00"
               className="font-mono"
               maxLength={42}
+              required
             />
           </div>
           <div>
@@ -97,6 +106,7 @@ export function BankDetailsEditor({ value, onChange }: Props) {
           </div>
         </div>
         <Button
+          type="button"
           variant={editing ? "default" : "outline"}
           className="h-[52px] min-w-[52px] border-input px-4 hover:border-ring focus-visible:border-foreground focus-visible:ring-0 md:h-12 md:min-w-12"
           onClick={toggle}

--- a/app/components/Reimbursements/reimbursementForm/useReimbursementForm.ts
+++ b/app/components/Reimbursements/reimbursementForm/useReimbursementForm.ts
@@ -1,4 +1,4 @@
-import { toNet } from "@/lib/bank-utils";
+import { getBankDetailsError, toNet } from "@/lib/bank-utils";
 import { createReimbursement } from "@/lib/server/reimbursements/actions";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -57,6 +57,8 @@ export function useReimbursementForm(defaultBankDetails: BankDetails) {
     if (!projectId) return toast.error("Bitte ein Projekt auswählen");
     if (receipts.length === 0)
       return toast.error("Bitte mindestens einen Beleg hinzufügen");
+    const bankDetailsError = getBankDetailsError(bank);
+    if (bankDetailsError) return toast.error(bankDetailsError);
     if (!signature) return toast.error("Bitte unterschreiben");
     if (isSubmitting) return;
     setIsSubmitting(true);

--- a/app/components/Reimbursements/travelForm/useTravelForm.ts
+++ b/app/components/Reimbursements/travelForm/useTravelForm.ts
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { createTravelReimbursement } from "@/lib/server/reimbursements/actions";
+import { getBankDetailsError } from "@/lib/bank-utils";
 import { type CostType, DEFAULT_TAX_RATES } from "@/lib/travel-costs";
 import type { BankDetails, Receipt } from "./types";
 
@@ -97,6 +98,8 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
 
   const handleSubmit = async () => {
     if (!projectId) return toast.error("Bitte ein Projekt auswählen");
+    const bankDetailsError = getBankDetailsError(bank);
+    if (bankDetailsError) return toast.error(bankDetailsError);
     if (!signature) return toast.error("Bitte unterschreiben");
     if (isSubmitting) return;
     setIsSubmitting(true);

--- a/app/components/Reimbursements/volunteerAllowanceForm/useVolunteerAllowanceForm.ts
+++ b/app/components/Reimbursements/volunteerAllowanceForm/useVolunteerAllowanceForm.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { create } from "@/lib/server/volunteerAllowance/actions";
+import { getBankDetailsError } from "@/lib/bank-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -55,8 +56,8 @@ export function useVolunteerAllowanceForm(defaultBankDetails: BankDetails) {
     if (!amount || amount <= 0) return "Bitte einen Betrag eingeben";
     if (amount > MAX_VOLUNTEER_ALLOWANCE_EUR)
       return `Maximal ${MAX_VOLUNTEER_ALLOWANCE_EUR} € erlaubt`;
-    if (!bank.accountHolder) return "Bitte den Kontoinhaber eingeben";
-    if (!bank.iban) return "Bitte die IBAN eingeben";
+    const bankDetailsError = getBankDetailsError(bank);
+    if (bankDetailsError) return bankDetailsError;
     if (!form.confirmed) return "Bitte die Bestätigung ankreuzen";
     if (!signature) return "Bitte unterschreiben";
     return null;
@@ -65,11 +66,12 @@ export function useVolunteerAllowanceForm(defaultBankDetails: BankDetails) {
   const handleSubmit = async () => {
     const error = validate();
     if (error) return toast.error(error);
+    if (!projectId || !signature) return;
     if (isSubmitting) return;
     setIsSubmitting(true);
     try {
       await create({
-        projectId: projectId!,
+        projectId,
         amount: parseAmount(form.amount),
         ...bank,
         activityDescription: form.activity,
@@ -80,7 +82,7 @@ export function useVolunteerAllowanceForm(defaultBankDetails: BankDetails) {
         volunteerStreet: form.street,
         volunteerPlz: form.plz,
         volunteerCity: form.city,
-        signatureStorageId: signature!,
+        signatureStorageId: signature,
       });
       toast.success("Ehrenamtspauschale eingereicht");
       router.push("/reimbursements");

--- a/app/lib/bank-utils.test.ts
+++ b/app/lib/bank-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { getBankDetailsError } from "./bank-utils";
+
+describe("getBankDetailsError", () => {
+  test("requires an account holder and a valid IBAN", () => {
+    expect(getBankDetailsError({ accountHolder: "", iban: "", bic: "" })).toBe(
+      "Bitte Kontoinhaber eingeben",
+    );
+    expect(
+      getBankDetailsError({ accountHolder: "Max", iban: "", bic: "" }),
+    ).toBe("Bitte IBAN eingeben");
+  });
+
+  test("accepts normalized bank details without a BIC", () => {
+    expect(
+      getBankDetailsError({
+        accountHolder: "Max Mustermann",
+        iban: "de89 3704 0044 0532 0130 00",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects an invalid optional BIC", () => {
+    expect(
+      getBankDetailsError({
+        accountHolder: "Max Mustermann",
+        iban: "DE89370400440532013000",
+        bic: "INVALID",
+      }),
+    ).toBe("Ungültige BIC");
+  });
+});

--- a/app/lib/bank-utils.ts
+++ b/app/lib/bank-utils.ts
@@ -9,6 +9,24 @@ export function normalizeIban(iban: string): string {
   return iban.replace(/\s/g, "").toUpperCase();
 }
 
+type BankDetails = {
+  iban: string;
+  bic?: string;
+  accountHolder: string;
+};
+
+export function getBankDetailsError(details: BankDetails): string | null {
+  if (!details.accountHolder.trim()) return "Bitte Kontoinhaber eingeben";
+  const iban = normalizeIban(details.iban);
+  if (!iban) return "Bitte IBAN eingeben";
+  if (!IBAN_REGEX.test(iban)) return "Ungültige IBAN";
+
+  const bic = details.bic?.replace(/\s/g, "").toUpperCase() ?? "";
+  if (bic && !BIC_REGEX.test(bic)) return "Ungültige BIC";
+
+  return null;
+}
+
 export function toNet(gross: number, taxRate: number): number {
   return gross / (1 + taxRate / 100);
 }

--- a/app/lib/server/bankDetails.ts
+++ b/app/lib/server/bankDetails.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { BIC_REGEX, IBAN_REGEX, normalizeIban } from "../bank-utils";
+
+const ibanSchema = z
+  .string()
+  .transform(normalizeIban)
+  .pipe(z.string().regex(IBAN_REGEX, "Ungültige IBAN"));
+
+const bicSchema = z
+  .string()
+  .transform((bic) => bic.replace(/\s/g, "").toUpperCase())
+  .refine((bic) => !bic || BIC_REGEX.test(bic), "Ungültige BIC");
+
+export const bankDetailsFields = {
+  iban: ibanSchema,
+  bic: bicSchema.optional(),
+  accountHolder: z.string().trim().min(1, "Bitte Kontoinhaber eingeben"),
+};
+
+export const bankDetailsSchema = z.object(bankDetailsFields);

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -121,7 +121,7 @@ function reimbursementInput() {
   return {
     amount: 50,
     projectId: projectA,
-    iban: "DE00",
+    iban: "DE89370400440532013000",
     accountHolder: "Max",
     signatureStorageId: "sig-key",
     receipts: [
@@ -160,6 +160,16 @@ test("getFileInfo returns signed download metadata", async () => {
     contentType: "application/pdf",
   });
   expect(getDownloadInfo).toHaveBeenCalledWith("receipt-key");
+});
+
+test("createReimbursement rejects missing bank details", async () => {
+  await expect(
+    createReimbursement({
+      ...reimbursementInput(),
+      iban: "",
+      accountHolder: "",
+    }),
+  ).rejects.toThrow();
 });
 
 test("getAllReimbursements stays scoped to the caller's org", async () => {

--- a/app/lib/server/reimbursements/validators.ts
+++ b/app/lib/server/reimbursements/validators.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { bankDetailsFields } from "../bankDetails";
 
 const baseReceiptFields = {
   receiptNumber: z.string().optional(),
@@ -22,9 +23,7 @@ const travelReceiptValidator = z.object({
 export const createReimbursementSchema = z.object({
   amount: z.number(),
   projectId: z.string(),
-  iban: z.string(),
-  bic: z.string().optional(),
-  accountHolder: z.string(),
+  ...bankDetailsFields,
   currency: z.string().optional(),
   signatureStorageId: z.string(),
   receipts: z.array(receiptValidator),
@@ -33,9 +32,7 @@ export const createReimbursementSchema = z.object({
 export const createTravelReimbursementSchema = z.object({
   amount: z.number(),
   projectId: z.string(),
-  iban: z.string(),
-  bic: z.string().optional(),
-  accountHolder: z.string(),
+  ...bankDetailsFields,
   currency: z.string().optional(),
   signatureStorageId: z.string(),
   startDate: z.string(),

--- a/app/lib/server/users/actions.ts
+++ b/app/lib/server/users/actions.ts
@@ -5,6 +5,7 @@ import { requireRole, requireUser } from "../../auth/session";
 import { users } from "../../db/collections";
 import type { UserRole } from "../../db/types";
 import { addLog } from "../logs";
+import { bankDetailsSchema } from "../bankDetails";
 
 const roleSchema = z.enum(["admin", "finance", "member"]);
 
@@ -82,13 +83,7 @@ export async function updateBankDetails(input: {
   accountHolder: string;
 }): Promise<void> {
   const user = await requireUser();
-  const { iban, bic, accountHolder } = z
-    .object({
-      iban: z.string(),
-      bic: z.string(),
-      accountHolder: z.string(),
-    })
-    .parse(input);
+  const { iban, bic, accountHolder } = bankDetailsSchema.parse(input);
 
   await (await users()).updateOne(
     { _id: user._id },

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -124,12 +124,18 @@ test("addUserToOrganization cannot pull in a user from another org", async () =>
 
 test("updateBankDetails updates the caller's own bank details", async () => {
   await updateBankDetails({
-    iban: "DE89",
-    bic: "ABCDEF",
+    iban: "de89 3704 0044 0532 0130 00",
+    bic: "cobadeffxxx",
     accountHolder: "Admin A",
   });
   const updated = await (await users()).findOne({ _id: adminA });
-  expect(updated?.iban).toBe("DE89");
-  expect(updated?.bic).toBe("ABCDEF");
+  expect(updated?.iban).toBe("DE89370400440532013000");
+  expect(updated?.bic).toBe("COBADEFFXXX");
   expect(updated?.accountHolder).toBe("Admin A");
+});
+
+test("updateBankDetails rejects missing bank details", async () => {
+  await expect(
+    updateBankDetails({ iban: "", bic: "", accountHolder: "" }),
+  ).rejects.toThrow();
 });

--- a/app/lib/server/volunteerAllowance/actions.ts
+++ b/app/lib/server/volunteerAllowance/actions.ts
@@ -8,6 +8,7 @@ import { newId } from "../../db/ids";
 import { deleteObject } from "../../s3/storage";
 import { addLog } from "../logs";
 import { getSignatureUrl } from "./data";
+import { bankDetailsFields } from "../bankDetails";
 
 const MAX_VOLUNTEER_ALLOWANCE_EUR = 960;
 export async function create(input: {
@@ -31,9 +32,7 @@ export async function create(input: {
     .object({
       projectId: z.string(),
       amount: z.number(),
-      iban: z.string(),
-      bic: z.string().optional(),
-      accountHolder: z.string(),
+      ...bankDetailsFields,
       activityDescription: z.string(),
       startDate: z.string(),
       endDate: z.string(),

--- a/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
+++ b/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
@@ -33,7 +33,7 @@ function newAllowanceInput(projectId: string) {
   return {
     projectId,
     amount: 100,
-    iban: "DE00",
+    iban: "DE89370400440532013000",
     accountHolder: "Max Mustermann",
     activityDescription: "Helfen",
     startDate: "2026-01-01",
@@ -169,6 +169,18 @@ test("create + getAll stay scoped to the caller's org", async () => {
     "Other member",
   ]);
   expect(list.every((item) => item.projectName === "Projekt A")).toBe(true);
+});
+
+test("create rejects missing bank details", async () => {
+  const projectA = newId();
+
+  await expect(
+    create({
+      ...newAllowanceInput(projectA),
+      iban: "",
+      accountHolder: "",
+    }),
+  ).rejects.toThrow();
 });
 
 test("create persists the allowance as pending", async () => {

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -113,6 +113,16 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("button", { name: "Beleg speichern" }).click();
     await expect(page.getByText("Test Firma")).toBeVisible();
 
+    await expect(
+      page.getByText("Bitte vervollständige deine Bankverbindung."),
+    ).toBeVisible();
+    await page.getByPlaceholder("Vor- und Nachname").fill("Test User");
+    await page
+      .getByPlaceholder("DE12 3456 7890 0000 0000 00")
+      .fill("DE89370400440532013000");
+    await page.getByRole("button", { name: "Speichern" }).click();
+    await expect(page.getByText("Bankverbindung gespeichert")).toBeVisible();
+
     await addSignature(page);
 
     await page


### PR DESCRIPTION
## summary

- Require account holders and structurally valid IBANs before reimbursement submission while keeping BIC optional.
- Open incomplete bank details for editing automatically and enforce shared client/server validation across expense, travel, allowance, and profile actions.
- Cover first-time bank detail setup with unit, integration, and browser tests.

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm test` (63 Vitest tests and 4 Playwright tests)
- `pnpm build`
- `pnpm lint` (fails on pre-existing errors in untouched upload and reimbursement components)