### PR TITLE
feat(reimbursements): show reviewer in dedicated column

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -84,6 +84,7 @@ export function ReimbursementTable({
             <TableHead>Erstellt</TableHead>
             <TableHead className="text-right">Betrag</TableHead>
             <TableHead>Status</TableHead>
+            <TableHead>Bearbeitet von</TableHead>
             <TableHead className="text-right" />
           </TableRow>
         </TableHeader>

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -49,8 +49,6 @@ export function ReimbursementRow({
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
   const isPending = item.status === "pending";
-  const reviewerName =
-    item.status === "approved" ? item.reviewedByName : undefined;
 
   return (
     <TableRow
@@ -87,11 +85,6 @@ export function ReimbursementRow({
           <Badge variant={display.variant} className={display.className}>
             {display.label}
           </Badge>
-          {reviewerName ? (
-            <span className="text-xs text-muted-foreground">
-              {reviewerName}
-            </span>
-          ) : null}
           {item.rejectionNote ? (
             <span
               className="max-w-56 truncate text-xs text-red-700"
@@ -101,6 +94,9 @@ export function ReimbursementRow({
             </span>
           ) : null}
         </div>
+      </TableCell>
+      <TableCell className="max-w-48 truncate text-muted-foreground">
+        {item.reviewedByName ?? "–"}
       </TableCell>
       <TableCell onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-end gap-0.5">


### PR DESCRIPTION
## summary

- moves the reviewer name from the status details into a dedicated "Bearbeitet von" column
- shows reviewers for both approved and rejected reimbursements and allowances

## validation

- `pnpm exec prettier --check app/components/Tables/Reimbursements/ReimbursementRow.tsx app/\(protected\)/reimbursements/ReimbursementTable.tsx`
- `pnpm exec biome lint app/components/Tables/Reimbursements/ReimbursementRow.tsx app/\(protected\)/reimbursements/ReimbursementTable.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (fails reproducibly in the unrelated signature helper with "Bitte unterschreiben"; 2 passed and 2 did not run)