### PR TITLE
fix(reimbursements): prevent fragmented dropzone borders

### DIFF
--- a/app/components/Reimbursements/ReceiptDropzone.tsx
+++ b/app/components/Reimbursements/ReceiptDropzone.tsx
@@ -36,10 +36,19 @@ export function ReceiptDropzone({ inputRef, isUploading, onFile }: Props) {
         if (file) onFile(file);
       }}
       className={cn(
-        "flex w-full flex-col items-center justify-center gap-3 rounded-[8px] border-2 border-dashed border-border px-4 py-6 text-center transition-colors hover:border-ring",
-        isDragging && "border-ring bg-muted/60",
+        "group relative flex w-full flex-col items-center justify-center gap-3 rounded-[8px] px-4 py-6 text-center transition-colors",
+        isDragging && "bg-muted/60",
       )}
     >
+      <div
+        aria-hidden="true"
+        data-slot="receipt-dropzone-border"
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-[8px] border-2 border-dashed border-border transition-colors group-hover:border-ring",
+          isDragging && "border-ring",
+        )}
+      />
+
       {isUploading ? (
         <div className="flex flex-col items-center gap-3 py-2">
           <Loader2 className="size-8 animate-spin text-muted-foreground" />

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -134,7 +134,17 @@ test.describe.serial("reimbursement flow", () => {
       name: "Beleg hochladen",
     });
     await expect(receiptDropzone).toHaveCSS("display", "flex");
-    await expect(receiptDropzone).toHaveCSS("border-style", "dashed");
+    const receiptDropzoneBorder = receiptDropzone.locator(
+      '[data-slot="receipt-dropzone-border"]',
+    );
+    await expect(receiptDropzoneBorder).toHaveCSS("position", "absolute");
+    await expect(receiptDropzoneBorder).toHaveCSS("border-style", "dashed");
+    await expect(receiptDropzoneBorder).toHaveCSS("inset", "0px");
+    await expect(receiptDropzoneBorder).toHaveCount(1);
+    await expect(receiptDropzoneBorder).toBeVisible();
+    expect(await receiptDropzoneBorder.boundingBox()).toEqual(
+      await receiptDropzone.boundingBox(),
+    );
     await expect(
       page.getByRole("button", { name: "Datei auswählen" }),
     ).toBeVisible();


### PR DESCRIPTION
## summary

- Render the dashed receipt dropzone frame as one absolutely positioned border box.
- Match the Member Platform styling with an 8px dropzone radius and a square upload button.
- Add E2E regression coverage for the frame bounds, corner radii, and JPG upload.

## validation

- pnpm exec prettier --check app/components/Reimbursements/ReceiptDropzone.tsx e2e/reimbursements.spec.ts
- pnpm exec biome lint app/components/Reimbursements/ReceiptDropzone.tsx e2e/reimbursements.spec.ts
- pnpm exec playwright test e2e/reimbursements.spec.ts --grep "Create expense reimbursement with JPG receipt"
- pnpm build: not run (repo-wide; the targeted browser test compiled the affected route)