### PR TITLE
fix(reimbursements): wrap summaries earlier on laptops

### DIFF
--- a/app/components/Reimbursements/ReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/ReimbursementFormUI.tsx
@@ -15,7 +15,7 @@ export function ReimbursementFormUI({ defaultBankDetails, projects }: Props) {
   const hasReceipts = form.receipts.length > 0;
 
   return (
-    <div className="p-6 lg:grid lg:grid-cols-[minmax(0,1fr)_400px] lg:items-start lg:gap-10">
+    <div className="p-6 xl:grid xl:grid-cols-[minmax(0,1fr)_400px] xl:items-start xl:gap-10">
       <div className="space-y-8 min-w-0">
         <ProjectCurrencyFields
           projects={projects}
@@ -47,7 +47,7 @@ export function ReimbursementFormUI({ defaultBankDetails, projects }: Props) {
         )}
       </div>
 
-      <div className="mt-8 lg:mt-0 lg:sticky lg:top-6">
+      <div className="mt-8 xl:mt-0 xl:sticky xl:top-6">
         <ReimbursementSummary
           receipts={form.receipts}
           currencySymbol={currencySymbol}

--- a/app/components/Reimbursements/TravelReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/TravelReimbursementFormUI.tsx
@@ -37,7 +37,7 @@ export function TravelReimbursementFormUI({
   };
 
   return (
-    <div className="p-6 lg:grid lg:grid-cols-[minmax(0,1fr)_400px] lg:items-start lg:gap-10">
+    <div className="p-6 xl:grid xl:grid-cols-[minmax(0,1fr)_400px] xl:items-start xl:gap-10">
       <div className="space-y-8 min-w-0">
         <div className="w-full sm:w-[260px]">
           <Label>Projekt *</Label>
@@ -78,7 +78,7 @@ export function TravelReimbursementFormUI({
         )}
       </div>
 
-      <div className="mt-8 lg:mt-0 lg:sticky lg:top-6">
+      <div className="mt-8 xl:mt-0 xl:sticky xl:top-6">
         <SummarySection
           receipts={form.receipts}
           totalNet={form.totalNet}


### PR DESCRIPTION
## summary

- Stack reimbursement summaries below the forms until the `xl` breakpoint to prevent laptop-width overflow.
- Apply the same responsive and sticky behavior to standard and travel reimbursements.

## validation

- `pnpm exec biome lint app/components/Reimbursements/ReimbursementFormUI.tsx app/components/Reimbursements/TravelReimbursementFormUI.tsx`
- `pnpm exec prettier --check app/components/Reimbursements/ReimbursementFormUI.tsx app/components/Reimbursements/TravelReimbursementFormUI.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `git diff --check`
- `pnpm exec biome check ...` reports the pre-existing Biome formatter preference for tabs; project Prettier formatting passes.
- Tests not run (responsive Tailwind breakpoint-only change).