### PR TITLE
fix(reimbursements): prevent fragmented dropzone borders

### DIFF
--- a/app/components/Reimbursements/ReceiptDropzone.tsx
+++ b/app/components/Reimbursements/ReceiptDropzone.tsx
@@ -68,7 +68,7 @@ export function ReceiptDropzone({ inputRef, isUploading, onFile }: Props) {
           <Button
             type="button"
             variant="primary"
-            className="mt-1 rounded-[8px]"
+            className="mt-1 rounded-none"
             onClick={() => inputRef.current?.click()}
           >
             Datei auswählen

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -139,15 +139,18 @@ test.describe.serial("reimbursement flow", () => {
     );
     await expect(receiptDropzoneBorder).toHaveCSS("position", "absolute");
     await expect(receiptDropzoneBorder).toHaveCSS("border-style", "dashed");
+    await expect(receiptDropzoneBorder).toHaveCSS("border-radius", "8px");
     await expect(receiptDropzoneBorder).toHaveCSS("inset", "0px");
     await expect(receiptDropzoneBorder).toHaveCount(1);
     await expect(receiptDropzoneBorder).toBeVisible();
     expect(await receiptDropzoneBorder.boundingBox()).toEqual(
       await receiptDropzone.boundingBox(),
     );
-    await expect(
-      page.getByRole("button", { name: "Datei auswählen" }),
-    ).toBeVisible();
+    const selectReceiptButton = page.getByRole("button", {
+      name: "Datei auswählen",
+    });
+    await expect(selectReceiptButton).toBeVisible();
+    await expect(selectReceiptButton).toHaveCSS("border-radius", "0px");
 
     await page.locator('input[type="file"]').setInputFiles(IMAGE_FILE);
     await expect(page.getByText("Beleg hochgeladen")).toBeVisible({


### PR DESCRIPTION
## summary

- Render the dashed receipt dropzone frame as one absolutely positioned border box.
- Match the Member Platform styling with an 8px dropzone radius and a square upload button.
- Add E2E regression coverage for the frame bounds, corner radii, and JPG upload.

## validation

- pnpm exec prettier --check app/components/Reimbursements/ReceiptDropzone.tsx e2e/reimbursements.spec.ts
- pnpm exec biome lint app/components/Reimbursements/ReceiptDropzone.tsx e2e/reimbursements.spec.ts
- pnpm exec playwright test e2e/reimbursements.spec.ts --grep "Create expense reimbursement with JPG receipt"
- pnpm build: not run (repo-wide; the targeted browser test compiled the affected route)