### PR TITLE
feat(reimbursements): clarify receipt number labels

### DIFF
--- a/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
+++ b/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
@@ -39,7 +39,7 @@ export function ReceiptCard({ receipt }: { receipt: ReceiptWithUrl }) {
           <div>
             <p className="font-semibold">{receipt.companyName}</p>
             <p className="text-sm text-muted-foreground">
-              Beleg-Nr. {receipt.receiptNumber} •{" "}
+              Beleg-/Rechnungsnummer {receipt.receiptNumber} •{" "}
               {formatDate(receipt.receiptDate)}
             </p>
           </div>

--- a/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/SimpleReceiptsSection.tsx
@@ -60,7 +60,7 @@ export function SimpleReceiptsSection(props: Props) {
             />
           </div>
           <div>
-            <Label>Beleg-Nr.</Label>
+            <Label>Beleg-/Rechnungsnummer</Label>
             <Input
               value={props.number}
               onChange={(e) => props.onNumberChange(e.target.value)}

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -53,7 +53,7 @@ export function TravelReceiptCard(props: Props) {
           />
         </div>
         <div>
-          <Label>Beleg-Nr.</Label>
+          <Label>Beleg-/Rechnungsnummer</Label>
           <Input
             value={receipt.receiptNumber ?? ""}
             onChange={(e) =>

--- a/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
@@ -55,7 +55,7 @@ export function ReceiptDraftFields({
           />
         </div>
         <div>
-          <Label>Beleg-Nr.</Label>
+          <Label>Beleg-/Rechnungsnummer</Label>
           <Input
             value={draft.number}
             onChange={(e) => setDraft({ ...draft, number: e.target.value })}

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -69,7 +69,7 @@ export function ReceiptCard({
           />
         </div>
         <div>
-          <Label>Beleg-Nr.</Label>
+          <Label>Beleg-/Rechnungsnummer</Label>
           <Input
             value={receipt.receiptNumber ?? ""}
             onChange={(e) =>


### PR DESCRIPTION
## summary

- Clarify receipt number labels as Beleg-/Rechnungsnummer across internal and public reimbursement forms.
- Use the same wording in the reimbursement receipt detail view.

## validation

- `pnpm exec prettier --check <changed reimbursement files>`
- `pnpm exec biome lint <changed reimbursement files>` (passes with one pre-existing `noImgElement` warning)
- `git diff --check`
- not run (automated tests; copy-only change)