### PR TITLE
feat(reimbursements): show organization invoice guidance

### DIFF
--- a/app/(protected)/reimbursements/new/NewReimbursementUI.tsx
+++ b/app/(protected)/reimbursements/new/NewReimbursementUI.tsx
@@ -14,9 +14,14 @@ type BankDetails = { iban: string; bic: string; accountHolder: string };
 interface Props {
   defaultBankDetails: BankDetails;
   projects: Project[];
+  organizationName: string;
 }
 
-export function NewReimbursementUI({ defaultBankDetails, projects }: Props) {
+export function NewReimbursementUI({
+  defaultBankDetails,
+  projects,
+  organizationName,
+}: Props) {
   const [type, setType] = useState<ReimbursementType>("travel");
 
   return (
@@ -40,12 +45,14 @@ export function NewReimbursementUI({ defaultBankDetails, projects }: Props) {
         <TravelReimbursementFormUI
           defaultBankDetails={defaultBankDetails}
           projects={projects}
+          organizationName={organizationName}
         />
       )}
       {type === "expense" && (
         <ReimbursementFormUI
           defaultBankDetails={defaultBankDetails}
           projects={projects}
+          organizationName={organizationName}
         />
       )}
       {type === "volunteerAllowance" && (

--- a/app/(protected)/reimbursements/new/page.tsx
+++ b/app/(protected)/reimbursements/new/page.tsx
@@ -1,17 +1,20 @@
 import { getAllProjects } from "@/lib/server/projects/data";
+import { getOrganization } from "@/lib/server/organizations/data";
 import { getUserBankDetails } from "@/lib/server/reimbursements/data";
 import { NewReimbursementUI } from "./NewReimbursementUI";
 
 export default async function ReimbursementFormPage() {
-  const [defaultBankDetails, projects] = await Promise.all([
+  const [defaultBankDetails, projects, organization] = await Promise.all([
     getUserBankDetails(),
     getAllProjects(),
+    getOrganization(),
   ]);
 
   return (
     <NewReimbursementUI
       defaultBankDetails={defaultBankDetails}
       projects={projects}
+      organizationName={organization.name}
     />
   );
 }

--- a/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
+++ b/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
@@ -47,6 +47,7 @@ export default function ExternalReimbursementPageUI(
             />
 
             <TravelCostsSection
+              organizationName={props.organizationName}
               travelReceipts={props.travelReceipts}
               costLabels={props.costLabels}
               onToggleCostType={props.onToggleCostType}
@@ -70,6 +71,7 @@ export default function ExternalReimbursementPageUI(
           </>
         ) : (
           <SimpleReceiptsSection
+            organizationName={props.organizationName}
             company={props.company}
             number={props.number}
             description={props.description}

--- a/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReceiptUploadExternal } from "@/components/Reimbursements/ReceiptUploadExternal";
+import { InvoiceOrganizationHint } from "@/components/Reimbursements/InvoiceOrganizationHint";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,6 +17,7 @@ import { AddedReceiptsList } from "./AddedReceiptsList";
 import type { Receipt } from "./types";
 
 type Props = {
+  organizationName: string;
   company: string;
   number: string;
   description: string;
@@ -47,6 +49,7 @@ export function SimpleReceiptsSection(props: Props) {
       <p className="text-sm text-muted-foreground">
         Füge alle Belege hinzu, die du einreichen möchtest.
       </p>
+      <InvoiceOrganizationHint organizationName={props.organizationName} />
       <div className="border rounded-lg p-4 space-y-4">
         <div className="grid grid-cols-2 gap-4">
           <div>
@@ -104,7 +107,9 @@ export function SimpleReceiptsSection(props: Props) {
             <Label>USt.-Satz</Label>
             <Select
               value={String(props.taxRate)}
-              onValueChange={(value) => props.onTaxRateChange(parseInt(value))}
+              onValueChange={(value) =>
+                props.onTaxRateChange(parseInt(value, 10))
+              }
             >
               <SelectTrigger>
                 <SelectValue />

--- a/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { InvoiceOrganizationHint } from "@/components/Reimbursements/InvoiceOrganizationHint";
 import { TravelReceiptCard } from "./TravelReceiptCard";
 import type { CostType, TravelReceipt } from "./types";
 
 type Props = {
+  organizationName: string;
   travelReceipts: TravelReceipt[];
   costLabels: Record<CostType, string>;
   onToggleCostType: (costType: CostType) => void;
@@ -26,6 +28,7 @@ export function TravelCostsSection(props: Props) {
       <p className="text-sm text-muted-foreground">
         Wähle alle Kostenarten aus, für die du Belege einreichen möchtest.
       </p>
+      <InvoiceOrganizationHint organizationName={props.organizationName} />
 
       <div className="flex flex-wrap gap-2">
         {(Object.keys(props.costLabels) as CostType[]).map((costType) => (

--- a/app/components/Reimbursements/InvoiceOrganizationHint.tsx
+++ b/app/components/Reimbursements/InvoiceOrganizationHint.tsx
@@ -1,0 +1,22 @@
+import { Info } from "lucide-react";
+
+interface Props {
+  organizationName: string;
+}
+
+export function InvoiceOrganizationHint({ organizationName }: Props) {
+  if (!organizationName.trim()) return null;
+
+  return (
+    <div
+      role="note"
+      className="flex gap-2 rounded-lg border bg-muted/50 p-3 text-sm"
+    >
+      <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <p>
+        Falls möglich, gib bei Rechnungen im Feld „Unternehmen/Institution“{" "}
+        <span className="font-medium">{organizationName}</span> an.
+      </p>
+    </div>
+  );
+}

--- a/app/components/Reimbursements/ReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/ReimbursementFormUI.tsx
@@ -9,7 +9,11 @@ import { ReimbursementSummary } from "./reimbursementForm/ReimbursementSummary";
 import type { Props } from "./reimbursementForm/types";
 import { useReimbursementForm } from "./reimbursementForm/useReimbursementForm";
 
-export function ReimbursementFormUI({ defaultBankDetails, projects }: Props) {
+export function ReimbursementFormUI({
+  defaultBankDetails,
+  projects,
+  organizationName,
+}: Props) {
   const form = useReimbursementForm(defaultBankDetails);
   const currencySymbol = CURRENCY_SYMBOLS[form.currency] || form.currency;
   const hasReceipts = form.receipts.length > 0;
@@ -30,6 +34,7 @@ export function ReimbursementFormUI({ defaultBankDetails, projects }: Props) {
           setDraft={form.setDraft}
           currencySymbol={currencySymbol}
           receiptCount={form.receipts.length}
+          organizationName={organizationName}
           onAddReceipt={form.addReceipt}
         />
 

--- a/app/components/Reimbursements/TravelReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/TravelReimbursementFormUI.tsx
@@ -14,11 +14,13 @@ import { useTravelForm } from "./travelForm/useTravelForm";
 interface Props {
   defaultBankDetails: BankDetails;
   projects: Project[];
+  organizationName: string;
 }
 
 export function TravelReimbursementFormUI({
   defaultBankDetails,
   projects,
+  organizationName,
 }: Props) {
   const form = useTravelForm(defaultBankDetails);
 
@@ -61,6 +63,7 @@ export function TravelReimbursementFormUI({
             showMealAllowance={form.showMealAllowance}
             setShowMealAllowance={form.setShowMealAllowance}
             mealTotal={form.mealTotal}
+            organizationName={organizationName}
           />
         )}
 

--- a/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toNet } from "@/lib/bank-utils";
 import { formatAmount } from "@/lib/formatters/formatCurrency";
 import { Plus } from "lucide-react";
+import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { ReceiptUpload } from "../ReceiptUpload";
 import type { Draft } from "./types";
 
@@ -23,6 +24,7 @@ interface Props {
   setDraft: (draft: Draft) => void;
   currencySymbol: string;
   receiptCount: number;
+  organizationName: string;
   onAddReceipt: () => void;
 }
 
@@ -31,6 +33,7 @@ export function ReceiptDraftFields({
   setDraft,
   currencySymbol,
   receiptCount,
+  organizationName,
   onAddReceipt,
 }: Props) {
   const net = draft.gross ? toNet(draft.gross, draft.tax) : 0;
@@ -42,6 +45,7 @@ export function ReceiptDraftFields({
         Du kannst mehrere Belege hinzufügen, um sie in einer Erstattung
         einzureichen.
       </p>
+      <InvoiceOrganizationHint organizationName={organizationName} />
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Label>Name/Firma *</Label>
@@ -101,7 +105,7 @@ export function ReceiptDraftFields({
           <Select
             value={String(draft.tax)}
             onValueChange={(value) =>
-              setDraft({ ...draft, tax: parseInt(value) })
+              setDraft({ ...draft, tax: parseInt(value, 10) })
             }
           >
             <SelectTrigger>

--- a/app/components/Reimbursements/reimbursementForm/types.ts
+++ b/app/components/Reimbursements/reimbursementForm/types.ts
@@ -20,4 +20,5 @@ export type Draft = {
 export interface Props {
   defaultBankDetails: BankDetails;
   projects: Project[];
+  organizationName: string;
 }

--- a/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
@@ -6,6 +6,7 @@ import {
   type CostType,
   COST_LABELS as LABELS,
 } from "@/lib/travel-costs";
+import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { MealAllowanceSection } from "./MealAllowanceSection";
 import { ReceiptCard } from "./ReceiptCard";
 import type { Receipt, Travel } from "./types";
@@ -20,6 +21,7 @@ interface Props {
   showMealAllowance: boolean;
   setShowMealAllowance: (value: boolean) => void;
   mealTotal: number;
+  organizationName: string;
 }
 
 export function ReceiptsSection({
@@ -32,6 +34,7 @@ export function ReceiptsSection({
   showMealAllowance,
   setShowMealAllowance,
   mealTotal,
+  organizationName,
 }: Props) {
   return (
     <div className="space-y-6">
@@ -40,6 +43,7 @@ export function ReceiptsSection({
         <p className="text-sm text-muted-foreground mb-2">
           Wähle alle Kostenarten aus, für die du Belege einreichen möchtest.
         </p>
+        <InvoiceOrganizationHint organizationName={organizationName} />
         <div className="flex flex-wrap gap-2">
           {COST_TYPES.map((type) => (
             <Button

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -103,6 +103,9 @@ test.describe.serial("reimbursement flow", () => {
       page.getByRole("tab", { name: "Reisekostenerstattung" }),
     ).toHaveAttribute("data-state", "active");
     await page.getByRole("tab", { name: "Auslagenerstattung" }).click();
+    await expect(page.getByRole("note")).toContainText(
+      "Falls möglich, gib bei Rechnungen im Feld „Unternehmen/Institution“ Test Verein an.",
+    );
 
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Neues Projekt erstellen" }).click();


### PR DESCRIPTION
## summary

- show the current organization name in invoice guidance across internal and public expense and travel reimbursement forms
- centralize the accessible hint component and verify its dynamic content in the reimbursement flow

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run` (65 passed)
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (5 passed on one complete run; a repeat reached the unchanged signature-canvas flake after the new assertion passed)
