### PR TITLE
feat(reimbursements): align pdf fields with submitted data

### DIFF
--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -41,13 +41,23 @@ export function TravelReceiptCard(props: Props) {
         </Button>
       </div>
 
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <Label>Name/Firma *</Label>
           <Input
             value={receipt.companyName}
             onChange={(e) => props.onUpdate({ companyName: e.target.value })}
             placeholder="z.B. Deutsche Bahn"
+          />
+        </div>
+        <div>
+          <Label>Beleg-Nr.</Label>
+          <Input
+            value={receipt.receiptNumber ?? ""}
+            onChange={(e) =>
+              props.onUpdate({ receiptNumber: e.target.value || undefined })
+            }
+            placeholder="z.B. RE-2026-001 (optional)"
           />
         </div>
 
@@ -107,7 +117,7 @@ export function TravelReceiptCard(props: Props) {
               <Select
                 value={String(receipt.taxRate)}
                 onValueChange={(value) => {
-                  const tax = parseInt(value);
+                  const tax = parseInt(value, 10);
                   props.onUpdate({
                     taxRate: tax,
                     netAmount: props.toNet(receipt.grossAmount, tax),

--- a/app/(public)/erstattung/[id]/_components/useReceipts.ts
+++ b/app/(public)/erstattung/[id]/_components/useReceipts.ts
@@ -68,7 +68,7 @@ export function useReceipts(startDate: string) {
       ...travelReceipts,
       {
         costType,
-        receiptNumber: `${costType.toUpperCase()}-001`,
+        receiptNumber: undefined,
         receiptDate: startDate,
         companyName: "",
         description: "",

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -48,7 +48,7 @@ export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
         </Button>
       </div>
 
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <Label>Firma/Anbieter *</Label>
           <Input
@@ -59,6 +59,18 @@ export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
               })
             }
             placeholder={PLACEHOLDERS[receipt.costType]}
+          />
+        </div>
+        <div>
+          <Label>Beleg-Nr.</Label>
+          <Input
+            value={receipt.receiptNumber ?? ""}
+            onChange={(e) =>
+              updateReceipt(receipt.costType, {
+                receiptNumber: e.target.value || undefined,
+              })
+            }
+            placeholder="z.B. RE-2026-001 (optional)"
           />
         </div>
         {receipt.costType === "car" ? (
@@ -118,7 +130,7 @@ export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
               <Select
                 value={String(receipt.taxRate)}
                 onValueChange={(value) => {
-                  const tax = parseInt(value);
+                  const tax = parseInt(value, 10);
                   updateReceipt(receipt.costType, {
                     taxRate: tax,
                     netAmount: toNet(receipt.grossAmount, tax),

--- a/app/components/Reimbursements/travelForm/useTravelForm.ts
+++ b/app/components/Reimbursements/travelForm/useTravelForm.ts
@@ -44,7 +44,7 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
       ...receipts,
       {
         costType: type,
-        receiptNumber: `${type.toUpperCase()}-001`,
+        receiptNumber: undefined,
         receiptDate: travel.startDate,
         companyName: "",
         description: "",

--- a/app/lib/fileHandlers/reimbursementPdf/formPage.ts
+++ b/app/lib/fileHandlers/reimbursementPdf/formPage.ts
@@ -108,7 +108,6 @@ function drawBankColumn(
     ["Kontoinhaber:", data.accountHolder],
     ["IBAN:", data.iban],
     ["BIC:", data.bic ?? ""],
-    ["Bankname:", ""],
   ];
   let y = top - 96;
   for (const [label, value] of rows) {

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -233,6 +233,9 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("button", { name: "PKW" }).click();
 
     await page.getByPlaceholder("Eigenfahrt, Miles, Sixt, etc.").fill("Miles");
+    await page
+      .getByPlaceholder("z.B. RE-2026-001 (optional)")
+      .fill("RK-2026-001");
     await page.getByRole("spinbutton").first().fill("500");
 
     await page.locator('input[type="file"]').setInputFiles(PDF_FILE);


### PR DESCRIPTION
## summary

- allow travel reimbursement submitters to provide optional receipt numbers in authenticated and shared forms
- replace synthetic cost-type receipt numbers while preserving the PDF fallback to sequential numbering
- remove the unused blank bank name row from reimbursement PDFs

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts`