### PR TITLE
fix(reimbursements): stop saved signature loading spinner

### DIFF
--- a/app/components/Reimbursements/SignatureField.tsx
+++ b/app/components/Reimbursements/SignatureField.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { CheckCircle2, Monitor, Smartphone } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { getFileUrlAction } from "@/lib/server/reimbursements/actions";
-import { Loader2, Monitor, Smartphone } from "lucide-react";
-import { useEffect, useState } from "react";
 import { SignatureCanvas } from "./SignatureCanvas";
 import { SignatureQRPanel } from "./SignatureQRPanel";
 
@@ -64,9 +64,14 @@ function SignaturePreview({ storageId }: { storageId: string }) {
 
   useEffect(() => {
     let active = true;
-    getFileUrlAction(storageId).then((url) => {
-      if (active) setPreviewUrl(url);
-    });
+    setPreviewUrl(null);
+    getFileUrlAction(storageId)
+      .then((url) => {
+        if (active) setPreviewUrl(url);
+      })
+      .catch(() => {
+        if (active) setPreviewUrl(null);
+      });
     return () => {
       active = false;
     };
@@ -78,7 +83,7 @@ function SignaturePreview({ storageId }: { storageId: string }) {
         <img src={previewUrl} alt="Unterschrift" className="max-h-24 mx-auto" />
       ) : (
         <div className="h-24 flex items-center justify-center">
-          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          <CheckCircle2 className="size-8 text-green-600" aria-hidden="true" />
         </div>
       )}
       <p className="text-sm text-muted-foreground text-center mt-2">

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -57,6 +57,7 @@ async function addSignature(page: Page) {
   if (await failed.isVisible()) {
     throw new Error(`Unterschrift fehlgeschlagen: ${await failed.innerText()}`);
   }
+  await expect(saved.locator("..").locator(".animate-spin")).toHaveCount(0);
 }
 
 test.describe.serial("reimbursement flow", () => {


### PR DESCRIPTION
## summary

- Show a completed state immediately after signature upload while loading the optional preview in the background.
- Keep the saved confirmation if preview loading fails and cover the result with an end-to-end assertion.

## validation

- `pnpm exec prettier --check app/components/Reimbursements/SignatureField.tsx e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Reimbursements/SignatureField.tsx e2e/reimbursements.spec.ts` (passes with the pre-existing `noImgElement` warning)
- `pnpm exec tsc --noEmit`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep '1\\. Create expense reimbursement'`\n- `pnpm build` — not run (repo-wide; the targeted browser flow compiles and exercises the change)