### PR TITLE
fix(reimbursements): match share form control heights

### DIFF
--- a/app/components/Reimbursements/shareModal/ShareForm.tsx
+++ b/app/components/Reimbursements/shareModal/ShareForm.tsx
@@ -54,8 +54,7 @@ export function ShareForm({
             type="button"
             variant={type === linkType ? "default" : "outline"}
             onClick={() => onTypeChange(linkType)}
-            className="flex-1"
-            size="sm"
+            className="h-12 flex-1"
           >
             {TYPE_LABELS[linkType]}
           </Button>
@@ -148,7 +147,7 @@ export function ShareForm({
       <Button
         variant="outline"
         onClick={onCopy}
-        className="w-full"
+        className="h-12 w-full"
         disabled={isGenerating || !form.projectId}
       >
         {isGenerating ? (


### PR DESCRIPTION
## summary

- Match all three reimbursement type selectors to the 48 px project input height.
- Give the copy-link action the same form-control height for a consistent modal layout.

## validation

- `pnpm exec prettier --check app/components/Reimbursements/shareModal/ShareForm.tsx`
- `pnpm exec biome lint app/components/Reimbursements/shareModal/ShareForm.tsx`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- Not run (no targeted automated test covers this CSS-only sizing change).