### PR TITLE
fix(reimbursements): restore receipt upload dropzone

### DIFF
--- a/app/components/Reimbursements/ReceiptDropzone.tsx
+++ b/app/components/Reimbursements/ReceiptDropzone.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { CirclePlus, Loader2 } from "lucide-react";
+import { type RefObject, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  inputRef: RefObject<HTMLInputElement | null>;
+  isUploading: boolean;
+  onFile: (file: File) => void;
+};
+
+export function ReceiptDropzone({ inputRef, isUploading, onFile }: Props) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  return (
+    <section
+      aria-label="Beleg hochladen"
+      aria-busy={isUploading}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        if (isUploading) return;
+        setIsDragging(true);
+      }}
+      onDragLeave={(event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node)) return;
+        setIsDragging(false);
+      }}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault();
+        setIsDragging(false);
+        if (isUploading) return;
+        const file = event.dataTransfer.files[0];
+        if (file) onFile(file);
+      }}
+      className={cn(
+        "flex w-full flex-col items-center justify-center gap-3 rounded-[8px] border-2 border-dashed border-border px-4 py-6 text-center transition-colors hover:border-ring",
+        isDragging && "border-ring bg-muted/60",
+      )}
+    >
+      {isUploading ? (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <Loader2 className="size-8 animate-spin text-muted-foreground" />
+          <p className="font-medium">Beleg wird verarbeitet...</p>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col items-center gap-2">
+            <CirclePlus className="mb-2 size-12 text-muted-foreground" />
+            <strong className="text-base">
+              Datei hochladen oder hier ablegen
+            </strong>
+            <p className="text-sm text-muted-foreground">
+              JPG, PNG, HEIC oder PDF, bis 10 MB
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="primary"
+            className="mt-1 rounded-[8px]"
+            onClick={() => inputRef.current?.click()}
+          >
+            Datei auswählen
+          </Button>
+        </>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".jpg,.jpeg,.png,.heic,.pdf"
+        disabled={isUploading}
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) onFile(file);
+          event.target.value = "";
+        }}
+        className="hidden"
+      />
+    </section>
+  );
+}

--- a/app/components/Reimbursements/ReceiptUpload.tsx
+++ b/app/components/Reimbursements/ReceiptUpload.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { FileText, Upload } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 import {
   convertToJPG,
   FileConversionError,
@@ -9,9 +12,7 @@ import {
   generateUploadUrl,
   getFileInfoAction,
 } from "@/lib/server/reimbursements/actions";
-import { FileText, Loader2, Upload } from "lucide-react";
-import { useEffect, useId, useState } from "react";
-import toast from "react-hot-toast";
+import { ReceiptDropzone } from "./ReceiptDropzone";
 
 interface Props {
   onUploadComplete: (key: string) => void;
@@ -19,10 +20,10 @@ interface Props {
 }
 
 export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
-  const inputId = useId();
   const [isUploading, setIsUploading] = useState(false);
   const [isPdf, setIsPdf] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!storageId) {
@@ -53,7 +54,6 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
     }
 
     const fileIsPdf = file.type === "application/pdf";
-    setIsPdf(fileIsPdf);
     setIsUploading(true);
     try {
       const convertedFile = await convertToJPG(file);
@@ -65,6 +65,7 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
       });
       if (!result.ok) throw new Error();
 
