### PR TITLE
feat(reimbursements): group row actions in menus

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -96,7 +96,7 @@ export function ReimbursementTable({
             <TableHead className="text-right">Betrag</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>Bearbeitet von</TableHead>
-            <TableHead className="text-right" />
+            <TableHead className="w-12 text-right" />
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   ExternalLink,
   MessageSquareWarning,
+  MoreHorizontal,
   Pencil,
   Trash2,
   X,
@@ -11,6 +12,13 @@ import {
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
 import { formatDate } from "@/lib/formatters/formatDate";
@@ -63,6 +71,8 @@ export function ReimbursementRow({
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
   const isPending = item.status === "pending";
+  const showReviewActions = canManageReimbursements && isPending;
+  const showEditAction = canEdit && item.status === "changes_requested";
 
   return (
     <TableRow
@@ -120,77 +130,60 @@ export function ReimbursementRow({
       <TableCell className="max-w-48 truncate text-muted-foreground">
         {item.reviewedByName ?? "–"}
       </TableCell>
-      <TableCell onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-end gap-0.5">
-          {canManageReimbursements && isPending ? (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-green-600 hover:text-green-700 hover:bg-green-50"
-                onClick={onApprove}
-                aria-label="Genehmigen"
-                title="Genehmigen"
-              >
-                <Check className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-orange-600 hover:bg-orange-50 hover:text-orange-700"
-                onClick={onRequestChanges}
-                aria-label="Änderungen anfordern"
-                title="Änderungen anfordern"
-              >
-                <MessageSquareWarning className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-red-600 hover:text-red-700 hover:bg-red-50"
-                onClick={onReject}
-                aria-label="Ablehnen"
-                title="Ablehnen"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </>
-          ) : null}
-          {canEdit && item.status === "changes_requested" ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 border-orange-200 px-2 text-orange-700 hover:bg-orange-50 hover:text-orange-800"
-              onClick={onEdit}
-            >
-              <Pencil className="h-4 w-4" />
-              Bearbeiten
-            </Button>
-          ) : null}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2"
-            onClick={onOpen}
-            aria-label="PDF in neuem Tab öffnen"
-            title="PDF in neuem Tab öffnen"
-          >
-            <ExternalLink className="h-4 w-4" />
-            Öffnen
-          </Button>
-          {canManageReimbursements && isPending ? (
+      <TableCell
+        className="w-12 text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={onDelete}
-              aria-label="Löschen"
-              title="Löschen"
+              size="icon-sm"
+              aria-label="Aktionen anzeigen"
+              title="Aktionen anzeigen"
             >
-              <Trash2 className="h-4 w-4" />
+              <MoreHorizontal className="size-4" />
             </Button>
-          ) : null}
-        </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            {showReviewActions ? (
+              <>
+                <DropdownMenuItem onSelect={onApprove}>
+                  <Check className="text-green-600" />
+                  Genehmigen
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={onRequestChanges}>
+                  <MessageSquareWarning className="text-orange-600" />
+                  Änderungen anfordern
+                </DropdownMenuItem>
+                <DropdownMenuItem variant="destructive" onSelect={onReject}>
+                  <X />
+                  Ablehnen
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            ) : null}
+            {showEditAction ? (
+              <DropdownMenuItem onSelect={onEdit}>
+                <Pencil />
+                Bearbeiten
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem onSelect={onOpen}>
+              <ExternalLink />
+              Öffnen
+            </DropdownMenuItem>
+            {showReviewActions ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+                  <Trash2 />
+                  Löschen
+                </DropdownMenuItem>
+              </>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </TableCell>
     </TableRow>
   );

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 const TEST_EMAIL = "reimbursement@test.com";
 const IMAGE_FILE = path.join(__dirname, "files/test-invoice.jpg");
@@ -58,6 +58,11 @@ async function addSignature(page: Page) {
     throw new Error(`Unterschrift fehlgeschlagen: ${await failed.innerText()}`);
   }
   await expect(saved.locator("..").locator(".animate-spin")).toHaveCount(0);
+}
+
+async function selectRowAction(page: Page, row: Locator, action: string) {
+  await row.getByRole("button", { name: "Aktionen anzeigen" }).click();
+  await page.getByRole("menuitem", { name: action, exact: true }).click();
 }
 
 test.describe.serial("reimbursement flow", () => {
@@ -187,9 +192,7 @@ test.describe.serial("reimbursement flow", () => {
 
   test("2. Request changes and resubmit an expense reimbursement", async () => {
     const expenseRow = page.locator("table tbody tr").first();
-    await expenseRow
-      .getByRole("button", { name: "Änderungen anfordern" })
-      .click();
+    await selectRowAction(page, expenseRow, "Änderungen anfordern");
     await page
       .getByRole("textbox", { name: "Benötigte Änderungen..." })
       .fill("Bitte Beschreibung präzisieren");
@@ -222,11 +225,11 @@ test.describe.serial("reimbursement flow", () => {
   });
 
   test("3. Approve expense reimbursement", async () => {
-    await page
-      .locator("table tbody tr")
-      .first()
-      .getByRole("button", { name: "Genehmigen" })
-      .click();
+    await selectRowAction(
+      page,
+      page.locator("table tbody tr").first(),
+      "Genehmigen",
+    );
     await expect(
       page.getByRole("table").getByText("Genehmigt", { exact: true }),
     ).toBeVisible();
@@ -366,11 +369,11 @@ test.describe.serial("reimbursement flow", () => {
   });
 
   test("6. Reject travel reimbursement", async () => {
-    await page
-      .locator("table tbody tr")
-      .first()
-      .getByRole("button", { name: "Ablehnen" })
-      .click();
+    await selectRowAction(
+      page,
+      page.locator("table tbody tr").first(),
+      "Ablehnen",
+    );
     await page
       .getByRole("textbox", { name: "Grund für die Ablehnung..." })
       .fill("Falsche Angaben");
@@ -427,9 +430,7 @@ test.describe.serial("reimbursement flow", () => {
     const allowanceRow = page
       .locator("table tbody tr")
       .filter({ hasText: "Ehrenamtspauschale" });
-    await allowanceRow
-      .getByRole("button", { name: "Änderungen anfordern" })
-      .click();
+    await selectRowAction(page, allowanceRow, "Änderungen anfordern");
     await page
       .getByRole("textbox", { name: "Benötigte Änderungen..." })
       .fill("Bitte Zeitraum prüfen");
@@ -438,7 +439,7 @@ test.describe.serial("reimbursement flow", () => {
       allowanceRow.getByText("Änderungen angefordert"),
     ).toBeVisible();
 
-    await allowanceRow.getByRole("button", { name: "Bearbeiten" }).click();
+    await selectRowAction(page, allowanceRow, "Bearbeiten");
     await expect(page).toHaveURL(/\/ehrenamtspauschale\/[^/]+$/);
     await expect(page.getByText("Bitte Zeitraum prüfen")).toBeVisible();
     await expect(page.getByPlaceholder("Musterstraße 123")).toHaveValue(


### PR DESCRIPTION
## summary

- replace crowded reimbursement row controls with an accessible three-dot action menu
- preserve status-based permissions and update the reimbursement browser flow for menu interactions

## validation

- `pnpm exec prettier --check app/components/Tables/Reimbursements/ReimbursementRow.tsx app/(protected)/reimbursements/ReimbursementTable.tsx e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Tables/Reimbursements/ReimbursementRow.tsx app/(protected)/reimbursements/ReimbursementTable.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm vitest run`
- `pnpm exec playwright test e2e/reimbursements.spec.ts`
- `pnpm build`