### PR TITLE
feat(reimbursements): add email lifecycle and revision flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Simple, free, intuitive budget and reimbursement tracking for non-profits.
 - **Volunteer Allowance:** "Ehrenamtspauschale" forms with shareable links for external signatures
 - **Team Management:** Organize members into teams with project access control
 - **Donor Export:** Export transactions by donor to CSV
-- **Email Notifications:** Transactional approval and rejection emails (powered by Brevo)
+- **Email Notifications:** Transactional request, submission, revision, approval, and rejection emails (powered by Brevo)
 - **Guided Onboarding:** Interactive tour for new users
 - **Audit Logs:** Track all actions for transparency and compliance
 

--- a/app/(protected)/dashboard/DashboardPageUI.tsx
+++ b/app/(protected)/dashboard/DashboardPageUI.tsx
@@ -15,6 +15,7 @@ import { STATUS_DISPLAY } from "@/lib/reimbursementStatus";
 
 const STATUS_CARDS = [
   { status: "pending", title: "Offen" },
+  { status: "changes_requested", title: "Änderungen angefordert" },
   { status: "approved", title: "Genehmigt" },
   { status: "declined", title: "Abgelehnt" },
 ] as const;
@@ -87,7 +88,7 @@ export function DashboardPageUI({ entries }: { entries: DashboardEntry[] }) {
       <PageHeader title="Dashboard" />
 
       <div className="flex flex-col gap-6">
-        <div className="grid gap-4 sm:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           {STATUS_CARDS.map((card) => (
             <Card key={card.status}>
               <CardHeader className="pb-2">

--- a/app/(protected)/reimbursements/ReimbursementPageUI.tsx
+++ b/app/(protected)/reimbursements/ReimbursementPageUI.tsx
@@ -23,6 +23,7 @@ import type {
 
 interface Props {
   canManageReimbursements: boolean;
+  currentUserId: string;
   reimbursements: Reimbursement[];
   allowances: Allowance[];
   typeFilter: ReimbursementTypeFilter;
@@ -34,12 +35,18 @@ interface Props {
   onRowClick: (id: string) => void;
   onApproveReimbursement: (id: string) => void;
   onApproveAllowance: (id: string) => void;
+  onOpenChangesDialog: (
+    type: "reimbursement" | "allowance",
+    id: string,
+  ) => void;
   onOpenRejectDialog: (type: "reimbursement" | "allowance", id: string) => void;
   onRejectDialogChange: (dialog: RejectDialog) => void;
   onReject: () => void;
   isRejecting: boolean;
   onOpenReimbursement: (id: string) => void;
   onOpenAllowance: (allowance: Allowance) => void;
+  onEditReimbursement: (id: string) => void;
+  onEditAllowance: (id: string) => void;
   onDeleteReimbursement: (id: string) => void;
   onDeleteAllowance: (id: string) => void;
   onToggleSelect: (key: SelectionKey) => void;
@@ -52,6 +59,7 @@ interface Props {
 
 export function ReimbursementPageUI({
   canManageReimbursements,
+  currentUserId,
   reimbursements,
   allowances,
   typeFilter,
@@ -63,12 +71,15 @@ export function ReimbursementPageUI({
   onRowClick,
   onApproveReimbursement,
   onApproveAllowance,
+  onOpenChangesDialog,
   onOpenRejectDialog,
   onRejectDialogChange,
   onReject,
   isRejecting,
   onOpenReimbursement,
   onOpenAllowance,
+  onEditReimbursement,
+  onEditAllowance,
   onDeleteReimbursement,
   onDeleteAllowance,
   onToggleSelect,
@@ -140,15 +151,19 @@ export function ReimbursementPageUI({
 
       <ReimbursementTable
         canManageReimbursements={canManageReimbursements}
+        currentUserId={currentUserId}
         reimbursements={reimbursements}
         allowances={allowances}
         selected={selected}
         onRowClick={onRowClick}
         onApproveReimbursement={onApproveReimbursement}
         onApproveAllowance={onApproveAllowance}
+        onOpenChangesDialog={onOpenChangesDialog}
         onOpenRejectDialog={onOpenRejectDialog}
         onOpenReimbursement={onOpenReimbursement}
         onOpenAllowance={onOpenAllowance}
+        onEditReimbursement={onEditReimbursement}
+        onEditAllowance={onEditAllowance}
         onDeleteReimbursement={onDeleteReimbursement}
         onDeleteAllowance={onDeleteAllowance}
         onToggleSelect={onToggleSelect}

--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -13,15 +13,22 @@ import type { Allowance, Reimbursement, SelectionKey } from "./types";
 
 type Props = {
   canManageReimbursements: boolean;
+  currentUserId: string;
   reimbursements: Reimbursement[];
   allowances: Allowance[];
   selected: Set<SelectionKey>;
   onRowClick: (id: string) => void;
   onApproveReimbursement: (id: string) => void;
   onApproveAllowance: (id: string) => void;
+  onOpenChangesDialog: (
+    type: "reimbursement" | "allowance",
+    id: string,
+  ) => void;
   onOpenRejectDialog: (type: "reimbursement" | "allowance", id: string) => void;
   onOpenReimbursement: (id: string) => void;
   onOpenAllowance: (allowance: Allowance) => void;
+  onEditReimbursement: (id: string) => void;
+  onEditAllowance: (id: string) => void;
   onDeleteReimbursement: (id: string) => void;
   onDeleteAllowance: (id: string) => void;
   onToggleSelect: (key: SelectionKey) => void;
@@ -30,15 +37,19 @@ type Props = {
 
 export function ReimbursementTable({
   canManageReimbursements,
+  currentUserId,
   reimbursements,
   allowances,
   selected,
   onRowClick,
   onApproveReimbursement,
   onApproveAllowance,
+  onOpenChangesDialog,
   onOpenRejectDialog,
   onOpenReimbursement,
   onOpenAllowance,
+  onEditReimbursement,
+  onEditAllowance,
   onDeleteReimbursement,
   onDeleteAllowance,
   onToggleSelect,
@@ -94,6 +105,9 @@ export function ReimbursementTable({
               key={item._id}
               item={item}
               canManageReimbursements={canManageReimbursements}
+              canEdit={
+                item.createdBy === currentUserId && !item.requestedExternally
+              }
               selectionCheckbox={
                 <Checkbox
                   checked={selected.has(`r:${item._id}`)}
@@ -115,8 +129,12 @@ export function ReimbursementTable({
               applicantName={item.submitterName || item.creatorName}
               onClick={() => onRowClick(item._id)}
               onApprove={() => onApproveReimbursement(item._id)}
+              onRequestChanges={() =>
+                onOpenChangesDialog("reimbursement", item._id)
+              }
               onReject={() => onOpenRejectDialog("reimbursement", item._id)}
               onOpen={() => onOpenReimbursement(item._id)}
+              onEdit={() => onEditReimbursement(item._id)}
               onDelete={() => onDeleteReimbursement(item._id)}
             />
           ))}
@@ -126,6 +144,9 @@ export function ReimbursementTable({
               key={item._id}
               item={item}
               canManageReimbursements={canManageReimbursements}
+              canEdit={
+                item.createdBy === currentUserId && !item.requestedExternally
+              }
               selectionCheckbox={
                 <Checkbox
                   checked={selected.has(`a:${item._id}`)}
@@ -138,8 +159,12 @@ export function ReimbursementTable({
               detail={item.activityDescription}
               applicantName={item.volunteerName || item.creatorName}
               onApprove={() => onApproveAllowance(item._id)}
+              onRequestChanges={() =>
+                onOpenChangesDialog("allowance", item._id)
+              }
               onReject={() => onOpenRejectDialog("allowance", item._id)}
               onOpen={() => onOpenAllowance(item)}
+              onEdit={() => onEditAllowance(item._id)}
               onDelete={() => onDeleteAllowance(item._id)}
             />
           ))}

--- a/app/(protected)/reimbursements/ReimbursementsClient.tsx
+++ b/app/(protected)/reimbursements/ReimbursementsClient.tsx
@@ -21,6 +21,7 @@ interface Props {
   allowances: Allowance[];
   projects: Project[];
   organizationName: string;
+  currentUserId: string;
 }
 
 export function ReimbursementsClient({
@@ -28,6 +29,7 @@ export function ReimbursementsClient({
   allowances,
   projects,
   organizationName,
+  currentUserId,
 }: Props) {
   const canManageReimbursements = useCanManageReimbursements();
   const router = useRouter();
@@ -86,6 +88,7 @@ export function ReimbursementsClient({
     <>
       <ReimbursementPageUI
         canManageReimbursements={canManageReimbursements}
+        currentUserId={currentUserId}
         reimbursements={filteredReimbursements}
         allowances={filteredAllowances}
         typeFilter={typeFilter}
@@ -97,12 +100,19 @@ export function ReimbursementsClient({
         onRowClick={(id) => router.push(`/reimbursements/${id}`)}
         onApproveReimbursement={actions.handleApproveReimbursement}
         onApproveAllowance={actions.handleApproveAllowance}
-        onOpenRejectDialog={actions.handleOpenRejectDialog}
+        onOpenChangesDialog={(type, id) =>
+          actions.handleOpenReviewDialog("changes", type, id)
+        }
+        onOpenRejectDialog={(type, id) =>
+          actions.handleOpenReviewDialog("reject", type, id)
+        }
         onRejectDialogChange={actions.setRejectDialog}
-        onReject={actions.handleReject}
+        onReject={actions.handleReview}
         isRejecting={actions.isRejecting}
         onOpenReimbursement={handleOpenReimbursement}
         onOpenAllowance={handleOpenAllowance}
+        onEditReimbursement={(id) => router.push(`/erstattung/${id}`)}
+        onEditAllowance={(id) => router.push(`/ehrenamtspauschale/${id}`)}
         onDeleteReimbursement={actions.handleDeleteReimbursement}
         onDeleteAllowance={actions.handleDeleteAllowance}
         onToggleSelect={handleToggleSelect}

--- a/app/(protected)/reimbursements/RejectDialogModal.tsx
+++ b/app/(protected)/reimbursements/RejectDialogModal.tsx
@@ -26,6 +26,8 @@ export function RejectDialogModal({
   onReject,
   isRejecting,
 }: Props) {
+  const requestsChanges = rejectDialog.action === "changes";
+
   return (
     <Dialog
       open={rejectDialog.open}
@@ -33,9 +35,13 @@ export function RejectDialogModal({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Ablehnen</DialogTitle>
+          <DialogTitle>
+            {requestsChanges ? "Änderungen anfordern" : "Endgültig ablehnen"}
+          </DialogTitle>
           <DialogDescription>
-            Bitte gib einen Grund für die Ablehnung ein.
+            {requestsChanges
+              ? "Beschreibe, was vor der Genehmigung geändert werden muss."
+              : "Bitte gib einen Grund für die endgültige Ablehnung ein."}
           </DialogDescription>
         </DialogHeader>
         <Textarea
@@ -43,7 +49,11 @@ export function RejectDialogModal({
           onChange={(e) =>
             onRejectDialogChange({ ...rejectDialog, note: e.target.value })
           }
-          placeholder="Grund für die Ablehnung..."
+          placeholder={
+            requestsChanges
+              ? "Benötigte Änderungen..."
+              : "Grund für die Ablehnung..."
+          }
           rows={4}
         />
         <DialogFooter>
@@ -61,7 +71,7 @@ export function RejectDialogModal({
             disabled={isRejecting || !rejectDialog.note.trim()}
           >
             {isRejecting && <Loader2 className="size-4 animate-spin" />}
-            Ablehnen
+            {requestsChanges ? "Änderungen anfordern" : "Ablehnen"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/(protected)/reimbursements/[id]/_components/RejectionNote.tsx
+++ b/app/(protected)/reimbursements/[id]/_components/RejectionNote.tsx
@@ -1,8 +1,30 @@
-export function RejectionNote({ note }: { note: string }) {
+export function RejectionNote({
+  note,
+  changesRequested = false,
+}: {
+  note: string;
+  changesRequested?: boolean;
+}) {
   return (
-    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-      <p className="text-sm font-medium text-red-800">Ablehnungsgrund:</p>
-      <p className="text-red-700">{note}</p>
+    <div
+      className={
+        changesRequested
+          ? "rounded-lg border border-orange-200 bg-orange-50 p-4"
+          : "rounded-lg border border-red-200 bg-red-50 p-4"
+      }
+    >
+      <p
+        className={
+          changesRequested
+            ? "text-sm font-medium text-orange-800"
+            : "text-sm font-medium text-red-800"
+        }
+      >
+        {changesRequested ? "Angeforderte Änderungen:" : "Ablehnungsgrund:"}
+      </p>
+      <p className={changesRequested ? "text-orange-700" : "text-red-700"}>
+        {note}
+      </p>
     </div>
   );
 }

--- a/app/(protected)/reimbursements/[id]/page.tsx
+++ b/app/(protected)/reimbursements/[id]/page.tsx
@@ -56,6 +56,10 @@ export default async function ReimbursementDetailPage({
           <RejectionNote note={reimbursement.rejectionNote} />
         )}
 
+        {reimbursement.reviewNote && (
+          <RejectionNote note={reimbursement.reviewNote} changesRequested />
+        )}
+
         {reimbursement.travelDetails && (
           <TravelDetailsCard travelDetails={reimbursement.travelDetails} />
         )}

--- a/app/(protected)/reimbursements/page.tsx
+++ b/app/(protected)/reimbursements/page.tsx
@@ -1,16 +1,18 @@
 import { getOrganization } from "@/lib/server/organizations/data";
+import { requireUser } from "@/lib/auth/session";
 import { getAllProjects } from "@/lib/server/projects/data";
 import { getAllReimbursements } from "@/lib/server/reimbursements/data";
 import { getAll } from "@/lib/server/volunteerAllowance/data";
 import { ReimbursementsClient } from "./ReimbursementsClient";
 
 export default async function ReimbursementPage() {
-  const [reimbursements, allowances, projects, organization] =
+  const [reimbursements, allowances, projects, organization, user] =
     await Promise.all([
       getAllReimbursements(),
       getAll(),
       getAllProjects(),
       getOrganization(),
+      requireUser(),
     ]);
 
   return (
@@ -19,6 +21,7 @@ export default async function ReimbursementPage() {
       allowances={allowances}
       projects={projects}
       organizationName={organization.name}
+      currentUserId={user._id}
     />
   );
 }

--- a/app/(protected)/reimbursements/types.ts
+++ b/app/(protected)/reimbursements/types.ts
@@ -32,6 +32,7 @@ export type ReimbursementTypeFilter =
 
 export type RejectDialog = {
   open: boolean;
+  action: "changes" | "reject";
   type: "reimbursement" | "allowance";
   id: string | null;
   note: string;

--- a/app/(protected)/reimbursements/useReimbursementActions.ts
+++ b/app/(protected)/reimbursements/useReimbursementActions.ts
@@ -2,12 +2,14 @@ import {
   approve as approveReimbursement,
   decline as declineReimbursement,
   deleteReimbursement,
+  requestChanges as requestReimbursementChanges,
 } from "@/lib/server/reimbursements/actions";
+import { remove as removeAllowance } from "@/lib/server/volunteerAllowance/actions";
 import {
   approve as approveAllowance,
   decline as declineAllowance,
-  remove as removeAllowance,
-} from "@/lib/server/volunteerAllowance/actions";
+  requestChanges as requestAllowanceChanges,
+} from "@/lib/server/volunteerAllowance/reviewActions";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -15,6 +17,7 @@ import type { RejectDialog } from "./types";
 
 const CLOSED_DIALOG: RejectDialog = {
   open: false,
+  action: "reject",
   type: "reimbursement",
   id: null,
   note: "",
@@ -39,7 +42,7 @@ export function useReimbursementActions() {
     }
   };
 
-  const handleReject = async () => {
+  const handleReview = async () => {
     const note = rejectDialog.note.trim();
     if (!rejectDialog.id || !note || isRejecting) return;
     const id = rejectDialog.id;
@@ -47,18 +50,37 @@ export function useReimbursementActions() {
     setIsRejecting(true);
     try {
       if (rejectDialog.type === "reimbursement") {
-        await declineReimbursement({
-          reimbursementId: id,
-          rejectionNote: note,
-        });
+        if (rejectDialog.action === "changes") {
+          await requestReimbursementChanges({
+            reimbursementId: id,
+            reviewNote: note,
+          });
+        } else {
+          await declineReimbursement({
+            reimbursementId: id,
+            rejectionNote: note,
+          });
+        }
       } else {
-        await declineAllowance({ id, rejectionNote: note });
+        if (rejectDialog.action === "changes") {
+          await requestAllowanceChanges({ id, reviewNote: note });
+        } else {
+          await declineAllowance({ id, rejectionNote: note });
+        }
       }
-      toast.success("Abgelehnt");
+      toast.success(
+        rejectDialog.action === "changes"
+          ? "Änderungen angefordert"
+          : "Abgelehnt",
+      );
       router.refresh();
       setRejectDialog(CLOSED_DIALOG);
     } catch {
-      toast.error("Fehler beim Ablehnen");
+      toast.error(
+        rejectDialog.action === "changes"
+          ? "Änderungen konnten nicht angefordert werden"
+          : "Fehler beim Ablehnen",
+      );
     } finally {
       setIsRejecting(false);
     }
@@ -68,9 +90,12 @@ export function useReimbursementActions() {
     rejectDialog,
     setRejectDialog,
     isRejecting,
-    handleReject,
-    handleOpenRejectDialog: (type: "reimbursement" | "allowance", id: string) =>
-      setRejectDialog({ open: true, type, id, note: "" }),
+    handleReview,
+    handleOpenReviewDialog: (
+      action: "changes" | "reject",
+      type: "reimbursement" | "allowance",
+      id: string,
+    ) => setRejectDialog({ open: true, action, type, id, note: "" }),
     handleApproveReimbursement: (id: string) =>
       run(
         () => approveReimbursement({ reimbursementId: id }),

--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -24,10 +24,15 @@ const ACTION_LABELS: Record<string, string> = {
   "reimbursement.create": "Erstattung erstellt",
   "reimbursement.approve": "Erstattung genehmigt",
   "reimbursement.decline": "Erstattung abgelehnt",
+  "reimbursement.requestChanges": "Änderungen an Erstattung angefordert",
+  "reimbursement.resubmit": "Erstattung erneut eingereicht",
   "reimbursement.delete": "Erstattung gelöscht",
   "volunteerAllowance.create": "Ehrenamtspauschale erstellt",
   "volunteerAllowance.approve": "Ehrenamtspauschale genehmigt",
   "volunteerAllowance.decline": "Ehrenamtspauschale abgelehnt",
+  "volunteerAllowance.requestChanges":
+    "Änderungen an Ehrenamtspauschale angefordert",
+  "volunteerAllowance.resubmit": "Ehrenamtspauschale erneut eingereicht",
   "volunteerAllowance.delete": "Ehrenamtspauschale gelöscht",
   "user.role_change": "Rolle geändert",
 };

--- a/app/(public)/_lib/publicApi.ts
+++ b/app/(public)/_lib/publicApi.ts
@@ -35,13 +35,45 @@ export type ReimbursementLink =
       organizationName: string;
       projectName: string;
       description?: string;
+      invitedName?: string;
+      invitedEmail?: string;
+      changesRequested?: string;
       travelDetails: {
         destination: string;
         purpose: string;
         startDate: string;
         endDate: string;
         allowFoodAllowance?: boolean;
+        isInternational?: boolean;
+        mealAllowanceDays?: number;
+        mealAllowanceDailyBudget?: number;
       } | null;
+      submission?: {
+        name: string;
+        email: string;
+        iban: string;
+        bic: string;
+        accountHolder: string;
+        signatureStorageId: string | null;
+        receipts: Array<{
+          receiptNumber?: string;
+          receiptDate: string;
+          companyName: string;
+          description: string;
+          netAmount: number;
+          taxRate: number;
+          grossAmount: number;
+          fileStorageId: string;
+          costType?:
+            | "car"
+            | "train"
+            | "flight"
+            | "taxi"
+            | "bus"
+            | "accommodation";
+          kilometers?: number;
+        }>;
+      };
     };
 
 export async function validateReimbursementLink(
@@ -87,6 +119,22 @@ export type AllowanceLink =
       activityDescription: string;
       startDate: string;
       endDate: string;
+      invitedName?: string;
+      invitedEmail?: string;
+      changesRequested?: string;
+      submission?: {
+        volunteerName: string;
+        submitterEmail: string;
+        volunteerStreet: string;
+        volunteerPlz: string;
+        volunteerCity: string;
+        amount: number;
+        iban: string;
+        bic: string;
+        accountHolder: string;
+        taxYear: string;
+        signatureStorageId: string | null;
+      };
     };
 
 export async function validateAllowanceLink(

--- a/app/(public)/ehrenamtspauschale/[id]/_components/AllowanceFormView.tsx
+++ b/app/(public)/ehrenamtspauschale/[id]/_components/AllowanceFormView.tsx
@@ -39,6 +39,14 @@ export function AllowanceFormView({
     <div className="min-h-svh py-8">
       <div className="max-w-2xl mx-auto px-6 space-y-8">
         <FormHeader linkData={linkData} />
+        {linkData.changesRequested ? (
+          <div className="rounded-lg border border-orange-200 bg-orange-50 p-4">
+            <p className="text-sm font-medium text-orange-800">
+              Folgende Änderungen wurden angefordert:
+            </p>
+            <p className="mt-1 text-orange-700">{linkData.changesRequested}</p>
+          </div>
+        ) : null}
         <PersonalDataSection form={form} updateField={updateField} />
         <ActivitySection form={form} updateField={updateField} />
         <AmountSection

--- a/app/(public)/ehrenamtspauschale/[id]/_components/PersonalDataSection.tsx
+++ b/app/(public)/ehrenamtspauschale/[id]/_components/PersonalDataSection.tsx
@@ -23,6 +23,17 @@ export function PersonalDataSection({ form, updateField }: Props) {
           />
         </div>
         <div className="col-span-2">
+          <Label>E-Mail (für Rückfragen und Statusmeldungen) *</Label>
+          <Input
+            type="email"
+            value={form.submitterEmail}
+            onChange={(event) =>
+              updateField("submitterEmail", event.target.value)
+            }
+            placeholder="max@beispiel.de"
+          />
+        </div>
+        <div className="col-span-2">
           <Label>Straße und Hausnummer *</Label>
           <Input
             value={form.volunteerStreet}

--- a/app/(public)/ehrenamtspauschale/[id]/_components/helpers.ts
+++ b/app/(public)/ehrenamtspauschale/[id]/_components/helpers.ts
@@ -27,6 +27,8 @@ export const validateAllowanceForm = (
 ): ValidationResult => {
   if (!form.volunteerName)
     return { ok: false, error: "Bitte deinen Namen eingeben" };
+  if (!/^\S+@\S+\.\S+$/.test(form.submitterEmail))
+    return { ok: false, error: "Bitte eine gültige E-Mail-Adresse eingeben" };
   if (!form.volunteerStreet)
     return { ok: false, error: "Bitte deine Straße eingeben" };
   if (!form.volunteerPlz)

--- a/app/(public)/ehrenamtspauschale/[id]/_components/types.ts
+++ b/app/(public)/ehrenamtspauschale/[id]/_components/types.ts
@@ -2,6 +2,7 @@ import type { AllowanceLink } from "@/(public)/_lib/publicApi";
 
 export type AllowanceForm = {
   volunteerName: string;
+  submitterEmail: string;
   volunteerStreet: string;
   volunteerPlz: string;
   volunteerCity: string;

--- a/app/(public)/ehrenamtspauschale/[id]/_components/useAllowanceForm.ts
+++ b/app/(public)/ehrenamtspauschale/[id]/_components/useAllowanceForm.ts
@@ -14,6 +14,7 @@ import type { AllowanceForm } from "./types";
 
 const initialForm: AllowanceForm = {
   volunteerName: "",
+  submitterEmail: "",
   volunteerStreet: "",
   volunteerPlz: "",
   volunteerCity: "",
@@ -42,19 +43,27 @@ export function useAllowanceForm(id: string) {
   }, [id]);
 
   useEffect(() => {
-    if (
-      linkData?.valid &&
-      !form.activityDescription &&
-      linkData.activityDescription
-    ) {
-      setForm((prev) => ({
-        ...prev,
-        activityDescription: linkData.activityDescription || "",
-        startDate: linkData.startDate || "",
-        endDate: linkData.endDate || "",
-      }));
-    }
-  }, [linkData, form.activityDescription]);
+    if (!linkData?.valid) return;
+    const submission = linkData.submission;
+    setForm((prev) => ({
+      ...prev,
+      volunteerName: submission?.volunteerName ?? linkData.invitedName ?? "",
+      submitterEmail: submission?.submitterEmail ?? linkData.invitedEmail ?? "",
+      volunteerStreet: submission?.volunteerStreet ?? "",
+      volunteerPlz: submission?.volunteerPlz ?? "",
+      volunteerCity: submission?.volunteerCity ?? "",
+      activityDescription: linkData.activityDescription || "",
+      startDate: linkData.startDate || "",
+      endDate: linkData.endDate || "",
+      amount: submission ? String(submission.amount) : "",
+      iban: submission?.iban ?? "",
+      bic: submission?.bic ?? "",
+      accountHolder: submission?.accountHolder ?? "",
+      taxYear: submission?.taxYear || prev.taxYear,
+      confirmation: false,
+    }));
+    setSignatureStorageId(submission?.signatureStorageId ?? null);
+  }, [linkData]);
 
   const updateField = (field: keyof AllowanceForm, value: string | boolean) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -88,6 +97,7 @@ export function useAllowanceForm(id: string) {
         startDate: form.startDate,
         endDate: form.endDate,
         volunteerName: form.volunteerName,
+        submitterEmail: form.submitterEmail,
         volunteerStreet: form.volunteerStreet,
         volunteerPlz: form.volunteerPlz,
         volunteerCity: form.volunteerCity,

--- a/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
+++ b/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
@@ -24,6 +24,15 @@ export default function ExternalReimbursementPageUI(
           </p>
         </div>
 
+        {props.changesRequested ? (
+          <div className="rounded-lg border border-orange-200 bg-orange-50 p-4">
+            <p className="text-sm font-medium text-orange-800">
+              Folgende Änderungen wurden angefordert:
+            </p>
+            <p className="mt-1 text-orange-700">{props.changesRequested}</p>
+          </div>
+        ) : null}
+
         <SubmitterSection
           name={props.name}
           email={props.email}

--- a/app/(public)/erstattung/[id]/_components/SubmitterSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/SubmitterSection.tsx
@@ -24,7 +24,7 @@ export function SubmitterSection(props: Props) {
           />
         </div>
         <div>
-          <Label>E-Mail (optional)</Label>
+          <Label>E-Mail *</Label>
           <Input
             type="email"
             value={props.email}

--- a/app/(public)/erstattung/[id]/_components/submitReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/submitReimbursementForm.ts
@@ -30,18 +30,26 @@ type SubmitParams = {
 function withFileStorageId<T extends { fileStorageId: string | null }>(
   items: T[],
 ) {
-  return items.map((item) => ({ ...item, fileStorageId: item.fileStorageId! }));
+  return items.filter(
+    (item): item is T & { fileStorageId: string } =>
+      typeof item.fileStorageId === "string",
+  );
 }
 
 export function validateReimbursement(params: SubmitParams) {
   if (
     !params.name ||
+    !params.email ||
     !params.iban ||
     !params.accountHolder ||
     !params.confirmation ||
     !params.signature
   ) {
     return "Bitte alle Pflichtfelder ausfüllen";
+  }
+
+  if (!/^\S+@\S+\.\S+$/.test(params.email)) {
+    return "Bitte eine gültige E-Mail-Adresse eingeben";
   }
 
   if (params.isTravel) {
@@ -77,6 +85,11 @@ export function validateReimbursement(params: SubmitParams) {
 }
 
 export async function submitReimbursementForm(params: SubmitParams) {
+  if (!params.signature) {
+    toast.error("Bitte unterschreiben");
+    return false;
+  }
+
   const validReceipts = withFileStorageId(
     params.receipts.filter((receipt) => receipt.fileStorageId),
   );
@@ -94,8 +107,8 @@ export async function submitReimbursementForm(params: SubmitParams) {
       bic: params.bic.toUpperCase(),
       accountHolder: params.accountHolder,
       submitterName: params.name,
-      submitterEmail: params.email || undefined,
-      signatureStorageId: params.signature!,
+      submitterEmail: params.email,
+      signatureStorageId: params.signature,
       receipts: validReceipts,
       travelReceipts: params.isTravel ? validTravelReceipts : undefined,
       travelDetails: params.isTravel

--- a/app/(public)/erstattung/[id]/_components/types.ts
+++ b/app/(public)/erstattung/[id]/_components/types.ts
@@ -23,6 +23,7 @@ export type ExternalReimbursementPageUIProps = {
   organizationName: string;
   projectName: string;
   allowFoodAllowance: boolean;
+  changesRequested?: string;
   showFoodAllowance: boolean;
   onShowFoodAllowanceChange: (value: boolean) => void;
 

--- a/app/(public)/erstattung/[id]/_components/useReceipts.ts
+++ b/app/(public)/erstattung/[id]/_components/useReceipts.ts
@@ -94,7 +94,9 @@ export function useReceipts(startDate: string) {
 
   return {
     receipts,
+    setReceipts,
     travelReceipts,
+    setTravelReceipts,
     company,
     number,
     description,

--- a/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
@@ -38,6 +38,7 @@ export function useReimbursementForm(id: string) {
   const [showFoodAllowance, setShowFoodAllowance] = useState(false);
 
   const receiptState = useReceipts(startDate);
+  const { setReceipts, setTravelReceipts } = receiptState;
 
   useEffect(() => {
     let ignoreResult = false;
@@ -45,19 +46,47 @@ export function useReimbursementForm(id: string) {
     void validateReimbursementLink(id).then((result) => {
       if (ignoreResult) return;
       setLink(result);
-      if (!result.valid || result.type !== "travel" || !result.travelDetails) {
-        return;
+      if (!result.valid) return;
+
+      const submission = result.submission;
+      setName(submission?.name ?? result.invitedName ?? "");
+      setEmail(submission?.email ?? result.invitedEmail ?? "");
+      if (submission) {
+        setIban(submission.iban);
+        setBic(submission.bic);
+        setAccountHolder(submission.accountHolder);
+        setSignature(submission.signatureStorageId);
+        setReceipts(
+          submission.receipts
+            .filter((receipt) => !receipt.costType)
+            .map((receipt) => ({
+              ...receipt,
+              receiptNumber: receipt.receiptNumber,
+            })),
+        );
+        setTravelReceipts(
+          submission.receipts.filter(
+            (receipt) => receipt.costType,
+          ) as typeof receiptState.travelReceipts,
+        );
       }
-      setDestination(result.travelDetails.destination);
-      setPurpose(result.travelDetails.purpose);
-      setStartDate(result.travelDetails.startDate);
-      setEndDate(result.travelDetails.endDate);
+
+      if (result.type === "travel" && result.travelDetails) {
+        setDestination(result.travelDetails.destination);
+        setPurpose(result.travelDetails.purpose);
+        setStartDate(result.travelDetails.startDate);
+        setEndDate(result.travelDetails.endDate);
+        setIsInternational(result.travelDetails.isInternational ?? false);
+        setMealDays(result.travelDetails.mealAllowanceDays ?? 0);
+        setMealRate(result.travelDetails.mealAllowanceDailyBudget ?? 0);
+        setShowFoodAllowance((result.travelDetails.mealAllowanceDays ?? 0) > 0);
+      }
     });
 
     return () => {
       ignoreResult = true;
     };
-  }, [id]);
+  }, [id, setReceipts, setTravelReceipts]);
 
   const isTravel = link?.valid === true && link.type === "travel";
   const mealTotal = mealDays * mealRate;

--- a/app/(public)/erstattung/[id]/page.tsx
+++ b/app/(public)/erstattung/[id]/page.tsx
@@ -33,6 +33,7 @@ export default function ExternalReimbursementPage() {
       organizationName={form.link.organizationName}
       projectName={form.link.projectName}
       allowFoodAllowance={form.link.travelDetails?.allowFoodAllowance ?? false}
+      changesRequested={form.link.changesRequested}
       showFoodAllowance={form.showFoodAllowance}
       onShowFoodAllowanceChange={form.setShowFoodAllowance}
       name={form.name}

--- a/app/api/public/allowance/[id]/route.ts
+++ b/app/api/public/allowance/[id]/route.ts
@@ -13,7 +13,10 @@ export async function GET(_request: Request, context: RouteContext) {
 
   if (!doc)
     return Response.json({ valid: false, error: "Dieser Link ist ungültig." });
-  if (doc.volunteerName && doc.signatureStorageId)
+  if (!doc.isSharedLink)
+    return Response.json({ valid: false, error: "Dieser Link ist ungültig." });
+  const isEditing = doc.status === "changes_requested";
+  if (doc.volunteerName && doc.signatureStorageId && !isEditing)
     return Response.json({
       valid: false,
       error: "Dieses Formular wurde bereits eingereicht.",
@@ -36,5 +39,23 @@ export async function GET(_request: Request, context: RouteContext) {
     activityDescription: doc.activityDescription,
     startDate: doc.startDate,
     endDate: doc.endDate,
+    invitedName: doc.invitedName,
+    invitedEmail: doc.invitedEmail,
+    changesRequested: isEditing ? doc.reviewNote : undefined,
+    submission: isEditing
+      ? {
+          volunteerName: doc.volunteerName,
+          submitterEmail: doc.submitterEmail ?? doc.invitedEmail ?? "",
+          volunteerStreet: doc.volunteerStreet,
+          volunteerPlz: doc.volunteerPlz,
+          volunteerCity: doc.volunteerCity,
+          amount: doc.amount,
+          iban: doc.iban,
+          bic: doc.bic ?? "",
+          accountHolder: doc.accountHolder,
+          taxYear: doc.taxYear ?? "",
+          signatureStorageId: doc.signatureStorageId ?? null,
+        }
+      : undefined,
   });
 }

--- a/app/api/public/allowance/[id]/submit/route.ts
+++ b/app/api/public/allowance/[id]/submit/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { volunteerAllowance } from "@/lib/db/collections";
 import { addLog } from "@/lib/server/logs";
+import { sendSubmissionReceivedEmail } from "@/lib/server/volunteerAllowance/email";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -16,9 +17,11 @@ const bodySchema = z.object({
   endDate: z.string(),
   taxYear: z.string().optional(),
   volunteerName: z.string(),
+  submitterEmail: z.string().email(),
   volunteerStreet: z.string(),
   volunteerPlz: z.string(),
   volunteerCity: z.string(),
+  signatureStorageId: z.string(),
 });
 
 export async function POST(request: Request, context: RouteContext) {
@@ -31,33 +34,53 @@ export async function POST(request: Request, context: RouteContext) {
       throw new Error(`Amount cannot exceed ${MAX_VOLUNTEER_ALLOWANCE_EUR}€`);
 
     const collection = await volunteerAllowance();
+    const existing = await collection.findOne({ _id: id });
+    if (!existing?.isSharedLink) throw new Error("Invalid link");
+    const isResubmission = existing.status === "changes_requested";
+    if (existing.signatureStorageId && !isResubmission) {
+      throw new Error("Already submitted");
+    }
+    const signatureAllowed =
+      args.signatureStorageId === existing.pendingSignatureStorageId ||
+      args.signatureStorageId === existing.signatureStorageId;
+    if (!signatureAllowed) throw new Error("Invalid signature");
 
     const result = await collection.updateOne(
       {
         _id: id,
-        signatureStorageId: { $exists: false },
-        pendingSignatureStorageId: { $exists: true },
+        isSharedLink: true,
+        $or: [
+          { signatureStorageId: { $exists: false } },
+          { status: "changes_requested" },
+        ],
       },
-      [
-        {
-          $set: {
-            amount: args.amount,
-            iban: args.iban,
-            bic: args.bic,
-            accountHolder: args.accountHolder,
-            activityDescription: args.activityDescription,
-            startDate: args.startDate,
-            endDate: args.endDate,
-            taxYear: args.taxYear,
-            volunteerName: args.volunteerName,
-            volunteerStreet: args.volunteerStreet,
-            volunteerPlz: args.volunteerPlz,
-            volunteerCity: args.volunteerCity,
-            status: "pending",
-            signatureStorageId: "$pendingSignatureStorageId",
-          },
+      {
+        $set: {
+          amount: args.amount,
+          iban: args.iban,
+          bic: args.bic,
+          accountHolder: args.accountHolder,
+          activityDescription: args.activityDescription,
+          startDate: args.startDate,
+          endDate: args.endDate,
+          taxYear: args.taxYear,
+          volunteerName: args.volunteerName,
+          submitterEmail: args.submitterEmail,
+          volunteerStreet: args.volunteerStreet,
+          volunteerPlz: args.volunteerPlz,
+          volunteerCity: args.volunteerCity,
+          status: "pending",
+          signatureStorageId: args.signatureStorageId,
+          submittedExternally: true,
         },
-      ],
+        $unset: {
+          reviewNote: "",
+          rejectionNote: "",
+          reviewedBy: "",
+          reviewedAt: "",
+          pendingSignatureStorageId: "",
+        },
+      },
     );
 
     if (result.matchedCount !== 1 || result.modifiedCount !== 1)
@@ -69,10 +92,13 @@ export async function POST(request: Request, context: RouteContext) {
     await addLog(
       doc.organizationId,
       doc.createdBy,
-      "volunteerAllowance.create",
+      isResubmission
+        ? "volunteerAllowance.resubmit"
+        : "volunteerAllowance.create",
       id,
       `extern ${args.amount}€`,
     );
+    await sendSubmissionReceivedEmail(id);
 
     return Response.json({ ok: true });
   } catch (error) {

--- a/app/api/public/allowance/[id]/upload-url/route.ts
+++ b/app/api/public/allowance/[id]/upload-url/route.ts
@@ -14,7 +14,12 @@ export async function POST(request: Request, context: RouteContext) {
 
     const doc = await (await volunteerAllowance()).findOne({ _id: id });
     if (!doc) throw new Error("Invalid link");
-    if (doc.volunteerName && doc.signatureStorageId)
+    if (!doc.isSharedLink) throw new Error("Invalid link");
+    if (
+      doc.volunteerName &&
+      doc.signatureStorageId &&
+      doc.status !== "changes_requested"
+    )
       throw new Error("Already submitted");
 
     const { key, url } = await presignUpload(contentType);
@@ -22,7 +27,14 @@ export async function POST(request: Request, context: RouteContext) {
     await (
       await volunteerAllowance()
     ).updateOne(
-      { _id: id, signatureStorageId: { $exists: false } },
+      {
+        _id: id,
+        isSharedLink: true,
+        $or: [
+          { signatureStorageId: { $exists: false } },
+          { status: "changes_requested" },
+        ],
+      },
       { $set: { pendingSignatureStorageId: key } },
     );
 

--- a/app/api/public/reimbursement/[id]/file-url/route.ts
+++ b/app/api/public/reimbursement/[id]/file-url/route.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { reimbursements } from "@/lib/db/collections";
+import { receipts, reimbursements } from "@/lib/db/collections";
 import { presignDownload } from "@/lib/s3/storage";
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -13,12 +13,22 @@ export async function POST(request: Request, context: RouteContext) {
     const { key } = bodySchema.parse(await request.json());
 
     const doc = await (await reimbursements()).findOne({ _id: id });
-    if (!doc || !doc.isSharedLink || doc.amount !== 0) {
+    if (
+      !doc ||
+      !doc.isSharedLink ||
+      (doc.amount !== 0 && doc.status !== "changes_requested")
+    ) {
       throw new Error("Invalid link");
     }
 
-    if (!(doc.pendingUploadKeys ?? []).includes(key))
-      throw new Error("Invalid key");
+    const existingReceipt = await (
+      await receipts()
+    ).findOne({ reimbursementId: id, fileStorageId: key });
+    const allowed =
+      (doc.pendingUploadKeys ?? []).includes(key) ||
+      Boolean(existingReceipt) ||
+      doc.signatureStorageId === key;
+    if (!allowed) throw new Error("Invalid key");
 
     const url = await presignDownload(key);
     return Response.json({ url });

--- a/app/api/public/reimbursement/[id]/route.ts
+++ b/app/api/public/reimbursement/[id]/route.ts
@@ -1,6 +1,7 @@
 import {
   organizations,
   projects,
+  receipts,
   reimbursements,
   travelDetails,
 } from "@/lib/db/collections";
@@ -15,7 +16,8 @@ export async function GET(_request: Request, context: RouteContext) {
   if (!doc) return Response.json({ valid: false, error: "Link ungültig" });
   if (!doc.isSharedLink)
     return Response.json({ valid: false, error: "Kein geteilter Link" });
-  if (doc.amount > 0)
+  const isEditing = doc.status === "changes_requested";
+  if (doc.amount > 0 && !isEditing)
     return Response.json({ valid: false, error: "Bereits eingereicht" });
 
   const organization = await (
@@ -29,6 +31,9 @@ export async function GET(_request: Request, context: RouteContext) {
     doc.type === "travel"
       ? await (await travelDetails()).findOne({ reimbursementId: id })
       : null;
+  const receiptList = isEditing
+    ? await (await receipts()).find({ reimbursementId: id }).toArray()
+    : [];
 
   return Response.json({
     valid: true,
@@ -36,6 +41,22 @@ export async function GET(_request: Request, context: RouteContext) {
     organizationName: organization?.name || "",
     projectName: project?.name || "",
     description: doc.description,
+    invitedName: doc.invitedName,
+    invitedEmail: doc.invitedEmail,
     travelDetails: travel,
+    changesRequested: isEditing ? doc.reviewNote : undefined,
+    submission: isEditing
+      ? {
+          name: doc.submitterName ?? doc.invitedName ?? "",
+          email: doc.submitterEmail ?? doc.invitedEmail ?? "",
+          iban: doc.iban,
+          bic: doc.bic ?? "",
+          accountHolder: doc.accountHolder,
+          signatureStorageId: doc.signatureStorageId ?? null,
+          receipts: receiptList.map(
+            ({ _id, _creationTime, reimbursementId, ...receipt }) => receipt,
+          ),
+        }
+      : undefined,
   });
 }

--- a/app/api/public/reimbursement/[id]/submit/route.ts
+++ b/app/api/public/reimbursement/[id]/submit/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { receipts, reimbursements, travelDetails } from "@/lib/db/collections";
 import { newId } from "@/lib/db/ids";
 import { addLog } from "@/lib/server/logs";
+import { sendSubmissionReceivedEmail } from "@/lib/server/reimbursements/email";
 import {
   getTravelDateRangeError,
   TRAVEL_DATE_RANGE_ERROR,
@@ -34,7 +35,7 @@ const bodySchema = z.object({
   bic: z.string(),
   accountHolder: z.string(),
   submitterName: z.string(),
-  submitterEmail: z.string().optional(),
+  submitterEmail: z.string().email(),
   signatureStorageId: z.string(),
   receipts: z.array(receiptSchema),
   travelReceipts: z.array(travelReceiptSchema).optional(),
@@ -64,8 +65,21 @@ export async function POST(request: Request, context: RouteContext) {
 
     const existing = await collection.findOne({ _id: id });
     if (!existing) throw new Error("Invalid link");
+    if (!existing.isSharedLink) throw new Error("Not a shared link");
+    const isResubmission = existing.status === "changes_requested";
+    if (existing.submitterName && !isResubmission) {
+      throw new Error("Already submitted");
+    }
 
-    const allowed = new Set(existing.pendingUploadKeys ?? []);
+    const existingReceipts = await (await receipts())
+      .find({ reimbursementId: id })
+      .toArray();
+
+    const allowed = new Set([
+      ...(existing.pendingUploadKeys ?? []),
+      ...existingReceipts.map((receipt) => receipt.fileStorageId),
+      ...(existing.signatureStorageId ? [existing.signatureStorageId] : []),
+    ]);
     const allReceipts = [...args.receipts, ...(args.travelReceipts ?? [])];
     const usedKeys = [
       args.signatureStorageId,
@@ -75,7 +89,14 @@ export async function POST(request: Request, context: RouteContext) {
       return Response.json({ error: "Invalid key" }, { status: 400 });
 
     const result = await collection.updateOne(
-      { _id: id, isSharedLink: true, submitterName: { $exists: false } },
+      {
+        _id: id,
+        isSharedLink: true,
+        $or: [
+          { submitterName: { $exists: false } },
+          { status: "changes_requested" },
+        ],
+      },
       {
         $set: {
           amount: args.amount,
@@ -85,6 +106,15 @@ export async function POST(request: Request, context: RouteContext) {
           submitterName: args.submitterName,
           submitterEmail: args.submitterEmail,
           signatureStorageId: args.signatureStorageId,
+          status: "pending",
+          submittedExternally: true,
+        },
+        $unset: {
+          reviewNote: "",
+          rejectionNote: "",
+          reviewedBy: "",
+          reviewedAt: "",
+          pendingUploadKeys: "",
         },
       },
     );
@@ -96,6 +126,9 @@ export async function POST(request: Request, context: RouteContext) {
 
     const receiptsToInsert =
       doc.type === "travel" ? args.travelReceipts || [] : args.receipts;
+    if (isResubmission) {
+      await (await receipts()).deleteMany({ reimbursementId: id });
+    }
     for (const receipt of receiptsToInsert) {
       await (
         await receipts()
@@ -132,10 +165,13 @@ export async function POST(request: Request, context: RouteContext) {
     await addLog(
       doc.organizationId,
       doc.createdBy,
-      "reimbursement.externalSubmit",
+      isResubmission
+        ? "reimbursement.resubmit"
+        : "reimbursement.externalSubmit",
       id,
       `extern ${args.amount}€`,
     );
+    await sendSubmissionReceivedEmail(id);
 
     return Response.json({ ok: true });
   } catch (error) {

--- a/app/api/public/reimbursement/[id]/upload-url/route.ts
+++ b/app/api/public/reimbursement/[id]/upload-url/route.ts
@@ -15,14 +15,23 @@ export async function POST(request: Request, context: RouteContext) {
     const doc = await (await reimbursements()).findOne({ _id: id });
     if (!doc) throw new Error("Invalid link");
     if (!doc.isSharedLink) throw new Error("Not a shared link");
-    if (doc.submitterName) throw new Error("Already submitted");
+    if (doc.submitterName && doc.status !== "changes_requested") {
+      throw new Error("Already submitted");
+    }
 
     const { key, url } = await presignUpload(contentType);
 
     await (
       await reimbursements()
     ).updateOne(
-      { _id: id, isSharedLink: true, submitterName: { $exists: false } },
+      {
+        _id: id,
+        isSharedLink: true,
+        $or: [
+          { submitterName: { $exists: false } },
+          { status: "changes_requested" },
+        ],
+      },
       { $addToSet: { pendingUploadKeys: key } },
     );
 

--- a/app/components/Reimbursements/ShareModal.tsx
+++ b/app/components/Reimbursements/ShareModal.tsx
@@ -24,6 +24,7 @@ export function ShareModal({
     updateForm,
     handleClose,
     handleCopy,
+    handleSend,
     handleCopyExisting,
     handleDelete,
   } = useShareModal(open, onClose);
@@ -42,6 +43,7 @@ export function ShareModal({
       onTypeChange={setType}
       onFormUpdate={updateForm}
       onCopy={handleCopy}
+      onSend={handleSend}
       onCopyExistingLink={handleCopyExisting}
       onDeleteLink={handleDelete}
     />

--- a/app/components/Reimbursements/ShareModalUI.tsx
+++ b/app/components/Reimbursements/ShareModalUI.tsx
@@ -22,6 +22,7 @@ export function ShareModalUI({
   onTypeChange,
   onFormUpdate,
   onCopy,
+  onSend,
   onCopyExistingLink,
   onDeleteLink,
 }: ShareModalUIProps) {
@@ -45,6 +46,7 @@ export function ShareModalUI({
           onTypeChange={onTypeChange}
           onFormUpdate={onFormUpdate}
           onCopy={onCopy}
+          onSend={onSend}
         />
 
         <ExistingLinks

--- a/app/components/Reimbursements/shareModal/ShareForm.tsx
+++ b/app/components/Reimbursements/shareModal/ShareForm.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { ProjectTravelDefaults } from "@/lib/db/types";
-import { Copy, Loader2 } from "lucide-react";
+import { Copy, Loader2, Mail } from "lucide-react";
 import { TYPE_LABELS } from "./constants";
 import type { LinkType, ShareModalUIProps } from "./types";
 
@@ -20,6 +20,7 @@ type ShareFormProps = Pick<
   | "onTypeChange"
   | "onFormUpdate"
   | "onCopy"
+  | "onSend"
 >;
 
 export function ShareForm({
@@ -31,6 +32,7 @@ export function ShareForm({
   onTypeChange,
   onFormUpdate,
   onCopy,
+  onSend,
 }: ShareFormProps) {
   const handleProjectChange = (
     value: string,
@@ -144,19 +146,53 @@ export function ShareForm({
         </div>
       )}
 
-      <Button
-        variant="outline"
-        onClick={onCopy}
-        className="h-12 w-full"
-        disabled={isGenerating || !form.projectId}
-      >
-        {isGenerating ? (
-          <Loader2 className="size-4 animate-spin mr-2" />
-        ) : (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <Label>Empfängername (optional)</Label>
+          <Input
+            value={form.invitedName}
+            onChange={(event) =>
+              onFormUpdate({ invitedName: event.target.value })
+            }
+            placeholder="Max Mustermann"
+          />
+        </div>
+        <div>
+          <Label>Empfänger-E-Mail</Label>
+          <Input
+            type="email"
+            value={form.invitedEmail}
+            onChange={(event) =>
+              onFormUpdate({ invitedEmail: event.target.value })
+            }
+            placeholder="max@beispiel.de"
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Button
+          variant="outline"
+          onClick={onCopy}
+          className="h-12 w-full"
+          disabled={isGenerating || !form.projectId}
+        >
           <Copy className="size-4 mr-2" />
-        )}
-        Link kopieren
-      </Button>
+          Link kopieren
+        </Button>
+        <Button
+          onClick={onSend}
+          className="h-12 w-full"
+          disabled={isGenerating || !form.projectId || !form.invitedEmail}
+        >
+          {isGenerating ? (
+            <Loader2 className="size-4 animate-spin mr-2" />
+          ) : (
+            <Mail className="size-4 mr-2" />
+          )}
+          Per E-Mail senden
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/components/Reimbursements/shareModal/constants.ts
+++ b/app/components/Reimbursements/shareModal/constants.ts
@@ -8,6 +8,8 @@ export const INITIAL_FORM: FormState = {
   destination: "",
   purpose: "",
   allowFoodAllowance: false,
+  invitedName: "",
+  invitedEmail: "",
 };
 
 export const TYPE_LABELS: Record<LinkType, string> = {

--- a/app/components/Reimbursements/shareModal/types.ts
+++ b/app/components/Reimbursements/shareModal/types.ts
@@ -18,6 +18,8 @@ export type FormState = {
   destination: string;
   purpose: string;
   allowFoodAllowance: boolean;
+  invitedName: string;
+  invitedEmail: string;
 };
 
 export type ShareModalUIProps = {
@@ -33,6 +35,7 @@ export type ShareModalUIProps = {
   onTypeChange: (type: LinkType) => void;
   onFormUpdate: (updates: Partial<FormState>) => void;
   onCopy: () => void;
+  onSend: () => void;
   onCopyExistingLink: (id: string, linkType: LinkKind) => void;
   onDeleteLink: (id: string, linkType: LinkKind) => void;
 };

--- a/app/components/Reimbursements/shareModal/useShareModal.ts
+++ b/app/components/Reimbursements/shareModal/useShareModal.ts
@@ -57,13 +57,22 @@ export function useShareModal(open: boolean, onClose: () => void) {
     onClose();
   };
 
-  const generate = async (): Promise<{ id: string; linkType: LinkKind }> => {
+  const generate = async (
+    sendEmail: boolean,
+  ): Promise<{ id: string; linkType: LinkKind }> => {
+    const recipient = sendEmail
+      ? {
+          invitedName: form.invitedName || undefined,
+          invitedEmail: form.invitedEmail || undefined,
+        }
+      : {};
     if (type === "allowance") {
       const id = await createAllowanceLink({
         projectId: form.projectId ?? "",
         activityDescription: form.description,
         startDate: form.startDate,
         endDate: form.endDate,
+        ...recipient,
       });
       return { id, linkType: "allowance" };
     }
@@ -81,6 +90,7 @@ export function useShareModal(open: boolean, onClose: () => void) {
               allowFoodAllowance: form.allowFoodAllowance,
             }
           : undefined,
+      ...recipient,
     });
     return { id, linkType: "reimbursement" };
   };
@@ -89,12 +99,27 @@ export function useShareModal(open: boolean, onClose: () => void) {
     if (!form.projectId) return;
     setIsGenerating(true);
     try {
-      const { id, linkType } = await generate();
+      const { id, linkType } = await generate(false);
       await navigator.clipboard.writeText(linkUrl(linkType, id));
       toast.success("Link kopiert");
       refresh();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Fehler");
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!form.projectId || !form.invitedEmail) return;
+    setIsGenerating(true);
+    try {
+      await generate(true);
+      toast.success("Anforderung per E-Mail gesendet");
+      refresh();
+      setForm(INITIAL_FORM);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Fehler");
     } finally {
       setIsGenerating(false);
     }
@@ -132,6 +157,7 @@ export function useShareModal(open: boolean, onClose: () => void) {
     updateForm,
     handleClose,
     handleCopy,
+    handleSend,
     handleCopyExisting,
     handleDelete,
   };

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Check, ExternalLink, Trash2, X } from "lucide-react";
+import {
+  Check,
+  ExternalLink,
+  MessageSquareWarning,
+  Pencil,
+  Trash2,
+  X,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,33 +25,40 @@ interface ReimbursementRowProps {
     _creationTime: number;
     status: Status;
     rejectionNote?: string;
+    reviewNote?: string;
     projectName: string;
     amount: number;
     reviewedByName?: string;
   };
   canManageReimbursements: boolean;
+  canEdit: boolean;
   title: string;
   detail?: string;
   applicantName: string;
   selectionCheckbox?: ReactNode;
   onClick?: () => void;
   onApprove: () => void;
+  onRequestChanges: () => void;
   onReject: () => void;
   onOpen: () => void;
+  onEdit: () => void;
   onDelete: () => void;
 }
 
 export function ReimbursementRow({
   item,
   canManageReimbursements,
+  canEdit,
   title,
   detail,
   applicantName,
   selectionCheckbox,
   onClick,
   onApprove,
+  onRequestChanges,
   onReject,
   onOpen,
+  onEdit,
   onDelete,
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
@@ -93,6 +107,14 @@ export function ReimbursementRow({
               Grund: {item.rejectionNote}
             </span>
           ) : null}
+          {item.reviewNote ? (
+            <span
+              className="max-w-56 truncate text-xs text-orange-700"
+              title={`Angeforderte Änderungen: ${item.reviewNote}`}
+            >
+              Änderung: {item.reviewNote}
+            </span>
+          ) : null}
         </div>
       </TableCell>
       <TableCell className="max-w-48 truncate text-muted-foreground">
@@ -115,6 +137,16 @@ export function ReimbursementRow({
               <Button
                 variant="ghost"
                 size="icon"
+                className="h-7 w-7 text-orange-600 hover:bg-orange-50 hover:text-orange-700"
+                onClick={onRequestChanges}
+                aria-label="Änderungen anfordern"
+                title="Änderungen anfordern"
+              >
+                <MessageSquareWarning className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
                 className="h-7 w-7 text-red-600 hover:text-red-700 hover:bg-red-50"
                 onClick={onReject}
                 aria-label="Ablehnen"
@@ -123,6 +155,17 @@ export function ReimbursementRow({
                 <X className="h-4 w-4" />
               </Button>
             </>
+          ) : null}
+          {canEdit && item.status === "changes_requested" ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 border-orange-200 px-2 text-orange-700 hover:bg-orange-50 hover:text-orange-800"
+              onClick={onEdit}
+            >
+              <Pencil className="h-4 w-4" />
+              Bearbeiten
+            </Button>
           ) : null}
           <Button
             variant="ghost"

--- a/app/lib/dashboardStats.test.ts
+++ b/app/lib/dashboardStats.test.ts
@@ -25,11 +25,13 @@ describe("statusTotals", () => {
       entry({ status: "pending", amount: 70 }),
       entry({ status: "approved", amount: 200 }),
       entry({ status: "declined", amount: 10 }),
+      entry({ status: "changes_requested", amount: 20 }),
     ]);
 
     expect(totals.pending).toEqual({ count: 2, sum: 120 });
     expect(totals.approved).toEqual({ count: 1, sum: 200 });
     expect(totals.declined).toEqual({ count: 1, sum: 10 });
+    expect(totals.changes_requested).toEqual({ count: 1, sum: 20 });
   });
 
   it("returns zeroed totals for empty input", () => {
@@ -37,6 +39,7 @@ describe("statusTotals", () => {
     expect(totals.pending).toEqual({ count: 0, sum: 0 });
     expect(totals.approved).toEqual({ count: 0, sum: 0 });
     expect(totals.declined).toEqual({ count: 0, sum: 0 });
+    expect(totals.changes_requested).toEqual({ count: 0, sum: 0 });
   });
 });
 

--- a/app/lib/dashboardStats.ts
+++ b/app/lib/dashboardStats.ts
@@ -18,6 +18,7 @@ export function statusTotals(
 ): Record<ReimbursementStatus, StatusTotal> {
   const totals: Record<ReimbursementStatus, StatusTotal> = {
     pending: { count: 0, sum: 0 },
+    changes_requested: { count: 0, sum: 0 },
     approved: { count: 0, sum: 0 },
     declined: { count: 0, sum: 0 },
   };

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -1,6 +1,10 @@
 export type UserRole = "admin" | "finance" | "member";
 export type ReimbursementType = "expense" | "travel";
-export type ReviewStatus = "pending" | "approved" | "declined";
+export type ReviewStatus =
+  | "pending"
+  | "changes_requested"
+  | "approved"
+  | "declined";
 export type CostType =
   | "car"
   | "train"
@@ -70,6 +74,7 @@ export interface Reimbursement {
   bic?: string;
   accountHolder: string;
   rejectionNote?: string;
+  reviewNote?: string;
   createdBy: string;
   reviewedBy?: string;
   reviewedAt?: number;
@@ -78,6 +83,10 @@ export interface Reimbursement {
   isSharedLink?: boolean;
   submitterName?: string;
   submitterEmail?: string;
+  invitedName?: string;
+  invitedEmail?: string;
+  submittedExternally?: boolean;
+  requestedExternally?: boolean;
   description?: string;
   pendingUploadKeys?: string[];
 }
@@ -133,6 +142,7 @@ export interface VolunteerAllowance {
   bic?: string;
   accountHolder: string;
   rejectionNote?: string;
+  reviewNote?: string;
   createdBy: string;
   reviewedBy?: string;
   reviewedAt?: number;
@@ -146,6 +156,12 @@ export interface VolunteerAllowance {
   volunteerCity: string;
   signatureStorageId?: string;
   pendingSignatureStorageId?: string;
+  isSharedLink?: boolean;
+  submitterEmail?: string;
+  invitedName?: string;
+  invitedEmail?: string;
+  submittedExternally?: boolean;
+  requestedExternally?: boolean;
 }
 
 export interface SignatureToken {

--- a/app/lib/fileHandlers/fileConversion.ts
+++ b/app/lib/fileHandlers/fileConversion.ts
@@ -1,5 +1,3 @@
-import heic2any from "heic2any";
-
 const MAX_SIZE = 10 * 1024 * 1024; // 10MB
 const QUALITY = 0.7;
 
@@ -14,14 +12,24 @@ async function convertPNGtoJPG(file: File): Promise<File> {
         const canvas = document.createElement("canvas");
         canvas.width = img.width;
         canvas.height = img.height;
-        const ctx = canvas.getContext("2d")!;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new FileConversionError("Bild konnte nicht gelesen werden"));
+          return;
+        }
         ctx.fillStyle = "#FFFFFF";
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         ctx.drawImage(img, 0, 0);
         canvas.toBlob(
           (blob) => {
+            if (!blob) {
+              reject(
+                new FileConversionError("Bild konnte nicht konvertiert werden"),
+              );
+              return;
+            }
             resolve(
-              new File([blob!], file.name.replace(/\.png$/i, ".jpg"), {
+              new File([blob], file.name.replace(/\.png$/i, ".jpg"), {
                 type: "image/jpeg",
               }),
             );
@@ -39,6 +47,7 @@ async function convertPNGtoJPG(file: File): Promise<File> {
 }
 
 async function convertHEICtoJPG(file: File): Promise<File> {
+  const { default: heic2any } = await import("heic2any");
   const blob = await heic2any({
     blob: file,
     toType: "image/jpeg",

--- a/app/lib/reimbursementStatus.ts
+++ b/app/lib/reimbursementStatus.ts
@@ -1,4 +1,8 @@
-export type ReimbursementStatus = "pending" | "approved" | "declined";
+export type ReimbursementStatus =
+  | "pending"
+  | "changes_requested"
+  | "approved"
+  | "declined";
 
 export const STATUS_DISPLAY: Record<
   ReimbursementStatus,
@@ -14,6 +18,12 @@ export const STATUS_DISPLAY: Record<
     label: "Ausstehend",
     dot: "bg-yellow-500",
     className: "bg-amber-50 border-amber-200 text-amber-700",
+  },
+  changes_requested: {
+    variant: "default",
+    label: "Änderungen angefordert",
+    dot: "bg-orange-500",
+    className: "bg-orange-50 border-orange-200 text-orange-800",
   },
   approved: {
     variant: "default",

--- a/app/lib/server/reimbursements/actions.ts
+++ b/app/lib/server/reimbursements/actions.ts
@@ -8,6 +8,7 @@ import { presignUpload } from "../../s3/storage";
 import { addLog } from "../logs";
 import {
   applyApproval,
+  applyChangesRequest,
   applyDecline,
   buildReimbursementPdfData,
   deleteReimbursementById,
@@ -15,7 +16,12 @@ import {
   type ReimbursementPdfData,
 } from "./actionsHelpers";
 import { getFileInfo, getFileUrl } from "./data";
-import { sendApprovalEmail, sendRejectionEmail } from "./email";
+import {
+  sendApprovalEmail,
+  sendChangesRequestedEmail,
+  sendRejectionEmail,
+  sendSubmissionReceivedEmail,
+} from "./email";
 import {
   insertReceipts,
   insertReimbursement,
@@ -45,6 +51,8 @@ export async function createReimbursement(
     `${args.amount}€`,
   );
 
+  await sendSubmissionReceivedEmail(reimbursementId);
+
   return reimbursementId;
 }
 
@@ -68,6 +76,8 @@ export async function createTravelReimbursement(
     reimbursementId,
     `Travel ${args.amount}€`,
   );
+
+  await sendSubmissionReceivedEmail(reimbursementId);
 
   return reimbursementId;
 }
@@ -142,7 +152,10 @@ export async function decline(input: {
 }): Promise<void> {
   const user = await requireRole("finance");
   const { reimbursementId, rejectionNote } = z
-    .object({ reimbursementId: z.string(), rejectionNote: z.string() })
+    .object({
+      reimbursementId: z.string(),
+      rejectionNote: z.string().trim().min(1),
+    })
     .parse(input);
 
   await loadPendingForReview(reimbursementId, user.organizationId);
@@ -157,4 +170,28 @@ export async function decline(input: {
     rejectionNote,
   );
   await sendRejectionEmail(reimbursementId);
+}
+
+export async function requestChanges(input: {
+  reimbursementId: string;
+  reviewNote: string;
+}): Promise<void> {
+  const user = await requireRole("finance");
+  const { reimbursementId, reviewNote } = z
+    .object({
+      reimbursementId: z.string(),
+      reviewNote: z.string().trim().min(1),
+    })
+    .parse(input);
+
+  await loadPendingForReview(reimbursementId, user.organizationId);
+  await applyChangesRequest(reimbursementId, user._id, reviewNote);
+  await addLog(
+    user.organizationId,
+    user._id,
+    "reimbursement.requestChanges",
+    reimbursementId,
+    reviewNote,
+  );
+  await sendChangesRequestedEmail(reimbursementId);
 }

--- a/app/lib/server/reimbursements/actionsHelpers.ts
+++ b/app/lib/server/reimbursements/actionsHelpers.ts
@@ -103,6 +103,7 @@ export async function applyApproval(
         reviewedBy: reviewerId,
         reviewedAt: Date.now(),
       },
+      $unset: { reviewNote: "", rejectionNote: "" },
     },
   );
 }
@@ -123,6 +124,29 @@ export async function applyDecline(
         reviewedBy: reviewerId,
         reviewedAt: Date.now(),
       },
+      $unset: { reviewNote: "" },
+    },
+  );
+}
+
+export async function applyChangesRequest(
+  reimbursementId: string,
+  reviewerId: string,
+  reviewNote: string,
+): Promise<void> {
+  await (
+    await reimbursements()
+  ).updateOne(
+    { _id: reimbursementId },
+    {
+      $set: {
+        status: "changes_requested",
+        reviewNote,
+        reviewedBy: reviewerId,
+        reviewedAt: Date.now(),
+        isSharedLink: true,
+      },
+      $unset: { rejectionNote: "" },
     },
   );
 }

--- a/app/lib/server/reimbursements/email.ts
+++ b/app/lib/server/reimbursements/email.ts
@@ -59,13 +59,22 @@ async function getMailData(
   return { ...reimbursement, organization, creator, project };
 }
 
-function recipient(data: ReimbursementMailData): EmailRecipient | null {
-  const email = data.submitterEmail ?? data.creator.email;
+function submitterRecipient(
+  data: ReimbursementMailData,
+): EmailRecipient | null {
+  const email =
+    data.submitterEmail ??
+    (data.requestedExternally ? undefined : data.creator.email);
   if (!email) return null;
   return {
     email,
     name: data.submitterName ?? data.creator.name,
   };
+}
+
+function invitedRecipient(data: ReimbursementMailData): EmailRecipient | null {
+  if (!data.invitedEmail) return null;
+  return { email: data.invitedEmail, name: data.invitedName };
 }
 
 function documentType(data: ReimbursementMailData): string {
@@ -82,9 +91,24 @@ function submissionUrl(data: ReimbursementMailData): string {
   );
 }
 
-async function sendDecisionEmail(
+type LifecycleEvent =
+  | "requested"
+  | "received"
+  | "changes-requested"
+  | "approved"
+  | "rejected";
+
+const TEMPLATE_BY_EVENT: Record<LifecycleEvent, number> = {
+  requested: BREVO_TEMPLATE_IDS.SUBMISSION_REQUESTED,
+  received: BREVO_TEMPLATE_IDS.SUBMISSION_RECEIVED,
+  "changes-requested": BREVO_TEMPLATE_IDS.CHANGES_REQUESTED,
+  approved: BREVO_TEMPLATE_IDS.SUBMISSION_APPROVED,
+  rejected: BREVO_TEMPLATE_IDS.SUBMISSION_REJECTED,
+};
+
+async function sendLifecycleEmail(
   reimbursementId: string,
-  decision: "approved" | "rejected",
+  event: LifecycleEvent,
 ): Promise<void> {
   if (!process.env.BREVO_API_KEY) return;
 
@@ -92,17 +116,15 @@ async function sendDecisionEmail(
     const data = await getMailData(reimbursementId);
     if (!data) return;
 
-    const to = recipient(data);
+    const to =
+      event === "requested" ? invitedRecipient(data) : submitterRecipient(data);
     const accountingEmail = data.organization.accountingEmail;
     if (!to || !accountingEmail) return;
 
     await sendMail({
       to: [to],
       replyTo: { email: accountingEmail },
-      templateId:
-        decision === "approved"
-          ? BREVO_TEMPLATE_IDS.SUBMISSION_APPROVED
-          : BREVO_TEMPLATE_IDS.SUBMISSION_REJECTED,
+      templateId: TEMPLATE_BY_EVENT[event],
       params: {
         recipientName: to.name ?? "",
         accountingEmail,
@@ -110,23 +132,41 @@ async function sendDecisionEmail(
         projectName: data.project.name,
         amount: formatAmount(data.amount, data.currency),
         reviewedAt: formatDate(data.reviewedAt),
-        reviewMessage: data.rejectionNote ?? "",
+        reviewMessage: data.reviewNote ?? data.rejectionNote ?? "",
         submissionUrl: submissionUrl(data),
       },
-      tags: ["ybase", "reimbursement", `submission-${decision}`],
+      tags: ["ybase", "reimbursement", `submission-${event}`],
     });
   } catch (error) {
     console.error(
-      `Could not send ${decision} email for reimbursement ${reimbursementId}`,
+      `Could not send ${event} email for reimbursement ${reimbursementId}`,
       error,
     );
   }
 }
 
 export function sendApprovalEmail(reimbursementId: string): Promise<void> {
-  return sendDecisionEmail(reimbursementId, "approved");
+  return sendLifecycleEmail(reimbursementId, "approved");
 }
 
 export function sendRejectionEmail(reimbursementId: string): Promise<void> {
-  return sendDecisionEmail(reimbursementId, "rejected");
+  return sendLifecycleEmail(reimbursementId, "rejected");
+}
+
+export function sendSubmissionRequestedEmail(
+  reimbursementId: string,
+): Promise<void> {
+  return sendLifecycleEmail(reimbursementId, "requested");
+}
+
+export function sendSubmissionReceivedEmail(
+  reimbursementId: string,
+): Promise<void> {
+  return sendLifecycleEmail(reimbursementId, "received");
+}
+
+export function sendChangesRequestedEmail(
+  reimbursementId: string,
+): Promise<void> {
+  return sendLifecycleEmail(reimbursementId, "changes-requested");
 }

--- a/app/lib/server/reimbursements/helpers.ts
+++ b/app/lib/server/reimbursements/helpers.ts
@@ -5,7 +5,12 @@ import { deleteObject } from "../../s3/storage";
 
 type ReimbursementType = Reimbursement["type"];
 
-type ReimbursementActor = { _id: string; organizationId: string };
+type ReimbursementActor = {
+  _id: string;
+  organizationId: string;
+  name?: string;
+  email?: string;
+};
 
 type ReimbursementInsert = {
   projectId: string;
@@ -41,6 +46,8 @@ export async function insertReimbursement(
     currency: args.currency,
     signatureStorageId: args.signatureStorageId,
     createdBy: user._id,
+    submitterName: user.name,
+    submitterEmail: user.email,
   });
 }
 

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -27,7 +27,10 @@ vi.mock("../../s3/storage", () => ({
 
 vi.mock("./email", () => ({
   sendApprovalEmail: vi.fn(async () => {}),
+  sendChangesRequestedEmail: vi.fn(async () => {}),
   sendRejectionEmail: vi.fn(async () => {}),
+  sendSubmissionReceivedEmail: vi.fn(async () => {}),
+  sendSubmissionRequestedEmail: vi.fn(async () => {}),
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
@@ -46,9 +49,17 @@ import {
   createReimbursement,
   decline,
   deleteReimbursement,
+  requestChanges,
 } from "./actions";
 import { getAllReimbursements, getFileInfo, getReimbursement } from "./data";
-import { sendApprovalEmail, sendRejectionEmail } from "./email";
+import {
+  sendApprovalEmail,
+  sendChangesRequestedEmail,
+  sendRejectionEmail,
+  sendSubmissionReceivedEmail,
+  sendSubmissionRequestedEmail,
+} from "./email";
+import { createReimbursementLink } from "./sharing";
 
 let mongod: MongoMemoryServer;
 let orgA: string;
@@ -161,6 +172,20 @@ test("createReimbursement writes the reimbursement and receipts scoped to the or
     .toArray();
   expect(receiptList).toHaveLength(1);
   expect(receiptList[0]?.fileStorageId).toBe("receipt-key");
+  expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(id);
+});
+
+test("creating an emailed submission request sends the request template", async () => {
+  const id = await createReimbursementLink({
+    projectId: projectA,
+    type: "expense",
+    invitedName: "Erika",
+    invitedEmail: "erika@example.com",
+  });
+
+  const stored = await (await reimbursements()).findOne({ _id: id });
+  expect(stored?.invitedEmail).toBe("erika@example.com");
+  expect(sendSubmissionRequestedEmail).toHaveBeenCalledWith(id);
 });
 
 test("getFileInfo returns signed download metadata", async () => {
@@ -296,6 +321,17 @@ test("decline sets the status and sends the review email", async () => {
   expect(stored?.status).toBe("declined");
   expect(stored?.rejectionNote).toBe("Beleg fehlt");
   expect(sendRejectionEmail).toHaveBeenCalledWith(id);
+});
+
+test("requestChanges opens the submission for editing and sends an email", async () => {
+  const id = await createReimbursement(reimbursementInput());
+  await requestChanges({ reimbursementId: id, reviewNote: "Beleg ergänzen" });
+
+  const stored = await (await reimbursements()).findOne({ _id: id });
+  expect(stored?.status).toBe("changes_requested");
+  expect(stored?.reviewNote).toBe("Beleg ergänzen");
+  expect(stored?.isSharedLink).toBe(true);
+  expect(sendChangesRequestedEmail).toHaveBeenCalledWith(id);
 });
 
 test("deleteReimbursement removes receipts and deletes the stored files", async () => {

--- a/app/lib/server/reimbursements/sharing.ts
+++ b/app/lib/server/reimbursements/sharing.ts
@@ -15,6 +15,7 @@ import {
   type PendingReimbursementLink,
 } from "./sharingHelpers";
 import { createLinkSchema } from "./validators";
+import { sendSubmissionRequestedEmail } from "./email";
 
 export async function createReimbursementLink(
   input: z.input<typeof createLinkSchema>,
@@ -24,6 +25,9 @@ export async function createReimbursementLink(
 
   const reimbursementId = newId();
   await insertReimbursementLink(reimbursementId, user, args);
+  if (args.invitedEmail) {
+    await sendSubmissionRequestedEmail(reimbursementId);
+  }
 
   return reimbursementId;
 }

--- a/app/lib/server/reimbursements/sharingHelpers.ts
+++ b/app/lib/server/reimbursements/sharingHelpers.ts
@@ -50,7 +50,10 @@ export async function insertReimbursementLink(
     accountHolder: "",
     createdBy: user._id,
     isSharedLink: true,
+    requestedExternally: true,
     description: args.description || "",
+    invitedName: args.invitedName,
+    invitedEmail: args.invitedEmail,
   });
 
   if (args.type !== "travel" || !args.travelDetails) return;

--- a/app/lib/server/reimbursements/validators.ts
+++ b/app/lib/server/reimbursements/validators.ts
@@ -58,6 +58,8 @@ export const createLinkSchema = z.object({
   projectId: z.string(),
   type: z.enum(["expense", "travel"]),
   description: z.string().optional(),
+  invitedName: z.string().trim().optional(),
+  invitedEmail: z.string().email().optional(),
   travelDetails: z
     .object({
       destination: z.string().optional(),

--- a/app/lib/server/volunteerAllowance/actions.ts
+++ b/app/lib/server/volunteerAllowance/actions.ts
@@ -2,14 +2,14 @@
 
 import { z } from "zod";
 import { hasMinimumRole } from "../../auth/roles";
-import { requireRole, requireUser } from "../../auth/session";
+import { requireUser } from "../../auth/session";
 import { volunteerAllowance } from "../../db/collections";
 import { newId } from "../../db/ids";
 import { deleteObject } from "../../s3/storage";
 import { bankDetailsFields } from "../bankDetails";
 import { addLog } from "../logs";
 import { getSignatureUrl } from "./data";
-import { sendApprovalEmail, sendRejectionEmail } from "./email";
+import { sendSubmissionReceivedEmail } from "./email";
 
 const MAX_VOLUNTEER_ALLOWANCE_EUR = 960;
 export async function create(input: {
@@ -75,6 +75,7 @@ export async function create(input: {
     volunteerPlz: args.volunteerPlz,
     volunteerCity: args.volunteerCity,
     signatureStorageId: args.signatureStorageId,
+    submitterEmail: user.email,
   });
 
   await addLog(
@@ -84,92 +85,12 @@ export async function create(input: {
     _id,
     `${args.amount}€`,
   );
+  await sendSubmissionReceivedEmail(_id);
   return _id;
 }
 
 export async function getSignatureUrlAction(key: string): Promise<string> {
   return getSignatureUrl(key);
-}
-
-export async function approve(input: { id: string }): Promise<void> {
-  const user = await requireRole("finance");
-  const { id } = z.object({ id: z.string() }).parse(input);
-
-  const doc = await (await volunteerAllowance()).findOne({ _id: id });
-  if (!doc || doc.organizationId !== user.organizationId) {
-    throw new Error("Not found");
-  }
-  if (doc.status !== "pending") {
-    throw new Error("Already processed");
-  }
-  if (doc.amount > MAX_VOLUNTEER_ALLOWANCE_EUR) {
-    throw new Error(
-      `Cannot approve: amount exceeds ${MAX_VOLUNTEER_ALLOWANCE_EUR}€ legal limit`,
-    );
-  }
-
-  await (
-    await volunteerAllowance()
-  ).updateOne(
-    { _id: id },
-    {
-      $set: {
-        status: "approved",
-        reviewedBy: user._id,
-        reviewedAt: Date.now(),
-      },
-    },
-  );
-
-  await addLog(
-    user.organizationId,
-    user._id,
-    "volunteerAllowance.approve",
-    id,
-    `${doc.amount}€`,
-  );
-  await sendApprovalEmail(id);
-}
-
-export async function decline(input: {
-  id: string;
-  rejectionNote: string;
-}): Promise<void> {
-  const user = await requireRole("finance");
-  const { id, rejectionNote } = z
-    .object({ id: z.string(), rejectionNote: z.string() })
-    .parse(input);
-
-  const doc = await (await volunteerAllowance()).findOne({ _id: id });
-  if (!doc || doc.organizationId !== user.organizationId) {
-    throw new Error("Not found");
-  }
-  if (doc.status !== "pending") {
-    throw new Error("Already processed");
-  }
-
-  await (
-    await volunteerAllowance()
-  ).updateOne(
-    { _id: id },
-    {
-      $set: {
-        status: "declined",
-        rejectionNote,
-        reviewedBy: user._id,
-        reviewedAt: Date.now(),
-      },
-    },
-  );
-
-  await addLog(
-    user.organizationId,
-    user._id,
-    "volunteerAllowance.decline",
-    id,
-    rejectionNote,
-  );
-  await sendRejectionEmail(id);
 }
 
 export async function remove(input: { id: string }): Promise<void> {

--- a/app/lib/server/volunteerAllowance/email.ts
+++ b/app/lib/server/volunteerAllowance/email.ts
@@ -19,15 +19,47 @@ function formatDate(timestamp?: number): string {
   }).format(new Date(timestamp ?? Date.now()));
 }
 
-function recipient(data: VolunteerAllowanceWithDetails): EmailRecipient | null {
-  return data.creator.email
-    ? { email: data.creator.email, name: data.creator.name }
-    : null;
+function submitterRecipient(
+  data: VolunteerAllowanceWithDetails,
+): EmailRecipient | null {
+  const email =
+    data.submitterEmail ??
+    (data.requestedExternally ? undefined : data.creator.email);
+  if (!email) return null;
+  return { email, name: data.volunteerName || data.creator.name };
 }
 
-async function sendDecisionEmail(
+function invitedRecipient(
+  data: VolunteerAllowanceWithDetails,
+): EmailRecipient | null {
+  if (!data.invitedEmail) return null;
+  return { email: data.invitedEmail, name: data.invitedName };
+}
+
+function submissionUrl(data: VolunteerAllowanceWithDetails): string {
+  return appUrl(
+    data.isSharedLink ? `/ehrenamtspauschale/${data._id}` : "/reimbursements",
+  );
+}
+
+type LifecycleEvent =
+  | "requested"
+  | "received"
+  | "changes-requested"
+  | "approved"
+  | "rejected";
+
+const TEMPLATE_BY_EVENT: Record<LifecycleEvent, number> = {
+  requested: BREVO_TEMPLATE_IDS.SUBMISSION_REQUESTED,
+  received: BREVO_TEMPLATE_IDS.SUBMISSION_RECEIVED,
+  "changes-requested": BREVO_TEMPLATE_IDS.CHANGES_REQUESTED,
+  approved: BREVO_TEMPLATE_IDS.SUBMISSION_APPROVED,
+  rejected: BREVO_TEMPLATE_IDS.SUBMISSION_REJECTED,
+};
+
+async function sendLifecycleEmail(
   id: string,
-  decision: "approved" | "rejected",
+  event: LifecycleEvent,
 ): Promise<void> {
   if (!process.env.BREVO_API_KEY) return;
 
@@ -35,17 +67,15 @@ async function sendDecisionEmail(
     const data = await getWithDetails(id);
     if (!data) return;
 
-    const to = recipient(data);
+    const to =
+      event === "requested" ? invitedRecipient(data) : submitterRecipient(data);
     const accountingEmail = data.organization.accountingEmail;
     if (!to || !accountingEmail) return;
 
     await sendMail({
       to: [to],
       replyTo: { email: accountingEmail },
-      templateId:
-        decision === "approved"
-          ? BREVO_TEMPLATE_IDS.SUBMISSION_APPROVED
-          : BREVO_TEMPLATE_IDS.SUBMISSION_REJECTED,
+      templateId: TEMPLATE_BY_EVENT[event],
       params: {
         recipientName: to.name ?? data.volunteerName,
         accountingEmail,
@@ -53,23 +83,32 @@ async function sendDecisionEmail(
         projectName: data.project.name,
         amount: formatAmount(data.amount),
         reviewedAt: formatDate(data.reviewedAt),
-        reviewMessage: data.rejectionNote ?? "",
-        submissionUrl: appUrl("/reimbursements"),
+        reviewMessage: data.reviewNote ?? data.rejectionNote ?? "",
+        submissionUrl: submissionUrl(data),
       },
-      tags: ["ybase", "volunteer-allowance", `submission-${decision}`],
+      tags: ["ybase", "volunteer-allowance", `submission-${event}`],
     });
   } catch (error) {
-    console.error(
-      `Could not send ${decision} email for allowance ${id}`,
-      error,
-    );
+    console.error(`Could not send ${event} email for allowance ${id}`, error);
   }
 }
 
 export function sendApprovalEmail(id: string): Promise<void> {
-  return sendDecisionEmail(id, "approved");
+  return sendLifecycleEmail(id, "approved");
 }
 
 export function sendRejectionEmail(id: string): Promise<void> {
-  return sendDecisionEmail(id, "rejected");
+  return sendLifecycleEmail(id, "rejected");
+}
+
+export function sendSubmissionRequestedEmail(id: string): Promise<void> {
+  return sendLifecycleEmail(id, "requested");
+}
+
+export function sendSubmissionReceivedEmail(id: string): Promise<void> {
+  return sendLifecycleEmail(id, "received");
+}
+
+export function sendChangesRequestedEmail(id: string): Promise<void> {
+  return sendLifecycleEmail(id, "changes-requested");
 }

--- a/app/lib/server/volunteerAllowance/reviewActions.ts
+++ b/app/lib/server/volunteerAllowance/reviewActions.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { z } from "zod";
+import { requireRole } from "../../auth/session";
+import { volunteerAllowance } from "../../db/collections";
+import { addLog } from "../logs";
+import {
+  sendApprovalEmail,
+  sendChangesRequestedEmail,
+  sendRejectionEmail,
+} from "./email";
+
+const MAX_VOLUNTEER_ALLOWANCE_EUR = 960;
+
+async function loadPending(id: string, organizationId: string) {
+  const doc = await (await volunteerAllowance()).findOne({ _id: id });
+  if (!doc || doc.organizationId !== organizationId) {
+    throw new Error("Not found");
+  }
+  if (doc.status !== "pending") throw new Error("Already processed");
+  return doc;
+}
+
+export async function approve(input: { id: string }): Promise<void> {
+  const user = await requireRole("finance");
+  const { id } = z.object({ id: z.string() }).parse(input);
+  const doc = await loadPending(id, user.organizationId);
+
+  if (doc.amount > MAX_VOLUNTEER_ALLOWANCE_EUR) {
+    throw new Error(
+      `Cannot approve: amount exceeds ${MAX_VOLUNTEER_ALLOWANCE_EUR}€ legal limit`,
+    );
+  }
+
+  await (
+    await volunteerAllowance()
+  ).updateOne(
+    { _id: id },
+    {
+      $set: {
+        status: "approved",
+        reviewedBy: user._id,
+        reviewedAt: Date.now(),
+      },
+      $unset: { reviewNote: "", rejectionNote: "" },
+    },
+  );
+  await addLog(
+    user.organizationId,
+    user._id,
+    "volunteerAllowance.approve",
+    id,
+    `${doc.amount}€`,
+  );
+  await sendApprovalEmail(id);
+}
+
+export async function decline(input: {
+  id: string;
+  rejectionNote: string;
+}): Promise<void> {
+  const user = await requireRole("finance");
+  const { id, rejectionNote } = z
+    .object({ id: z.string(), rejectionNote: z.string().trim().min(1) })
+    .parse(input);
+  await loadPending(id, user.organizationId);
+
+  await (
+    await volunteerAllowance()
+  ).updateOne(
+    { _id: id },
+    {
+      $set: {
+        status: "declined",
+        rejectionNote,
+        reviewedBy: user._id,
+        reviewedAt: Date.now(),
+      },
+      $unset: { reviewNote: "" },
+    },
+  );
+  await addLog(
+    user.organizationId,
+    user._id,
+    "volunteerAllowance.decline",
+    id,
+    rejectionNote,
+  );
+  await sendRejectionEmail(id);
+}
+
+export async function requestChanges(input: {
+  id: string;
+  reviewNote: string;
+}): Promise<void> {
+  const user = await requireRole("finance");
+  const { id, reviewNote } = z
+    .object({ id: z.string(), reviewNote: z.string().trim().min(1) })
+    .parse(input);
+  await loadPending(id, user.organizationId);
+
+  await (
+    await volunteerAllowance()
+  ).updateOne(
+    { _id: id },
+    {
+      $set: {
+        status: "changes_requested",
+        reviewNote,
+        reviewedBy: user._id,
+        reviewedAt: Date.now(),
+        isSharedLink: true,
+      },
+      $unset: { rejectionNote: "" },
+    },
+  );
+  await addLog(
+    user.organizationId,
+    user._id,
+    "volunteerAllowance.requestChanges",
+    id,
+    reviewNote,
+  );
+  await sendChangesRequestedEmail(id);
+}

--- a/app/lib/server/volunteerAllowance/sharing.ts
+++ b/app/lib/server/volunteerAllowance/sharing.ts
@@ -4,12 +4,15 @@ import { z } from "zod";
 import { requireRole } from "../../auth/session";
 import { volunteerAllowance } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { sendSubmissionRequestedEmail } from "./email";
 
 const createLinkSchema = z.object({
   projectId: z.string(),
   activityDescription: z.string().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
+  invitedName: z.string().trim().optional(),
+  invitedEmail: z.string().email().optional(),
 });
 
 export async function createLink(
@@ -39,7 +42,13 @@ export async function createLink(
     volunteerStreet: "",
     volunteerPlz: "",
     volunteerCity: "",
+    isSharedLink: true,
+    requestedExternally: true,
+    invitedName: args.invitedName,
+    invitedEmail: args.invitedEmail,
   });
+
+  if (args.invitedEmail) await sendSubmissionRequestedEmail(id);
 
   return id;
 }

--- a/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
+++ b/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
@@ -13,7 +13,10 @@ vi.mock("../../s3/storage", () => ({
 
 vi.mock("./email", () => ({
   sendApprovalEmail: vi.fn(async () => {}),
+  sendChangesRequestedEmail: vi.fn(async () => {}),
   sendRejectionEmail: vi.fn(async () => {}),
+  sendSubmissionReceivedEmail: vi.fn(async () => {}),
+  sendSubmissionRequestedEmail: vi.fn(async () => {}),
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
@@ -26,9 +29,17 @@ import {
 } from "../../db/collections";
 import { newId } from "../../db/ids";
 import { deleteObject } from "../../s3/storage";
-import { approve, create, decline, remove } from "./actions";
+import { create, remove } from "./actions";
 import { getAll } from "./data";
-import { sendApprovalEmail, sendRejectionEmail } from "./email";
+import {
+  sendApprovalEmail,
+  sendChangesRequestedEmail,
+  sendRejectionEmail,
+  sendSubmissionReceivedEmail,
+  sendSubmissionRequestedEmail,
+} from "./email";
+import { createLink } from "./sharing";
+import { approve, decline, requestChanges } from "./reviewActions";
 
 let mongod: MongoMemoryServer;
 let orgA: string;
@@ -206,6 +217,21 @@ test("create persists the allowance as pending", async () => {
   const doc = await (await volunteerAllowance()).findOne({ _id: id });
   expect(doc?.status).toBe("pending");
   expect(doc?.organizationId).toBe(orgA);
+  expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(id);
+});
+
+test("creating an emailed allowance request sends the request template", async () => {
+  const projectA = newId();
+  const id = await createLink({
+    projectId: projectA,
+    invitedName: "Erika",
+    invitedEmail: "erika@example.com",
+  });
+
+  const doc = await (await volunteerAllowance()).findOne({ _id: id });
+  expect(doc?.isSharedLink).toBe(true);
+  expect(doc?.invitedEmail).toBe("erika@example.com");
+  expect(sendSubmissionRequestedEmail).toHaveBeenCalledWith(id);
 });
 
 test("approve sets status approved", async () => {
@@ -251,6 +277,29 @@ test("decline sets status and sends the review email", async () => {
   expect(doc?.status).toBe("declined");
   expect(doc?.rejectionNote).toBe("Angaben fehlen");
   expect(sendRejectionEmail).toHaveBeenCalledWith(id);
+});
+
+test("requestChanges opens the allowance for editing and sends an email", async () => {
+  const projectA = newId();
+  await (
+    await projects()
+  ).insertOne({
+    _id: projectA,
+    _creationTime: Date.now(),
+    name: "Projekt A",
+    organizationId: orgA,
+    isArchived: false,
+    createdBy: userA,
+  });
+
+  const id = await create(newAllowanceInput(projectA));
+  await requestChanges({ id, reviewNote: "Zeitraum korrigieren" });
+
+  const doc = await (await volunteerAllowance()).findOne({ _id: id });
+  expect(doc?.status).toBe("changes_requested");
+  expect(doc?.reviewNote).toBe("Zeitraum korrigieren");
+  expect(doc?.isSharedLink).toBe(true);
+  expect(sendChangesRequestedEmail).toHaveBeenCalledWith(id);
 });
 
 test("remove deletes the signature from S3 and the document", async () => {

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -185,7 +185,43 @@ test.describe.serial("reimbursement flow", () => {
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });
 
-  test("2. Approve expense reimbursement", async () => {
+  test("2. Request changes and resubmit an expense reimbursement", async () => {
+    const expenseRow = page.locator("table tbody tr").first();
+    await expenseRow
+      .getByRole("button", { name: "Änderungen anfordern" })
+      .click();
+    await page
+      .getByRole("textbox", { name: "Benötigte Änderungen..." })
+      .fill("Bitte Beschreibung präzisieren");
+    await page.getByRole("button", { name: "Änderungen anfordern" }).click();
+
+    await expect(
+      page.getByText("Änderung: Bitte Beschreibung präzisieren"),
+    ).toBeVisible();
+    await expect(expenseRow.getByText("Änderungen angefordert")).toBeVisible();
+
+    await expenseRow.click();
+    await expect(page).toHaveURL(/\/reimbursements\/[^/]+$/);
+    const reimbursementId = page.url().split("/").pop();
+    await page.goto(`/erstattung/${reimbursementId}`);
+
+    await expect(
+      page.getByText("Bitte Beschreibung präzisieren"),
+    ).toBeVisible();
+    await expect(page.getByText("Test Firma")).toBeVisible();
+    await page.getByRole("checkbox").check();
+    await page.getByRole("button", { name: "Einreichen" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Erfolgreich eingereicht" }),
+    ).toBeVisible();
+
+    await page.goto("/reimbursements");
+    await expect(
+      page.locator("table tbody tr").first().getByText("Ausstehend"),
+    ).toBeVisible();
+  });
+
+  test("3. Approve expense reimbursement", async () => {
     await page
       .locator("table tbody tr")
       .first()
@@ -196,7 +232,7 @@ test.describe.serial("reimbursement flow", () => {
     ).toBeVisible();
   });
 
-  test("3. Create travel reimbursement with PDF receipt", async () => {
+  test("4. Create travel reimbursement with PDF receipt", async () => {
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
 
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
@@ -289,7 +325,7 @@ test.describe.serial("reimbursement flow", () => {
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });
 
-  test("4. Filter reimbursements by type", async () => {
+  test("5. Filter reimbursements by type", async () => {
     const tableRows = page.locator("table tbody tr");
 
     await expect(tableRows).toHaveCount(2);
@@ -329,7 +365,7 @@ test.describe.serial("reimbursement flow", () => {
     await expect(tableRows).toHaveCount(2);
   });
 
-  test("5. Reject travel reimbursement", async () => {
+  test("6. Reject travel reimbursement", async () => {
     await page
       .locator("table tbody tr")
       .first()
@@ -345,6 +381,81 @@ test.describe.serial("reimbursement flow", () => {
     });
     await expect(
       page.locator("table tbody tr").first().getByText("Abgelehnt"),
+    ).toBeVisible();
+  });
+
+  test("7. Request changes and resubmit a volunteer allowance", async () => {
+    await page.getByRole("button", { name: "Neue Erstattung" }).click();
+    await expect(page).toHaveURL(/\/reimbursements\/new$/);
+    await expect(
+      page.getByRole("heading", { name: "Reiseangaben" }),
+    ).toBeVisible();
+    const allowanceTab = page.getByRole("tab", { name: "Ehrenamtspauschale" });
+    await allowanceTab.click();
+    await expect(allowanceTab).toHaveAttribute("data-state", "active");
+    await expect(
+      page.getByRole("heading", { name: "Persönliche Daten" }),
+    ).toBeVisible();
+    await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
+    await page.getByRole("button", { name: "Test Projekt" }).click();
+
+    await page.getByPlaceholder("Vor- und Nachname").first().fill("Test User");
+    await page.getByPlaceholder("Musterstraße 123").fill("Teststraße 1");
+    await page.getByPlaceholder("12345").fill("10115");
+    await page.getByPlaceholder("Musterstadt").fill("Berlin");
+    await page
+      .getByPlaceholder("z.B. Übungsleiter, Jugendarbeit, Vorstandstätigkeit")
+      .fill("Vorstandsarbeit");
+    await page
+      .getByRole("textbox", { name: "TT.MM.JJJJ" })
+      .first()
+      .fill("01.01.2026");
+    await page
+      .getByRole("textbox", { name: "TT.MM.JJJJ" })
+      .nth(1)
+      .fill("31.01.2026");
+    await page.getByPlaceholder("0,00").fill("120");
+    await page.getByRole("checkbox").check();
+    await addSignature(page);
+    await page
+      .getByRole("button", { name: "Zur Genehmigung einreichen" })
+      .click();
+    await expect(
+      page.getByText("Ehrenamtspauschale eingereicht"),
+    ).toBeVisible();
+
+    const allowanceRow = page
+      .locator("table tbody tr")
+      .filter({ hasText: "Ehrenamtspauschale" });
+    await allowanceRow
+      .getByRole("button", { name: "Änderungen anfordern" })
+      .click();
+    await page
+      .getByRole("textbox", { name: "Benötigte Änderungen..." })
+      .fill("Bitte Zeitraum prüfen");
+    await page.getByRole("button", { name: "Änderungen anfordern" }).click();
+    await expect(
+      allowanceRow.getByText("Änderungen angefordert"),
+    ).toBeVisible();
+
+    await allowanceRow.getByRole("button", { name: "Bearbeiten" }).click();
+    await expect(page).toHaveURL(/\/ehrenamtspauschale\/[^/]+$/);
+    await expect(page.getByText("Bitte Zeitraum prüfen")).toBeVisible();
+    await expect(page.getByPlaceholder("Musterstraße 123")).toHaveValue(
+      "Teststraße 1",
+    );
+    await page.getByRole("checkbox").check();
+    await page.getByRole("button", { name: "Einreichen" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Erfolgreich eingereicht" }),
+    ).toBeVisible();
+
+    await page.goto("/reimbursements");
+    await expect(
+      page
+        .locator("table tbody tr")
+        .filter({ hasText: "Ehrenamtspauschale" })
+        .getByText("Ausstehend"),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## summary
- Add Brevo request, receipt, revision, approval, and rejection emails for reimbursements and volunteer allowances.
- Let finance request changes and let applicants edit and resubmit existing forms through secure shared links.
- Add direct email invitations and lazy-load HEIC conversion so public forms render server-side.

## validation
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run` (78 tests)
- `pnpm build`
- `pnpm exec playwright test` (7 tests)
- `git diff --name-only -z origin/main...HEAD | xargs -0 pnpm exec biome lint --max-diagnostics=100`
- `pnpm run lint:lines`