### PR TITLE
fix(reimbursements): remove redundant bank details notice

### DIFF
--- a/app/components/BankDetailsEditor.tsx
+++ b/app/components/BankDetailsEditor.tsx
@@ -55,12 +55,6 @@ export function BankDetailsEditor({ value, onChange }: Props) {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-medium">Bankverbindung</h2>
-      {editing && !!getBankDetailsError(value) && (
-        <p className="text-sm text-amber-700" aria-live="polite">
-          Bitte vervollständige deine Bankverbindung. Ohne gültige Bankdaten
-          kannst du den Antrag nicht einreichen.
-        </p>
-      )}
       <div className="flex items-end gap-4">
         <div className="grid grid-cols-[1fr_2fr_1fr] gap-4 flex-1">
           <div>

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -137,9 +137,6 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("button", { name: "Beleg speichern" }).click();
     await expect(page.getByText("Test Firma")).toBeVisible();
 
-    await expect(
-      page.getByText("Bitte vervollständige deine Bankverbindung."),
-    ).toBeVisible();
     await page.getByPlaceholder("Vor- und Nachname").fill("Test User");
     await page
       .getByPlaceholder("DE12 3456 7890 0000 0000 00")


### PR DESCRIPTION
## summary

- remove the redundant bank details warning from reimbursement forms
- keep bank validation unchanged and align the E2E expectation with the streamlined UI

## validation

- `pnpm exec biome lint app/components/BankDetailsEditor.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "Create expense reimbursement with JPG receipt"`