### PR TITLE
feat(tally): add environment-backed api client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,7 @@ BREVO_API_KEY=XXXXX
 # Required outside production
 BREVO_RECIPIENT_ALLOWLIST=
 
+# Tally
+TALLY_MASTER_KEY=
+
 IS_TEST=

--- a/app/lib/server/tally/client.test.ts
+++ b/app/lib/server/tally/client.test.ts
@@ -1,0 +1,33 @@
+import { expect, test, vi } from "vitest";
+import { TALLY_API_VERSION } from "../../tally/constants";
+import { createConfiguredTallyClient } from "./client";
+
+function json(value: unknown) {
+  return new Response(JSON.stringify(value), { status: 200 });
+}
+
+test("loads the Tally API token exclusively from the server environment", async () => {
+  const fetcher = vi.fn(
+    async (_input: string | URL | Request, _init?: RequestInit) =>
+      json({ items: [], hasMore: false }),
+  );
+  const client = createConfiguredTallyClient(
+    { TALLY_MASTER_KEY: "  token-from-env  " },
+    fetcher as unknown as typeof fetch,
+  );
+
+  await client.resources();
+
+  expect(fetcher).toHaveBeenCalledTimes(2);
+  for (const call of fetcher.mock.calls) {
+    const headers = new Headers(call[1]?.headers);
+    expect(headers.get("authorization")).toBe("Bearer token-from-env");
+    expect(headers.get("tally-version")).toBe(TALLY_API_VERSION);
+  }
+});
+
+test("rejects a missing Tally API token", () => {
+  expect(() => createConfiguredTallyClient({})).toThrow(
+    "TALLY_MASTER_KEY is not configured",
+  );
+});

--- a/app/lib/server/tally/client.ts
+++ b/app/lib/server/tally/client.ts
@@ -1,0 +1,15 @@
+import { createTallyClient } from "../../tally/client";
+
+type TallyEnvironment = {
+  [key: string]: string | undefined;
+  TALLY_MASTER_KEY?: string;
+};
+
+export function createConfiguredTallyClient(
+  env: TallyEnvironment = process.env,
+  fetcher: typeof fetch = fetch,
+) {
+  const apiToken = env.TALLY_MASTER_KEY?.trim();
+  if (!apiToken) throw new Error("TALLY_MASTER_KEY is not configured");
+  return createTallyClient(apiToken, fetcher);
+}

--- a/app/lib/tally/client.test.ts
+++ b/app/lib/tally/client.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, vi } from "vitest";
+import { createTallyClient } from "./client";
+import { TALLY_API_VERSION } from "./constants";
+
+function json(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function tallyFetch(options?: {
+  requiredPhone?: boolean;
+  workspaceId?: string;
+}) {
+  return vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/workspaces") {
+      return json({
+        items: [{ id: "ws-a", name: "Workspace A" }],
+        hasMore: false,
+      });
+    }
+    if (url.pathname === "/forms") {
+      return json({
+        items: [
+          {
+            id: "form-a",
+            name: "Application",
+            workspaceId: "ws-a",
+            status: "PUBLISHED",
+          },
+        ],
+        hasMore: false,
+      });
+    }
+    if (url.pathname === "/forms/form-a") {
+      return json({
+        id: "form-a",
+        name: "Application",
+        workspaceId: options?.workspaceId ?? "ws-a",
+        status: "PUBLISHED",
+        blocks: options?.requiredPhone
+          ? [{ type: "INPUT_PHONE_NUMBER", payload: { isRequired: true } }]
+          : [],
+      });
+    }
+    if (url.pathname === "/forms/form-a/questions") {
+      return json({
+        questions: [
+          {
+            id: "q-name",
+            title: "Name",
+            type: "INPUT_TEXT",
+            fields: [{ type: "INPUT_TEXT" }],
+          },
+          {
+            id: "q-phone",
+            title: "Telefon",
+            type: "INPUT_PHONE_NUMBER",
+            fields: [{ type: "INPUT_PHONE_NUMBER" }],
+          },
+        ],
+      });
+    }
+    return new Response(null, { status: 404 });
+  });
+}
+
+test("loads resources and questions with a pinned API version", async () => {
+  const fetcher = tallyFetch();
+  const client = createTallyClient(
+    "token-a",
+    fetcher as unknown as typeof fetch,
+  );
+
+  const resources = await client.resources();
+  const questions = await client.questions("ws-a", "form-a");
+
+  expect(resources.workspaces[0]?.name).toBe("Workspace A");
+  expect(questions).toEqual([
+    { id: "q-name", title: "Name", type: "INPUT_TEXT" },
+  ]);
+  for (const call of fetcher.mock.calls) {
+    const headers = new Headers(call[1]?.headers);
+    expect(headers.get("tally-version")).toBe(TALLY_API_VERSION);
+    expect(headers.get("authorization")).toBe("Bearer token-a");
+  }
+});
+
+test("rejects a form outside the selected workspace", async () => {
+  const fetcher = tallyFetch({ workspaceId: "ws-b" });
+  const client = createTallyClient("token", fetcher as unknown as typeof fetch);
+  await expect(client.questions("ws-a", "form-a")).rejects.toThrow(
+    "does not belong to this workspace",
+  );
+});
+
+test("rejects a base form that requires a phone number", async () => {
+  const fetcher = tallyFetch({ requiredPhone: true });
+  const client = createTallyClient("token", fetcher as unknown as typeof fetch);
+  await expect(client.questions("ws-a", "form-a")).rejects.toThrow(
+    "requires a phone number",
+  );
+});
+
+test("requires a Tally API token", () => {
+  expect(() => createTallyClient("")).toThrow("Tally API token is required");
+});

