### PR TITLE
fix(reimbursements): prevent receipt field label overflow

### DIFF
--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -33,7 +33,7 @@ export function TravelReceiptCard(props: Props) {
   const isCar = receipt.costType === "car";
 
   return (
-    <div className="border rounded-lg p-4 space-y-4">
+    <div className="@container border rounded-lg p-4 space-y-4">
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {isCar ? "PKW (0,30€/km)" : props.costLabels[receipt.costType]}
@@ -43,7 +43,7 @@ export function TravelReceiptCard(props: Props) {
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @3xl:grid-cols-4">
         <div>
           <Label>Name/Firma *</Label>
           <Input

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -37,7 +37,7 @@ export function ReceiptCard({
   organizationName,
 }: Props) {
   return (
-    <div className="border rounded-lg p-4 space-y-4">
+    <div className="@container border rounded-lg p-4 space-y-4">
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {receipt.costType === "car"
@@ -55,7 +55,7 @@ export function ReceiptCard({
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @3xl:grid-cols-4">
         <div>
           <Label>Firma/Anbieter *</Label>
           <Input

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -235,6 +235,19 @@ test.describe.serial("reimbursement flow", () => {
 
     await page.getByRole("button", { name: "PKW" }).click();
 
+    const receiptCard = page
+      .getByRole("heading", { name: /^PKW/ })
+      .locator("..")
+      .locator("..");
+    const overflowingLabels = await receiptCard
+      .locator("label")
+      .evaluateAll((labels) =>
+        labels
+          .filter((label) => label.scrollWidth > label.clientWidth)
+          .map((label) => label.textContent),
+      );
+    expect(overflowingLabels).toEqual([]);
+
     await page.getByPlaceholder("Eigenfahrt, Miles, Sixt, etc.").fill("Miles");
     await page
       .getByPlaceholder("z.B. RE-2026-001 (optional)")


### PR DESCRIPTION
## summary

- prevent receipt field labels from overflowing by sizing columns from each card's container
- apply the responsive layout to authenticated and shared travel forms with an end-to-end regression assertion

## validation

- `pnpm exec prettier --check app/components/Reimbursements/travelForm/ReceiptCard.tsx "app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx" e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Reimbursements/travelForm/ReceiptCard.tsx "app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx" e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm vitest run`
- `pnpm exec playwright test e2e/reimbursements.spec.ts`
- `pnpm build`