### PR TITLE
feat(reimbursements): open individual pdfs in new tabs

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementPageUI.tsx
+++ b/app/(protected)/reimbursements/ReimbursementPageUI.tsx
@@ -38,8 +38,8 @@ interface Props {
   onRejectDialogChange: (dialog: RejectDialog) => void;
   onReject: () => void;
   isRejecting: boolean;
-  onDownloadReimbursement: (id: string) => void;
-  onDownloadAllowance: (allowance: Allowance) => void;
+  onOpenReimbursement: (id: string) => void;
+  onOpenAllowance: (allowance: Allowance) => void;
   onDeleteReimbursement: (id: string) => void;
   onDeleteAllowance: (id: string) => void;
   onToggleSelect: (key: SelectionKey) => void;
@@ -67,8 +67,8 @@ export function ReimbursementPageUI({
   onRejectDialogChange,
   onReject,
   isRejecting,
-  onDownloadReimbursement,
-  onDownloadAllowance,
+  onOpenReimbursement,
+  onOpenAllowance,
   onDeleteReimbursement,
   onDeleteAllowance,
   onToggleSelect,
@@ -147,8 +147,8 @@ export function ReimbursementPageUI({
         onApproveReimbursement={onApproveReimbursement}
         onApproveAllowance={onApproveAllowance}
         onOpenRejectDialog={onOpenRejectDialog}
-        onDownloadReimbursement={onDownloadReimbursement}
-        onDownloadAllowance={onDownloadAllowance}
+        onOpenReimbursement={onOpenReimbursement}
+        onOpenAllowance={onOpenAllowance}
         onDeleteReimbursement={onDeleteReimbursement}
         onDeleteAllowance={onDeleteAllowance}
         onToggleSelect={onToggleSelect}

--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -20,8 +20,8 @@ type Props = {
   onApproveReimbursement: (id: string) => void;
   onApproveAllowance: (id: string) => void;
   onOpenRejectDialog: (type: "reimbursement" | "allowance", id: string) => void;
-  onDownloadReimbursement: (id: string) => void;
-  onDownloadAllowance: (allowance: Allowance) => void;
+  onOpenReimbursement: (id: string) => void;
+  onOpenAllowance: (allowance: Allowance) => void;
   onDeleteReimbursement: (id: string) => void;
   onDeleteAllowance: (id: string) => void;
   onToggleSelect: (key: SelectionKey) => void;
@@ -37,8 +37,8 @@ export function ReimbursementTable({
   onApproveReimbursement,
   onApproveAllowance,
   onOpenRejectDialog,
-  onDownloadReimbursement,
-  onDownloadAllowance,
+  onOpenReimbursement,
+  onOpenAllowance,
   onDeleteReimbursement,
   onDeleteAllowance,
   onToggleSelect,
@@ -115,7 +115,7 @@ export function ReimbursementTable({
               onClick={() => onRowClick(item._id)}
               onApprove={() => onApproveReimbursement(item._id)}
               onReject={() => onOpenRejectDialog("reimbursement", item._id)}
-              onDownload={() => onDownloadReimbursement(item._id)}
+              onOpen={() => onOpenReimbursement(item._id)}
               onDelete={() => onDeleteReimbursement(item._id)}
             />
           ))}
@@ -138,7 +138,7 @@ export function ReimbursementTable({
               applicantName={item.volunteerName || item.creatorName}
               onApprove={() => onApproveAllowance(item._id)}
               onReject={() => onOpenRejectDialog("allowance", item._id)}
-              onDownload={() => onDownloadAllowance(item)}
+              onOpen={() => onOpenAllowance(item)}
               onDelete={() => onDeleteAllowance(item._id)}
             />
           ))}

--- a/app/(protected)/reimbursements/ReimbursementsClient.tsx
+++ b/app/(protected)/reimbursements/ReimbursementsClient.tsx
@@ -49,8 +49,8 @@ export function ReimbursementsClient({
   );
   const {
     isBulkDownloading,
-    handleDownloadReimbursement,
-    handleDownloadAllowance,
+    handleOpenReimbursement,
+    handleOpenAllowance,
     handleBulkDownload,
   } = usePdfDownloads({
     allowances,
@@ -101,8 +101,8 @@ export function ReimbursementsClient({
         onRejectDialogChange={actions.setRejectDialog}
         onReject={actions.handleReject}
         isRejecting={actions.isRejecting}
-        onDownloadReimbursement={handleDownloadReimbursement}
-        onDownloadAllowance={handleDownloadAllowance}
+        onOpenReimbursement={handleOpenReimbursement}
+        onOpenAllowance={handleOpenAllowance}
         onDeleteReimbursement={actions.handleDeleteReimbursement}
         onDeleteAllowance={actions.handleDeleteAllowance}
         onToggleSelect={handleToggleSelect}

--- a/app/(protected)/reimbursements/usePdfDownloads.ts
+++ b/app/(protected)/reimbursements/usePdfDownloads.ts
@@ -51,34 +51,38 @@ export function usePdfDownloads({
     );
   };
 
-  const handleDownloadReimbursement = async (id: string) => {
+  const openPdfInNewTab = async (createPdf: () => Promise<Blob | null>) => {
+    const pdfWindow = window.open("about:blank", "_blank");
+
+    if (!pdfWindow) {
+      toast.error("Neuer Tab konnte nicht geöffnet werden");
+      return;
+    }
+
+    pdfWindow.opener = null;
+
     try {
-      const blob = await getPdfBlobForReimbursement(id);
+      const blob = await createPdf();
       if (!blob) {
+        pdfWindow.close();
         toast.error("PDF konnte nicht erstellt werden");
         return;
       }
-      downloadBlob(blob, `Erstattung_${shortReferenceId(id)}.pdf`);
+
+      const url = URL.createObjectURL(blob);
+      pdfWindow.location.replace(url);
+      window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
     } catch {
-      toast.error("Fehler beim Herunterladen");
+      pdfWindow.close();
+      toast.error("Fehler beim Öffnen der PDF");
     }
   };
 
-  const handleDownloadAllowance = async (allowance: Allowance) => {
-    try {
-      const blob = await getPdfBlobForAllowance(allowance);
-      if (!blob) {
-        toast.error("PDF konnte nicht erstellt werden");
-        return;
-      }
-      downloadBlob(
-        blob,
-        `Ehrenamtspauschale_${shortReferenceId(allowance._id)}.pdf`,
-      );
-    } catch {
-      toast.error("Fehler beim Herunterladen");
-    }
-  };
+  const handleOpenReimbursement = (id: string) =>
+    openPdfInNewTab(() => getPdfBlobForReimbursement(id));
+
+  const handleOpenAllowance = (allowance: Allowance) =>
+    openPdfInNewTab(() => getPdfBlobForAllowance(allowance));
 
   const handleBulkDownload = async () => {
     if (selected.size === 0) return;
@@ -118,8 +122,8 @@ export function usePdfDownloads({
 
   return {
     isBulkDownloading,
-    handleDownloadReimbursement,
-    handleDownloadAllowance,
+    handleOpenReimbursement,
+    handleOpenAllowance,
     handleBulkDownload,
   };
 }

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Download, Trash2, X } from "lucide-react";
+import { Check, ExternalLink, Trash2, X } from "lucide-react";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -31,7 +31,7 @@ interface ReimbursementRowProps {
   onClick?: () => void;
   onApprove: () => void;
   onReject: () => void;
-  onDownload: () => void;
+  onOpen: () => void;
   onDelete: () => void;
 }
 
@@ -45,7 +45,7 @@ export function ReimbursementRow({
   onClick,
   onApprove,
   onReject,
-  onDownload,
+  onOpen,
   onDelete,
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
@@ -135,13 +135,14 @@ export function ReimbursementRow({
           ) : null}
           <Button
             variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={onDownload}
-            aria-label="PDF herunterladen"
-            title="PDF herunterladen"
+            size="sm"
+            className="h-7 px-2"
+            onClick={onOpen}
+            aria-label="PDF in neuem Tab öffnen"
+            title="PDF in neuem Tab öffnen"
           >
-            <Download className="h-4 w-4" />
+            <ExternalLink className="h-4 w-4" />
+            Öffnen
           </Button>
           {canManageReimbursements && isPending ? (
             <Button


### PR DESCRIPTION
## summary

- replace per-row PDF download icons with labeled open actions for reimbursements and allowances
- open generated PDFs in a new tab while preserving bulk ZIP downloads and handling blocked tabs or generation errors

## validation

- `git diff --check`
- `pnpm exec biome check --formatter-enabled=false --assist-enabled=false <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- e2e not run (no targeted coverage for generated PDF tab behavior)