--- a/app/lib/tally/client.ts
+++ b/app/lib/tally/client.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { TALLY_API_VERSION } from "./constants";
+import type {
+  TallyFormSummary,
+  TallyQuestion,
+  TallyResources,
+  TallyWorkspace,
+} from "./types";
+
+const API_URL = "https://api.tally.so";
+const MAX_PAGES = 50;
+const itemSchema = z.object({ id: z.string(), name: z.string() });
+const formSchema = itemSchema.extend({
+  workspaceId: z.string(),
+  status: z.string(),
+});
+const formDetailsSchema = formSchema.extend({
+  blocks: z
+    .array(
+      z.object({
+        type: z.string(),
+        payload: z.record(z.string(), z.unknown()).optional().default({}),
+      }),
+    )
+    .optional()
+    .default([]),
+});
+const pageSchema = <T extends z.ZodType>(item: T) =>
+  z.object({ items: z.array(item), hasMore: z.boolean() });
+const questionSchema = z.object({
+  id: z.string(),
+  title: z.string().optional().default(""),
+  type: z.string(),
+  isDeleted: z.boolean().optional().default(false),
+  fields: z
+    .array(z.object({ type: z.string(), title: z.string().optional() }))
+    .optional()
+    .default([]),
+});
+
+function isAnswerField(type: string): boolean {
+  return ![
+    "FORM_TITLE",
+    "TITLE",
+    "TEXT",
+    "LABEL",
+    "HEADING_1",
+    "HEADING_2",
+    "HEADING_3",
+  ].includes(type);
+}
+
+export function createTallyClient(
+  apiToken: string,
+  fetcher: typeof fetch = fetch,
+) {
+  if (!apiToken) throw new Error("Tally API token is required");
+
+  async function request(path: string): Promise<unknown> {
+    const response = await fetcher(`${API_URL}${path}`, {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Accept: "application/json",
+        "tally-version": TALLY_API_VERSION,
+      },
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Tally API request failed (${response.status})`);
+    }
+    return response.json();
+  }
+
+  async function listPages<T>(
+    path: string,
+    schema: z.ZodType<{ items: T[]; hasMore: boolean }>,
+  ): Promise<T[]> {
+    const items: T[] = [];
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const separator = path.includes("?") ? "&" : "?";
+      const result = schema.parse(
+        await request(`${path}${separator}page=${page}`),
+      );
+      items.push(...result.items);
+      if (!result.hasMore) return items;
+    }
+    throw new Error("Tally API pagination limit exceeded");
+  }
+
+  async function resources(): Promise<TallyResources> {
+    const [workspaces, forms] = await Promise.all([
+      listPages<TallyWorkspace>("/workspaces", pageSchema(itemSchema)),
+      listPages<TallyFormSummary>("/forms?limit=500", pageSchema(formSchema)),
+    ]);
+    return { workspaces, forms };
+  }
+
+  async function questions(
+    workspaceId: string,
+    formId: string,
+  ): Promise<TallyQuestion[]> {
+    const form = formDetailsSchema.parse(await request(`/forms/${formId}`));
+    if (form.workspaceId !== workspaceId) {
+      throw new Error("The selected form does not belong to this workspace");
+    }
+    const requiresPhone = form.blocks.some(
+      (block) =>
+        block.type.includes("PHONE") && block.payload.isRequired === true,
+    );
+    if (requiresPhone) {
+      throw new Error("The selected form requires a phone number");
+    }
+    const result = z
+      .object({ questions: z.array(questionSchema) })
+      .parse(await request(`/forms/${formId}/questions`));
+    return result.questions.flatMap((question) => {
+      const type = question.fields[0]?.type ?? question.type;
+      const isPhone = [
+        question.type,
+        ...question.fields.map((f) => f.type),
+      ].some((fieldType) => fieldType.includes("PHONE"));
+      if (question.isDeleted || isPhone || !isAnswerField(type)) return [];
+      return [{ id: question.id, title: question.title || "Ohne Titel", type }];
+    });
+  }
+
+  return { resources, questions };
+}

--- a/app/lib/tally/constants.ts
+++ b/app/lib/tally/constants.ts
@@ -1,0 +1,1 @@
+export const TALLY_API_VERSION = "2026-02-05";

--- a/app/lib/tally/types.ts
+++ b/app/lib/tally/types.ts
@@ -1,0 +1,22 @@
+export interface TallyWorkspace {
+  id: string;
+  name: string;
+}
+
+export interface TallyFormSummary {
+  id: string;
+  name: string;
+  workspaceId: string;
+  status: string;
+}
+
+export interface TallyQuestion {
+  id: string;
+  title: string;
+  type: string;
+}
+
+export interface TallyResources {
+  workspaces: TallyWorkspace[];
+  forms: TallyFormSummary[];
+}

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -27,6 +27,8 @@ keeps authentication, authorization and organization isolation on the server.
 ## Secrets and deployment
 
 - Credentials belong exclusively in Coolify environment variables.
+- `TALLY_MASTER_KEY` exists only in the server runtime and is never persisted or
+  returned to the browser.
 - `.env` and `.env.local` are ignored by Git.
 - Production email requires `SERVICE_STAGE=production`; non-production email is
   restricted by `BREVO_RECIPIENT_ALLOWLIST`.


### PR DESCRIPTION
## summary

- add a version-pinned Tally API client for workspaces, forms, and questions
- load the production API credential only from `TALLY_MASTER_KEY` and exclude phone fields

## validation

- `pnpm exec prettier --check docs/Security.md app/lib/tally app/lib/server/tally`
- `pnpm exec biome lint app/lib/tally app/lib/server/tally`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run`
- `pnpm lint:lines`
- `pnpm build`