### PR TITLE
fix(auth): refresh roles in persisted sessions

### DIFF
--- a/app/lib/auth/config.test.ts
+++ b/app/lib/auth/config.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./environment", () => ({
-  isLocalCredentialsEnabled: () => true,
+  isLocalCredentialsEnabled: () => false,
 }));
 vi.mock("./provisioning", () => ({
   ensureAppUser: mocks.ensureAppUser,
@@ -18,18 +18,19 @@ describe("auth config", () => {
     mocks.ensureAppUser.mockReset();
   });
 
-  it("refreshes a persisted local session against the current database", async () => {
+  it("refreshes a persisted session against the current database", async () => {
     mocks.ensureAppUser.mockResolvedValue({
       _id: "new-user-id",
       _creationTime: 1,
       email: "local@example.com",
       organizationId: "new-organization-id",
-      role: "admin",
+      role: "finance",
     });
     const token = {
       email: "local@example.com",
       userId: "stale-user-id",
       organizationId: "stale-organization-id",
+      role: "admin",
     };
 
     // Auth.js omits user for persisted JWT sessions despite requiring it in the callback type.
@@ -47,7 +48,7 @@ describe("auth config", () => {
     expect(result).toMatchObject({
       userId: "new-user-id",
       organizationId: "new-organization-id",
-      role: "admin",
+      role: "finance",
     });
   });
 });

--- a/app/lib/auth/config.ts
+++ b/app/lib/auth/config.ts
@@ -63,11 +63,9 @@ export const authConfig = {
       if (isLocalLoginEnabled) return true;
       return isAllowedEmail(user.email);
     },
-    async jwt({ token, user, trigger }) {
+    async jwt({ token, user }) {
       const email = user?.email ?? (token.email as string | undefined);
-      const shouldRefreshAppUser =
-        Boolean(user) || trigger === "update" || isLocalLoginEnabled;
-      if (email && shouldRefreshAppUser) {
+      if (email) {
         const appUser = await ensureAppUser({
           email,
           name: user?.name ?? (token.name as string | undefined),


### PR DESCRIPTION
## summary

- refresh persisted JWT sessions from the current database user so role changes take effect immediately
- cover an admin-to-finance transition in production auth configuration

## validation

- `pnpm vitest run` (74 tests passed)
- `pnpm vitest run app/lib/auth/config.test.ts app/lib/auth/roles.test.ts app/lib/server/users/users.test.ts` (12 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint app/lib/auth/config.ts app/lib/auth/config.test.ts`
- `pnpm exec prettier --check app/lib/auth/config.ts app/lib/auth/config.test.ts`
- `pnpm run build`
- `git diff --check`
- `pnpm exec biome check app/lib/auth/config.ts app/lib/auth/config.test.ts` (formatter check conflicts with the repository’s Prettier indentation; lint passes separately)
- `pnpm run lint:lines` (fails on the pre-existing 201-line `app/lib/server/volunteerAllowance/actions.ts` on `origin/main`)