### PR TITLE
feat(reimbursements): filter list by reimbursement type

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementPageUI.tsx
+++ b/app/(protected)/reimbursements/ReimbursementPageUI.tsx
@@ -2,6 +2,7 @@
 
 import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Download,
   FileCode2,
@@ -16,6 +17,7 @@ import type {
   Allowance,
   RejectDialog,
   Reimbursement,
+  ReimbursementTypeFilter,
   SelectionKey,
 } from "./types";
 
@@ -23,6 +25,7 @@ interface Props {
   canManageReimbursements: boolean;
   reimbursements: Reimbursement[];
   allowances: Allowance[];
+  typeFilter: ReimbursementTypeFilter;
   rejectDialog: RejectDialog;
   selected: Set<SelectionKey>;
   isBulkDownloading: boolean;
@@ -41,6 +44,7 @@ interface Props {
   onDeleteAllowance: (id: string) => void;
   onToggleSelect: (key: SelectionKey) => void;
   onToggleSelectAll: () => void;
+  onTypeFilterChange: (value: ReimbursementTypeFilter) => void;
   onBulkDownload: () => void;
   onFinomCsv: () => void;
   onSepaXml: () => void;
@@ -50,6 +54,7 @@ export function ReimbursementPageUI({
   canManageReimbursements,
   reimbursements,
   allowances,
+  typeFilter,
   rejectDialog,
   selected,
   isBulkDownloading,
@@ -68,6 +73,7 @@ export function ReimbursementPageUI({
   onDeleteAllowance,
   onToggleSelect,
   onToggleSelectAll,
+  onTypeFilterChange,
   onBulkDownload,
   onFinomCsv,
   onSepaXml,
@@ -116,6 +122,21 @@ export function ReimbursementPageUI({
           </Button>
         ) : null}
       </div>
+
+      <Tabs
+        value={typeFilter}
+        onValueChange={(value) =>
+          onTypeFilterChange(value as ReimbursementTypeFilter)
+        }
+        className="mb-4"
+      >
+        <TabsList aria-label="Erstattungsart filtern">
+          <TabsTrigger value="all">Alle</TabsTrigger>
+          <TabsTrigger value="travel">Reisekostenerstattung</TabsTrigger>
+          <TabsTrigger value="expense">Auslagenerstattung</TabsTrigger>
+          <TabsTrigger value="allowance">Ehrenamtspauschale</TabsTrigger>
+        </TabsList>
+      </Tabs>
 
       <ReimbursementTable
         canManageReimbursements={canManageReimbursements}

--- a/app/(protected)/reimbursements/ReimbursementsClient.tsx
+++ b/app/(protected)/reimbursements/ReimbursementsClient.tsx
@@ -6,7 +6,12 @@ import { useCanManageReimbursements } from "@/lib/hooks/useCurrentUserRole";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { ReimbursementPageUI } from "./ReimbursementPageUI";
-import type { Allowance, Reimbursement, SelectionKey } from "./types";
+import type {
+  Allowance,
+  Reimbursement,
+  ReimbursementTypeFilter,
+  SelectionKey,
+} from "./types";
 import { usePaymentExports } from "./usePaymentExports";
 import { usePdfDownloads } from "./usePdfDownloads";
 import { useReimbursementActions } from "./useReimbursementActions";
@@ -29,6 +34,13 @@ export function ReimbursementsClient({
 
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [selected, setSelected] = useState<Set<SelectionKey>>(new Set());
+  const [typeFilter, setTypeFilter] = useState<ReimbursementTypeFilter>("all");
+
+  const filteredReimbursements = reimbursements.filter(
+    (item) => typeFilter === "all" || item.type === typeFilter,
+  );
+  const filteredAllowances =
+    typeFilter === "all" || typeFilter === "allowance" ? allowances : [];
 
   const actions = useReimbursementActions();
   const { handleFinomCsv, handleSepaXml } = usePaymentExports(
@@ -57,20 +69,26 @@ export function ReimbursementsClient({
 
   const handleToggleSelectAll = () => {
     const allKeys: SelectionKey[] = [
-      ...reimbursements.map((item): SelectionKey => `r:${item._id}`),
-      ...allowances.map((item): SelectionKey => `a:${item._id}`),
+      ...filteredReimbursements.map((item): SelectionKey => `r:${item._id}`),
+      ...filteredAllowances.map((item): SelectionKey => `a:${item._id}`),
     ];
     setSelected((prev) =>
       prev.size === allKeys.length ? new Set() : new Set(allKeys),
     );
   };
 
+  const handleTypeFilterChange = (value: ReimbursementTypeFilter) => {
+    setTypeFilter(value);
+    setSelected(new Set());
+  };
+
   return (
     <>
       <ReimbursementPageUI
         canManageReimbursements={canManageReimbursements}
-        reimbursements={reimbursements}
-        allowances={allowances}
+        reimbursements={filteredReimbursements}
+        allowances={filteredAllowances}
+        typeFilter={typeFilter}
         rejectDialog={actions.rejectDialog}
         selected={selected}
         isBulkDownloading={isBulkDownloading}
@@ -89,6 +107,7 @@ export function ReimbursementsClient({
         onDeleteAllowance={actions.handleDeleteAllowance}
         onToggleSelect={handleToggleSelect}
         onToggleSelectAll={handleToggleSelectAll}
+        onTypeFilterChange={handleTypeFilterChange}
         onBulkDownload={handleBulkDownload}
         onFinomCsv={handleFinomCsv}
         onSepaXml={handleSepaXml}

--- a/app/(protected)/reimbursements/types.ts
+++ b/app/(protected)/reimbursements/types.ts
@@ -24,6 +24,12 @@ export type Allowance = VolunteerAllowance & {
 
 export type SelectionKey = `r:${string}` | `a:${string}`;
 
+export type ReimbursementTypeFilter =
+  | "all"
+  | "expense"
+  | "travel"
+  | "allowance";
+
 export type RejectDialog = {
   open: boolean;
   type: "reimbursement" | "allowance";

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -250,7 +250,47 @@ test.describe.serial("reimbursement flow", () => {
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });
 
-  test("4. Reject travel reimbursement", async () => {
+  test("4. Filter reimbursements by type", async () => {
+    const tableRows = page.locator("table tbody tr");
+
+    await expect(tableRows).toHaveCount(2);
+    await tableRows
+      .first()
+      .getByRole("checkbox", { name: "Antrag auswählen" })
+      .check();
+    await expect(
+      page.getByRole("button", { name: "1 herunterladen" }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("tab", { name: "Reisekostenerstattung", exact: true })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "1 herunterladen" }),
+    ).not.toBeVisible();
+    await expect(tableRows).toHaveCount(1);
+    await expect(
+      page.getByRole("cell", { name: "Reisekostenerstattung" }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("tab", { name: "Auslagenerstattung", exact: true })
+      .click();
+    await expect(tableRows).toHaveCount(1);
+    await expect(
+      page.getByRole("cell", { name: "Auslagenerstattung" }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("tab", { name: "Ehrenamtspauschale", exact: true })
+      .click();
+    await expect(page.getByText("Keine Erstattungen gefunden.")).toBeVisible();
+
+    await page.getByRole("tab", { name: "Alle", exact: true }).click();
+    await expect(tableRows).toHaveCount(2);
+  });
+
+  test("5. Reject travel reimbursement", async () => {
     await page
       .locator("table tbody tr")
       .first()


### PR DESCRIPTION
## summary

- add accessible tabs for filtering reimbursements by travel, expense, or volunteer allowance type
- keep bulk selection scoped to visible rows and clear it when the filter changes

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec vitest run`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --project=chromium`
