### PR TITLE
feat(auth): add people and culture permissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ pnpm exec playwright test e2e/reimbursements.spec.ts
 - `purpose-operations` (Zweckbetrieb)
 - `commercial-operations` (Wirtschaftlicher Geschäftsbetrieb)
 
-**User Roles:** `admin`, `finance`, `member`
+**User Roles:** `admin`, `finance`, `people_culture`, `member`
 
 ## Testing
 

--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { auth } from "@/lib/auth";
+import { hasPermission, USER_PERMISSIONS } from "@/lib/auth/roles";
 import { formatDateTime } from "@/lib/formatters/formatDateTime";
 import { getLogs } from "@/lib/server/logs/data";
 import { ScrollText } from "lucide-react";
@@ -39,7 +40,7 @@ const ACTION_LABELS: Record<string, string> = {
 
 export default async function LogsPage() {
   const session = await auth();
-  if (session?.user?.role !== "admin") {
+  if (!hasPermission(session?.user?.role, USER_PERMISSIONS.auditLogs)) {
     return <AccessDenied title="Logs" />;
   }
 

--- a/app/(protected)/settings/organization/page.tsx
+++ b/app/(protected)/settings/organization/page.tsx
@@ -1,11 +1,14 @@
 import { AccessDenied } from "@/components/Settings/AccessDenied";
 import { auth } from "@/lib/auth";
+import { hasPermission, USER_PERMISSIONS } from "@/lib/auth/roles";
 import { getOrganization } from "@/lib/server/organizations/data";
 import { OrganizationClient } from "./OrganizationClient";
 
 export default async function OrganizationSettingsPage() {
   const session = await auth();
-  if (session?.user?.role !== "admin") {
+  if (
+    !hasPermission(session?.user?.role, USER_PERMISSIONS.organizationSettings)
+  ) {
     return <AccessDenied title="Organisation" />;
   }
 

--- a/app/(protected)/settings/projects/page.tsx
+++ b/app/(protected)/settings/projects/page.tsx
@@ -1,10 +1,11 @@
 import { AccessDenied } from "@/components/Settings/AccessDenied";
 import { auth } from "@/lib/auth";
+import { hasPermission, USER_PERMISSIONS } from "@/lib/auth/roles";
 import { ProjectsClient } from "./ProjectsClient";
 
 export default async function ProjectsPage() {
   const session = await auth();
-  if (session?.user?.role !== "admin") {
+  if (!hasPermission(session?.user?.role, USER_PERMISSIONS.projects)) {
     return <AccessDenied title="Projekte" />;
   }
 

--- a/app/(protected)/settings/users/page.tsx
+++ b/app/(protected)/settings/users/page.tsx
@@ -1,11 +1,12 @@
 import { AccessDenied } from "@/components/Settings/AccessDenied";
 import { auth } from "@/lib/auth";
+import { hasPermission, USER_PERMISSIONS } from "@/lib/auth/roles";
 import { listOrganizationUsers } from "@/lib/server/users/data";
 import { UsersClient } from "./UsersClient";
 
 export default async function UsersPage() {
   const session = await auth();
-  if (session?.user?.role !== "admin") {
+  if (!hasPermission(session?.user?.role, USER_PERMISSIONS.roles)) {
     return <AccessDenied title="Benutzer" />;
   }
 

--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -10,7 +10,12 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useIsAdmin } from "@/lib/hooks/useCurrentUserRole";
+import {
+  hasPermission,
+  USER_PERMISSIONS,
+  type UserPermission,
+} from "@/lib/auth/roles";
+import { useCurrentUserRole } from "@/lib/hooks/useCurrentUserRole";
 import {
   Sidebar,
   SidebarContent,
@@ -28,15 +33,40 @@ const NAV_ITEMS: NavItem[] = [
   { name: "Erstattungen", url: "/reimbursements", icon: Coins },
 ];
 
-const ADMIN_NAV_ITEMS: NavItem[] = [
-  { name: "Organisation", url: "/settings/organization", icon: Building2 },
-  { name: "Benutzer", url: "/settings/users", icon: Users },
-  { name: "Projekte", url: "/settings/projects", icon: FolderKanban },
-  { name: "Logs", url: "/settings/logs", icon: ScrollText },
+type ProtectedNavItem = NavItem & { permission: UserPermission };
+
+const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
+  {
+    name: "Organisation",
+    url: "/settings/organization",
+    icon: Building2,
+    permission: USER_PERMISSIONS.organizationSettings,
+  },
+  {
+    name: "Benutzer",
+    url: "/settings/users",
+    icon: Users,
+    permission: USER_PERMISSIONS.roles,
+  },
+  {
+    name: "Projekte",
+    url: "/settings/projects",
+    icon: FolderKanban,
+    permission: USER_PERMISSIONS.projects,
+  },
+  {
+    name: "Logs",
+    url: "/settings/logs",
+    icon: ScrollText,
+    permission: USER_PERMISSIONS.auditLogs,
+  },
 ];
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
-  const isAdmin = useIsAdmin();
+  const role = useCurrentUserRole();
+  const administrationItems = ADMINISTRATION_NAV_ITEMS.filter(
+    ({ permission }) => hasPermission(role, permission),
+  );
 
   return (
     <Sidebar variant="sidebar" collapsible="icon" {...props}>
@@ -56,7 +86,9 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <MainNav items={NAV_ITEMS} />
-        {isAdmin && <MainNav items={ADMIN_NAV_ITEMS} label="Verwaltung" />}
+        {administrationItems.length > 0 && (
+          <MainNav items={administrationItems} label="Verwaltung" />
+        )}
       </SidebarContent>
       <SidebarFooter>
         <NavUser />

--- a/app/components/Tables/Users/UserRow.tsx
+++ b/app/components/Tables/Users/UserRow.tsx
@@ -48,12 +48,13 @@ export function UserRow({ user, onRoleChange, isAdmin, isUpdating }: Props) {
           onValueChange={(value) => onRoleChange(user._id, value as UserRole)}
           disabled={!isAdmin || isUpdating}
         >
-          <SelectTrigger className="w-[140px]">
+          <SelectTrigger className="w-[180px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="admin">Admin</SelectItem>
             <SelectItem value="finance">Finance</SelectItem>
+            <SelectItem value="people_culture">People &amp; Culture</SelectItem>
             <SelectItem value="member">Mitglied</SelectItem>
           </SelectContent>
         </Select>

--- a/app/lib/auth/config.test.ts
+++ b/app/lib/auth/config.test.ts
@@ -51,4 +51,34 @@ describe("auth config", () => {
       role: "finance",
     });
   });
+
+  it("keeps the People & Culture role in the session", () => {
+    const session = { user: { id: "", role: undefined }, expires: "later" };
+
+    const result = authConfig.callbacks.session({
+      session,
+      token: {
+        userId: "user-id",
+        organizationId: "organization-id",
+        role: "people_culture",
+      },
+    } as unknown as Parameters<typeof authConfig.callbacks.session>[0]);
+
+    expect(result.user).toMatchObject({
+      id: "user-id",
+      organizationId: "organization-id",
+      role: "people_culture",
+    });
+  });
+
+  it("limits invalid session roles to member access", () => {
+    const session = { user: { id: "", role: undefined }, expires: "later" };
+
+    const result = authConfig.callbacks.session({
+      session,
+      token: { userId: "user-id", role: "invalid" },
+    } as unknown as Parameters<typeof authConfig.callbacks.session>[0]);
+
+    expect(result.user.role).toBe("member");
+  });
 });

--- a/app/lib/auth/roles.test.ts
+++ b/app/lib/auth/roles.test.ts
@@ -1,15 +1,70 @@
-import { expect, test } from "vitest";
-import { hasMinimumRole, normalizeUserRole } from "./roles";
+import { describe, expect, test } from "vitest";
+import type { UserRole } from "../db/types";
+import {
+  hasPermission,
+  hasRoleAccess,
+  normalizeOptionalUserRole,
+  normalizeUserRole,
+  USER_PERMISSIONS,
+  type UserPermission,
+} from "./roles";
 
-test("unknown roles default to member access", () => {
-  expect(normalizeUserRole("unknown")).toBe("member");
+const roles: UserRole[] = ["member", "finance", "people_culture", "admin"];
+
+const expectedRoleAccess: Record<UserRole, UserRole[]> = {
+  member: ["member"],
+  finance: ["member", "finance"],
+  people_culture: ["member", "people_culture"],
+  admin: roles,
+};
+
+const permissions = Object.values(USER_PERMISSIONS);
+const expectedPermissions: Record<UserRole, UserPermission[]> = {
+  member: [],
+  finance: [USER_PERMISSIONS.finance],
+  people_culture: [
+    USER_PERMISSIONS.recruiting,
+    USER_PERMISSIONS.members,
+    USER_PERMISSIONS.organizationStructure,
+  ],
+  admin: permissions,
+};
+
+test.each(roles)("normalizes the supported %s role", (role) => {
+  expect(normalizeUserRole(role)).toBe(role);
 });
 
-test("finance can manage reimbursements without admin access", () => {
-  expect(hasMinimumRole("finance", "finance")).toBe(true);
-  expect(hasMinimumRole("finance", "admin")).toBe(false);
+test.each(["unknown", "ADMIN", "", 1, null, undefined])(
+  "normalizes invalid role %j to member",
+  (role) => {
+    expect(normalizeUserRole(role)).toBe("member");
+  },
+);
+
+test("keeps an absent optional role absent", () => {
+  expect(normalizeOptionalUserRole(undefined)).toBeUndefined();
+  expect(normalizeOptionalUserRole(null)).toBeUndefined();
+  expect(normalizeOptionalUserRole("invalid")).toBe("member");
 });
 
-test("admin inherits finance access", () => {
-  expect(hasMinimumRole("admin", "finance")).toBe(true);
+describe.each(roles)("%s role access", (role) => {
+  test.each(roles)("required role %s", (requiredRole) => {
+    expect(hasRoleAccess(role, requiredRole)).toBe(
+      expectedRoleAccess[role].includes(requiredRole),
+    );
+  });
+});
+
+describe.each(roles)("%s permissions", (role) => {
+  test.each(permissions)("permission %s", (permission) => {
+    expect(hasPermission(role, permission)).toBe(
+      expectedPermissions[role].includes(permission),
+    );
+  });
+});
+
+test("unknown roles only receive member permissions", () => {
+  expect(hasPermission("unknown", USER_PERMISSIONS.finance)).toBe(false);
+  expect(hasRoleAccess("unknown", "member")).toBe(true);
+  expect(hasRoleAccess("unknown", "finance")).toBe(false);
 });

--- a/app/lib/auth/roles.ts
+++ b/app/lib/auth/roles.ts
@@ -1,15 +1,55 @@
 import type { UserRole } from "../db/types";
 
-const roleHierarchy: Record<UserRole, number> = {
-  member: 0,
-  finance: 1,
-  admin: 2,
+export type UserPermission =
+  | "manage_finance"
+  | "manage_recruiting"
+  | "manage_members"
+  | "manage_organization_structure"
+  | "manage_roles"
+  | "manage_organization_settings"
+  | "manage_projects"
+  | "view_audit_logs";
+
+const rolePermissions: Record<UserRole, readonly UserPermission[]> = {
+  member: [],
+  finance: ["manage_finance"],
+  people_culture: [
+    "manage_recruiting",
+    "manage_members",
+    "manage_organization_structure",
+  ],
+  admin: [
+    "manage_finance",
+    "manage_recruiting",
+    "manage_members",
+    "manage_organization_structure",
+    "manage_roles",
+    "manage_organization_settings",
+    "manage_projects",
+    "view_audit_logs",
+  ],
 };
 
+const validRoles = new Set<UserRole>([
+  "admin",
+  "finance",
+  "people_culture",
+  "member",
+]);
+
+export const USER_PERMISSIONS = {
+  finance: "manage_finance",
+  recruiting: "manage_recruiting",
+  members: "manage_members",
+  organizationStructure: "manage_organization_structure",
+  roles: "manage_roles",
+  organizationSettings: "manage_organization_settings",
+  projects: "manage_projects",
+  auditLogs: "view_audit_logs",
+} as const satisfies Record<string, UserPermission>;
+
 export function normalizeUserRole(role: unknown): UserRole {
-  if (role === "admin") return "admin";
-  if (role === "finance") return "finance";
-  return "member";
+  return validRoles.has(role as UserRole) ? (role as UserRole) : "member";
 }
 
 export function normalizeOptionalUserRole(role: unknown): UserRole | undefined {
@@ -17,6 +57,18 @@ export function normalizeOptionalUserRole(role: unknown): UserRole | undefined {
   return normalizeUserRole(role);
 }
 
-export function hasMinimumRole(role: UserRole, minimumRole: UserRole): boolean {
-  return roleHierarchy[role] >= roleHierarchy[minimumRole];
+export function hasRoleAccess(role: unknown, requiredRole: UserRole): boolean {
+  if (requiredRole === "member") return true;
+  if (requiredRole === "admin") return normalizeUserRole(role) === "admin";
+  if (requiredRole === "finance") {
+    return hasPermission(role, USER_PERMISSIONS.finance);
+  }
+  return hasPermission(role, USER_PERMISSIONS.recruiting);
+}
+
+export function hasPermission(
+  role: unknown,
+  permission: UserPermission,
+): boolean {
+  return rolePermissions[normalizeUserRole(role)].includes(permission);
 }

--- a/app/lib/auth/session.test.ts
+++ b/app/lib/auth/session.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  findOne: vi.fn(),
+}));
+
+vi.mock("./index", () => ({ auth: mocks.auth }));
+vi.mock("../db/collections", () => ({
+  users: vi.fn(async () => ({ findOne: mocks.findOne })),
+}));
+
+import { requirePermission, requireRole } from "./session";
+
+beforeEach(() => {
+  mocks.auth.mockResolvedValue({ user: { id: "user-id" } });
+  mocks.findOne.mockReset();
+});
+
+test("People & Culture only passes its own elevated role guard", async () => {
+  mocks.findOne.mockResolvedValue({
+    _id: "user-id",
+    organizationId: "organization-id",
+    role: "people_culture",
+  });
+
+  await expect(requireRole("people_culture")).resolves.toMatchObject({
+    role: "people_culture",
+  });
+  await expect(requireRole("finance")).rejects.toThrow(
+    "Insufficient permissions",
+  );
+  await expect(requireRole("admin")).rejects.toThrow(
+    "Insufficient permissions",
+  );
+  await expect(requirePermission("manage_roles")).rejects.toThrow(
+    "Insufficient permissions",
+  );
+  await expect(
+    requirePermission("manage_organization_settings"),
+  ).rejects.toThrow("Insufficient permissions");
+});
+
+test("admin passes People & Culture and finance permission guards", async () => {
+  mocks.findOne.mockResolvedValue({
+    _id: "user-id",
+    organizationId: "organization-id",
+    role: "admin",
+  });
+
+  await expect(requirePermission("manage_recruiting")).resolves.toBeDefined();
+  await expect(requirePermission("manage_finance")).resolves.toBeDefined();
+});
+
+test("invalid persisted roles safely receive member access", async () => {
+  mocks.findOne.mockResolvedValue({
+    _id: "user-id",
+    organizationId: "organization-id",
+    role: "invalid",
+  });
+
+  await expect(requireRole("member")).resolves.toMatchObject({
+    role: "member",
+  });
+  await expect(requirePermission("manage_members")).rejects.toThrow(
+    "Insufficient permissions",
+  );
+});

--- a/app/lib/auth/session.ts
+++ b/app/lib/auth/session.ts
@@ -1,7 +1,12 @@
 import { users } from "../db/collections";
 import type { UserRole } from "../db/types";
 import { auth } from "./index";
-import { hasMinimumRole, normalizeUserRole } from "./roles";
+import {
+  hasRoleAccess,
+  hasPermission,
+  normalizeUserRole,
+  type UserPermission,
+} from "./roles";
 
 export async function requireAuthenticatedUser() {
   const session = await auth();
@@ -22,10 +27,20 @@ export async function requireUser() {
   return { ...user, organizationId: user.organizationId, role };
 }
 
-export async function requireRole(minRole: UserRole) {
+export async function requireRole(requiredRole: UserRole) {
   const user = await requireUser();
-  if (!hasMinimumRole(user.role, minRole)) {
-    throw new Error(`Insufficient permissions. Required role: ${minRole}`);
+  if (!hasRoleAccess(user.role, requiredRole)) {
+    throw new Error(`Insufficient permissions. Required role: ${requiredRole}`);
+  }
+  return user;
+}
+
+export async function requirePermission(permission: UserPermission) {
+  const user = await requireUser();
+  if (!hasPermission(user.role, permission)) {
+    throw new Error(
+      `Insufficient permissions. Required permission: ${permission}`,
+    );
   }
   return user;
 }

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -1,4 +1,4 @@
-export type UserRole = "admin" | "finance" | "member";
+export type UserRole = "admin" | "finance" | "people_culture" | "member";
 export type ReimbursementType = "expense" | "travel";
 export type ReviewStatus =
   | "pending"

--- a/app/lib/hooks/useCurrentUserRole.ts
+++ b/app/lib/hooks/useCurrentUserRole.ts
@@ -1,12 +1,16 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { hasMinimumRole } from "../auth/roles";
+import {
+  hasPermission,
+  normalizeUserRole,
+  USER_PERMISSIONS,
+} from "../auth/roles";
 import type { UserRole } from "../db/types";
 
 export function useCurrentUserRole(): UserRole {
   const { data } = useSession();
-  return (data?.user?.role as UserRole) ?? "member";
+  return normalizeUserRole(data?.user?.role);
 }
 
 export function useIsAdmin(): boolean {
@@ -16,5 +20,5 @@ export function useIsAdmin(): boolean {
 
 export function useCanManageReimbursements(): boolean {
   const role = useCurrentUserRole();
-  return hasMinimumRole(role, "finance");
+  return hasPermission(role, USER_PERMISSIONS.finance);
 }

--- a/app/lib/server/reimbursements/actionsHelpers.ts
+++ b/app/lib/server/reimbursements/actionsHelpers.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import { hasMinimumRole } from "../../auth/roles";
+import { hasPermission, USER_PERMISSIONS } from "../../auth/roles";
 import { reimbursements, travelDetails } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { UserRole } from "../../db/types";
@@ -74,7 +74,10 @@ export async function deleteReimbursementById(
     throw new Error("Reimbursement not found");
   }
 
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
   if (reimbursement.createdBy !== user._id && !canManageReimbursements) {
     throw new Error("Only the creator or finance can delete reimbursements");
   }

--- a/app/lib/server/reimbursements/data.ts
+++ b/app/lib/server/reimbursements/data.ts
@@ -1,4 +1,4 @@
-import { hasMinimumRole } from "../../auth/roles";
+import { hasPermission, USER_PERMISSIONS } from "../../auth/roles";
 import { isTestMode } from "../../auth/environment";
 import { requireUser } from "../../auth/session";
 import {
@@ -32,7 +32,10 @@ export async function getReimbursement(reimbursementId: string): Promise<
   | null
 > {
   const user = await requireUser();
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
   const reimbursement = await (
     await reimbursements()
   ).findOne({
@@ -57,7 +60,10 @@ export async function getReimbursement(reimbursementId: string): Promise<
 
 export async function getReceipts(reimbursementId: string): Promise<Receipt[]> {
   const user = await requireUser();
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
   const reimbursement = await (
     await reimbursements()
   ).findOne({
@@ -100,7 +106,10 @@ export async function getAllReimbursements(): Promise<
   >
 > {
   const user = await requireUser();
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
 
   const scope = canManageReimbursements
     ? { organizationId: user.organizationId }

--- a/app/lib/server/users/actions.ts
+++ b/app/lib/server/users/actions.ts
@@ -7,7 +7,7 @@ import type { UserRole } from "../../db/types";
 import { addLog } from "../logs";
 import { bankDetailsSchema } from "../bankDetails";
 
-const roleSchema = z.enum(["admin", "finance", "member"]);
+const roleSchema = z.enum(["admin", "finance", "people_culture", "member"]);
 
 export async function addUserToOrganization(input: {
   userId: string;

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -102,6 +102,12 @@ test("updateUserRole grants finance access without admin access", async () => {
   expect(updated?.role).toBe("finance");
 });
 
+test("updateUserRole supports the People & Culture role", async () => {
+  await updateUserRole({ userId: memberA, role: "people_culture" });
+  const updated = await (await users()).findOne({ _id: memberA });
+  expect(updated?.role).toBe("people_culture");
+});
+
 test("updateUserRole cannot touch a user from another org", async () => {
   await expect(updateUserRole({ userId: memberB, role: "admin" })).rejects.toThrow(
     "Access denied",

--- a/app/lib/server/volunteerAllowance/actions.ts
+++ b/app/lib/server/volunteerAllowance/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { z } from "zod";
-import { hasMinimumRole } from "../../auth/roles";
+import { hasPermission, USER_PERMISSIONS } from "../../auth/roles";
 import { requireUser } from "../../auth/session";
 import { volunteerAllowance } from "../../db/collections";
 import { newId } from "../../db/ids";
@@ -101,7 +101,10 @@ export async function remove(input: { id: string }): Promise<void> {
   if (!doc || doc.organizationId !== user.organizationId) {
     throw new Error("Not found");
   }
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
   if (doc.createdBy !== user._id && !canManageReimbursements) {
     throw new Error("Only the creator or finance can delete");
   }

--- a/app/lib/server/volunteerAllowance/data.ts
+++ b/app/lib/server/volunteerAllowance/data.ts
@@ -1,4 +1,4 @@
-import { hasMinimumRole } from "../../auth/roles";
+import { hasPermission, USER_PERMISSIONS } from "../../auth/roles";
 import { requireUser } from "../../auth/session";
 import {
   organizations,
@@ -26,7 +26,10 @@ export type VolunteerAllowanceWithNames = VolunteerAllowance & {
 
 export async function getAll(): Promise<VolunteerAllowanceWithNames[]> {
   const user = await requireUser();
-  const canManageReimbursements = hasMinimumRole(user.role, "finance");
+  const canManageReimbursements = hasPermission(
+    user.role,
+    USER_PERMISSIONS.finance,
+  );
 
   const filter = canManageReimbursements
     ? { organizationId: user.organizationId }

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -17,7 +17,8 @@ keeps authentication, authorization and organization isolation on the server.
 
 - Every protected operation requires an authenticated user.
 - Database access is scoped by `organizationId`.
-- Roles distinguish members, finance users and administrators.
+- Explicit role permissions distinguish members, finance, People & Culture and
+  administrators. Unknown roles safely receive member access.
 - Server-side Zod validation protects action and API inputs.
 - Uploaded objects use generated keys and time-limited download URLs.
 - Audit logs record important organization and reimbursement actions.


### PR DESCRIPTION
## summary

- add the exclusive `people_culture` role across sessions, role management, and UI
- replace linear role inheritance with explicit recruiting, member, finance, and administration capabilities
- align server guards and navigation while safely falling unknown roles back to member access

## validation

- `pnpm exec biome lint <19 changed TypeScript files>`
- `pnpm exec tsc --noEmit`
- `pnpm run lint:lines`
- `pnpm exec vitest run` (141 tests)
- `pnpm exec vitest run <6 affected test files>` (98 tests)
- `pnpm build`
- `git diff --check`
- repository-wide `pnpm exec biome check app docs/Security.md` reports pre-existing formatting drift in untouched files; targeted lint passes