+      setIsPdf(fileIsPdf);
       onUploadComplete(key);
       toast.success("Beleg hochgeladen");
     } catch (error) {
@@ -80,72 +81,55 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
 
   const fileInput = (
     <input
-      id={inputId}
+      ref={inputRef}
       type="file"
       accept=".jpg,.jpeg,.png,.heic,.pdf"
-      onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
+      onChange={(event) => {
+        const file = event.target.files?.[0];
+        if (file) handleFile(file);
+        event.target.value = "";
+      }}
       className="hidden"
     />
   );
 
   if (previewUrl || isPdf) {
     return (
-      <label
-        htmlFor={inputId}
-        className="block border rounded-lg p-4 relative group cursor-pointer"
-      >
-        {isPdf ? (
-          <div className="flex flex-col items-center gap-2 py-4">
-            <FileText className="size-16 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">PDF hochgeladen</p>
+      <>
+        <button
+          type="button"
+          className="group relative block w-full cursor-pointer border bg-transparent p-4 text-inherit"
+          onClick={() => inputRef.current?.click()}
+        >
+          {isPdf ? (
+            <div className="flex flex-col items-center gap-2 py-4">
+              <FileText className="size-16 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">PDF hochgeladen</p>
+            </div>
+          ) : (
+            <img
+              src={previewUrl ?? ""}
+              alt="Beleg"
+              className="max-h-48 mx-auto rounded"
+            />
+          )}
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+            <div className="text-center text-white">
+              <Upload className="mx-auto mb-2 size-8" />
+              <p className="text-sm font-medium">Klicken zum Ändern</p>
+            </div>
           </div>
-        ) : (
-          <img
-            src={previewUrl ?? ""}
-            alt="Beleg"
-            className="max-h-48 mx-auto rounded"
-          />
-        )}
-        <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-lg flex items-center justify-center">
-          <div className="text-white text-center">
-            <Upload className="size-8 mx-auto mb-2" />
-            <p className="text-sm font-medium">Klicken zum Ändern</p>
-          </div>
-        </div>
+        </button>
         {fileInput}
-      </label>
+      </>
     );
   }
 
   return (
-    <label
-      htmlFor={inputId}
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={(e) => {
-        e.preventDefault();
-        e.dataTransfer.files[0] && handleFile(e.dataTransfer.files[0]);
-      }}
-      className="border-2 border-dashed rounded-lg p-8 text-center hover:border-primary/50 hover:bg-primary/5 transition cursor-pointer"
-    >
-      {isUploading ? (
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="size-8 text-primary animate-spin" />
-          <p className="font-medium">Beleg wird verarbeitet...</p>
-        </div>
-      ) : (
-        <div className="flex flex-col items-center gap-3">
-          <div className="p-4 rounded-full bg-primary/10">
-            <Upload className="size-8 text-primary" />
-          </div>
-          <p className="font-medium">
-            Klicke hier oder ziehe deine Datei herein
-          </p>
-          <p className="text-sm text-muted-foreground">
-            JPG, PNG, HEIC oder PDF (max. 10 MB)
-          </p>
-        </div>
-      )}
-      {fileInput}
-    </label>
+    <ReceiptDropzone
+      inputRef={inputRef}
+      isUploading={isUploading}
+      onFile={handleFile}
+    />
   );
 }

--- a/app/components/Reimbursements/ReceiptUploadExternal.tsx
+++ b/app/components/Reimbursements/ReceiptUploadExternal.tsx
@@ -1,13 +1,14 @@
 "use client";
 
+import { FileText, Upload } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 import {
   convertToJPG,
   FileConversionError,
   isValidFileType,
 } from "@/lib/fileHandlers/fileConversion";
