### PR TITLE
fix(reimbursements): place invoice hint beside receipt uploads

### DIFF
--- a/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
@@ -49,7 +49,6 @@ export function SimpleReceiptsSection(props: Props) {
       <p className="text-sm text-muted-foreground">
         Füge alle Belege hinzu, die du einreichen möchtest.
       </p>
-      <InvoiceOrganizationHint organizationName={props.organizationName} />
       <div className="border rounded-lg p-4 space-y-4">
         <div className="grid grid-cols-2 gap-4">
           <div>
@@ -135,8 +134,9 @@ export function SimpleReceiptsSection(props: Props) {
           </div>
         </div>
 
-        <div>
+        <div className="space-y-3">
           <Label>Beleg hochladen *</Label>
+          <InvoiceOrganizationHint organizationName={props.organizationName} />
           <ReceiptUploadExternal
             onUploadComplete={props.onFileChange}
             storageId={props.file || undefined}

--- a/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { InvoiceOrganizationHint } from "@/components/Reimbursements/InvoiceOrganizationHint";
 import { TravelReceiptCard } from "./TravelReceiptCard";
 import type { CostType, TravelReceipt } from "./types";
 
@@ -28,8 +27,6 @@ export function TravelCostsSection(props: Props) {
       <p className="text-sm text-muted-foreground">
         Wähle alle Kostenarten aus, für die du Belege einreichen möchtest.
       </p>
-      <InvoiceOrganizationHint organizationName={props.organizationName} />
-
       <div className="flex flex-wrap gap-2">
         {(Object.keys(props.costLabels) as CostType[]).map((costType) => (
           <Button
@@ -61,6 +58,7 @@ export function TravelCostsSection(props: Props) {
           toNet={props.toNet}
           generateUploadUrl={props.generateUploadUrl}
           getFileUrl={props.getFileUrl}
+          organizationName={props.organizationName}
         />
       ))}
     </div>

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReceiptUploadExternal } from "@/components/Reimbursements/ReceiptUploadExternal";
+import { InvoiceOrganizationHint } from "@/components/Reimbursements/InvoiceOrganizationHint";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,6 +25,7 @@ type Props = {
     contentType: string,
   ) => Promise<{ key: string; url: string }>;
   getFileUrl: (key: string) => Promise<string | null>;
+  organizationName: string;
 };
 
 export function TravelReceiptCard(props: Props) {
@@ -141,6 +143,7 @@ export function TravelReceiptCard(props: Props) {
       {receipt.grossAmount > 0 && (
         <div className="space-y-3">
           <Label>Beleg *</Label>
+          <InvoiceOrganizationHint organizationName={props.organizationName} />
           <ReceiptUploadExternal
             onUploadComplete={(storageId) =>
               props.onUpdate({ fileStorageId: storageId })

--- a/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
@@ -45,7 +45,6 @@ export function ReceiptDraftFields({
         Du kannst mehrere Belege hinzufügen, um sie in einer Erstattung
         einzureichen.
       </p>
-      <InvoiceOrganizationHint organizationName={organizationName} />
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Label>Name/Firma *</Label>
@@ -130,8 +129,9 @@ export function ReceiptDraftFields({
         </div>
       </div>
 
-      <div>
+      <div className="space-y-3">
         <Label>Beleg hochladen *</Label>
+        <InvoiceOrganizationHint organizationName={organizationName} />
         <ReceiptUpload
           onUploadComplete={(id) => setDraft({ ...draft, file: id })}
           storageId={draft.file || undefined}

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -19,6 +19,7 @@ import {
   type CostType,
 } from "@/lib/travel-costs";
 import { Trash2 } from "lucide-react";
+import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { PLACEHOLDERS } from "./constants";
 import type { Receipt } from "./types";
 
@@ -26,9 +27,15 @@ interface Props {
   receipt: Receipt;
   toggleType: (type: CostType) => void;
   updateReceipt: (type: CostType, updates: Partial<Receipt>) => void;
+  organizationName: string;
 }
 
-export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
+export function ReceiptCard({
+  receipt,
+  toggleType,
+  updateReceipt,
+  organizationName,
+}: Props) {
   return (
     <div className="border rounded-lg p-4 space-y-4">
       <div className="flex justify-between items-center">
@@ -154,6 +161,7 @@ export function ReceiptCard({ receipt, toggleType, updateReceipt }: Props) {
       {(receipt.grossAmount > 0 || receipt.fileStorageId) && (
         <div className="space-y-3">
           <Label>Beleg *</Label>
+          <InvoiceOrganizationHint organizationName={organizationName} />
           <ReceiptUpload
             onUploadComplete={(id) =>
               updateReceipt(receipt.costType, { fileStorageId: id })

--- a/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
@@ -6,7 +6,6 @@ import {
   type CostType,
   COST_LABELS as LABELS,
 } from "@/lib/travel-costs";
-import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { MealAllowanceSection } from "./MealAllowanceSection";
 import { ReceiptCard } from "./ReceiptCard";
 import type { Receipt, Travel } from "./types";
@@ -43,7 +42,6 @@ export function ReceiptsSection({
         <p className="text-sm text-muted-foreground mb-2">
           Wähle alle Kostenarten aus, für die du Belege einreichen möchtest.
         </p>
-        <InvoiceOrganizationHint organizationName={organizationName} />
         <div className="flex flex-wrap gap-2">
           {COST_TYPES.map((type) => (
             <Button
@@ -65,6 +63,7 @@ export function ReceiptsSection({
           receipt={receipt}
           toggleType={toggleType}
           updateReceipt={updateReceipt}
+          organizationName={organizationName}
         />
       ))}
 


### PR DESCRIPTION
## summary

- move invoice organization guidance from section headers to the relevant receipt upload fields in internal and public reimbursement forms
- pass the organization name into travel receipt cards so each upload shows the same contextual guidance

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --reporter=list` (5 passed on retry; the initial run hit a transient unchanged signature-canvas validation)