### PR TITLE
style(settings): remove redundant page descriptions

### DIFF
--- a/app/(protected)/settings/projects/ProjectsClient.tsx
+++ b/app/(protected)/settings/projects/ProjectsClient.tsx
@@ -98,11 +98,7 @@ export function ProjectsClient() {
       <PageHeader title="Projekte" />
 
       <div className="space-y-6">
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-muted-foreground">
-            Projekte (z.B. Events oder Aktionen), denen Erstattungen zugeordnet
-            werden.
-          </p>
+        <div className="flex justify-end">
           <Button
             variant="ghost"
             size="sm"

--- a/app/(protected)/settings/users/UsersClient.tsx
+++ b/app/(protected)/settings/users/UsersClient.tsx
@@ -54,49 +54,43 @@ export function UsersClient({ users }: Props) {
     <div>
       <PageHeader title="Benutzer" />
 
-      <div className="space-y-6">
-        <p className="text-muted-foreground">
-          Hier kannst du Benutzer und deren Rollen verwalten.
-        </p>
-
-        {users.length === 0 ? (
-          <div className="text-center py-12 border rounded-lg">
-            <Users className="mx-auto h-12 w-12 text-muted-foreground" />
-            <h3 className="mt-4 text-lg font-semibold">
-              Keine Benutzer gefunden
-            </h3>
-            <p className="text-muted-foreground mt-2">
-              Noch keine Benutzer in deiner Organisation.
-            </p>
-          </div>
-        ) : (
-          <div className="rounded-md border overflow-hidden">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="pr-6">Benutzer</TableHead>
-                  <TableHead>E-Mail</TableHead>
-                  <TableHead className="pr-6">Rolle</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {users.map((user) => (
-                  <UserRow
-                    key={user._id}
-                    user={{
-                      ...user,
-                      role: user.role || "member",
-                    }}
-                    onRoleChange={handleRoleChange}
-                    isAdmin={isAdmin}
-                    isUpdating={updatingId === user._id}
-                  />
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </div>
+      {users.length === 0 ? (
+        <div className="text-center py-12 border rounded-lg">
+          <Users className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h3 className="mt-4 text-lg font-semibold">
+            Keine Benutzer gefunden
+          </h3>
+          <p className="text-muted-foreground mt-2">
+            Noch keine Benutzer in deiner Organisation.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="pr-6">Benutzer</TableHead>
+                <TableHead>E-Mail</TableHead>
+                <TableHead className="pr-6">Rolle</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((user) => (
+                <UserRow
+                  key={user._id}
+                  user={{
+                    ...user,
+                    role: user.role || "member",
+                  }}
+                  onRoleChange={handleRoleChange}
+                  isAdmin={isAdmin}
+                  isUpdating={updatingId === user._id}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## summary

- Remove redundant introductory copy from the projects and users settings pages.
- Keep the projects archive action right-aligned after removing its neighboring text.
- Simplify the users page markup by removing the now-unused layout wrapper.

## validation

- pnpm exec prettier --check (changed files)
- pnpm exec biome lint (changed files)
- pnpm exec tsc --noEmit
- pnpm lint:lines
- git diff --check
- not run (automated tests; copy-only UI change)