-import { FileText, Loader2, Upload } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import toast from "react-hot-toast";
+import { ReceiptDropzone } from "./ReceiptDropzone";
 
 interface Props {
   onUploadComplete: (key: string) => void;
@@ -41,7 +42,6 @@ export function ReceiptUploadExternal({
     }
 
     const fileIsPdf = file.type === "application/pdf";
-    setIsPdf(fileIsPdf);
     setIsUploading(true);
 
     try {
@@ -55,6 +55,7 @@ export function ReceiptUploadExternal({
 
       if (!result.ok) throw new Error();
 
+      setIsPdf(fileIsPdf);
       onUploadComplete(key);
 
       if (!fileIsPdf) {
@@ -83,71 +84,54 @@ export function ReceiptUploadExternal({
       ref={inputRef}
       type="file"
       accept=".jpg,.jpeg,.png,.heic,.pdf"
-      onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
+      onChange={(event) => {
+        const file = event.target.files?.[0];
+        if (file) handleFile(file);
+        event.target.value = "";
+      }}
       className="hidden"
     />
   );
 
   if (previewUrl || storageId || isPdf) {
     return (
-      <div
-        className="border rounded-lg p-4 relative group cursor-pointer"
-        onClick={() => inputRef.current?.click()}
-      >
-        {previewUrl && !isPdf ? (
-          <img
-            src={previewUrl}
-            alt="Beleg"
-            className="max-h-48 mx-auto rounded"
-          />
-        ) : (
-          <div className="flex flex-col items-center gap-2 py-4">
-            <FileText className="size-16 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
-              {isPdf ? "PDF hochgeladen" : "Beleg hochgeladen"}
-            </p>
+      <>
+        <button
+          type="button"
+          className="group relative block w-full cursor-pointer border bg-transparent p-4 text-inherit"
+          onClick={() => inputRef.current?.click()}
+        >
+          {previewUrl && !isPdf ? (
+            <img
+              src={previewUrl}
+              alt="Beleg"
+              className="max-h-48 mx-auto rounded"
+            />
+          ) : (
+            <div className="flex flex-col items-center gap-2 py-4">
+              <FileText className="size-16 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                {isPdf ? "PDF hochgeladen" : "Beleg hochgeladen"}
+              </p>
+            </div>
+          )}
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+            <div className="text-center text-white">
+              <Upload className="mx-auto mb-2 size-8" />
+              <p className="text-sm font-medium">Klicken zum Ändern</p>
+            </div>
           </div>
-        )}
-        <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-lg flex items-center justify-center">
-          <div className="text-white text-center">
-            <Upload className="size-8 mx-auto mb-2" />
-            <p className="text-sm font-medium">Klicken zum Ändern</p>
-          </div>
-        </div>
+        </button>
         {fileInput}
-      </div>
+      </>
     );
   }
 
   return (
-    <div
-      onClick={() => inputRef.current?.click()}
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={(e) => {
-        e.preventDefault();
-        e.dataTransfer.files[0] && handleFile(e.dataTransfer.files[0]);
-      }}
-      className="border-2 border-dashed rounded-lg p-8 text-center hover:border-primary/50 hover:bg-primary/5 transition cursor-pointer"
-    >
-      {isUploading ? (
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="size-8 text-primary animate-spin" />
-          <p className="font-medium">Beleg wird verarbeitet...</p>
-        </div>
-      ) : (
-        <div className="flex flex-col items-center gap-3">
-          <div className="p-4 rounded-full bg-primary/10">
-            <Upload className="size-8 text-primary" />
-          </div>
-          <p className="font-medium">
-            Klicke hier oder ziehe deine Datei herein
-          </p>
-          <p className="text-sm text-muted-foreground">
-            JPG, PNG, HEIC oder PDF (max. 10 MB)
-          </p>
-        </div>
-      )}
-      {fileInput}
-    </div>
+    <ReceiptDropzone
+      inputRef={inputRef}
+      isUploading={isUploading}
+      onFile={handleFile}
+    />
   );
 }

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -129,6 +129,15 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("textbox", { name: "TT.MM.JJJJ" }).fill("01.01.2025");
     await page.getByPlaceholder("119,95").fill("100");
 
+    const receiptDropzone = page.getByRole("region", {
+      name: "Beleg hochladen",
+    });
+    await expect(receiptDropzone).toHaveCSS("display", "flex");
+    await expect(receiptDropzone).toHaveCSS("border-style", "dashed");
+    await expect(
+      page.getByRole("button", { name: "Datei auswählen" }),
+    ).toBeVisible();
+
     await page.locator('input[type="file"]').setInputFiles(IMAGE_FILE);
     await expect(page.getByText("Beleg hochgeladen")).toBeVisible({
       timeout: 10000,

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -252,7 +252,7 @@ test.describe.serial("reimbursement flow", () => {
       travelRow.getByText("Reisekostenerstattung", { exact: true }),
     ).toBeVisible();
     await expect(
-      travelRow.getByText("Event · Berlin", { exact: true }),
+      travelRow.getByText("Test Projekt", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });


### PR DESCRIPTION
## summary

- replace the fragmented inline receipt uploader with a shared dropzone matching the member platform
- reuse an accessible file picker for internal and public flows, and only mark PDFs uploaded after a successful request
- add dropzone regression coverage and align the stale travel row assertion with the current table UI

## validation

- `pnpm exec prettier --check app/components/Reimbursements/ReceiptDropzone.tsx app/components/Reimbursements/ReceiptUpload.tsx app/components/Reimbursements/ReceiptUploadExternal.tsx e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Reimbursements/ReceiptDropzone.tsx app/components/Reimbursements/ReceiptUpload.tsx app/components/Reimbursements/ReceiptUploadExternal.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `node scripts/check-file-lines.mjs app/components/Reimbursements/ReceiptDropzone.tsx app/components/Reimbursements/ReceiptUpload.tsx app/components/Reimbursements/ReceiptUploadExternal.tsx e2e/reimbursements.spec.ts`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (5 passed)
