### PR TITLE
fix(reimbursements): match member platform action menu

### DIFF
--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -53,7 +53,7 @@ export function TravelReceiptCard(props: Props) {
           />
         </div>
         <div>
-          <Label>Beleg-/Rechnungsnummer</Label>
+          <Label className="break-all">Beleg-/Rechnungsnummer</Label>
           <Input
             value={receipt.receiptNumber ?? ""}
             onChange={(e) =>

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -43,7 +43,7 @@ export function TravelReceiptCard(props: Props) {
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @3xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:grid-cols-4">
         <div>
           <Label>Name/Firma *</Label>
           <Input

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -55,7 +55,7 @@ export function ReceiptCard({
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @3xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:grid-cols-4">
         <div>
           <Label>Firma/Anbieter *</Label>
           <Input

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -69,7 +69,7 @@ export function ReceiptCard({
           />
         </div>
         <div>
-          <Label>Beleg-/Rechnungsnummer</Label>
+          <Label className="break-all">Beleg-/Rechnungsnummer</Label>
           <Input
             value={receipt.receiptNumber ?? ""}
             onChange={(e) =>

--- a/app/components/Tables/Reimbursements/ReimbursementRow.module.css
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.module.css
@@ -1,0 +1,133 @@
+.menuTrigger {
+  border: none;
+  border-radius: 0.25rem;
+  background-color: transparent;
+  color: var(--foreground);
+  transition: background-color 0.2s ease-out;
+}
+
+.menuTrigger:hover {
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
+.menuTrigger:focus-visible {
+  border-color: transparent;
+  outline: 2px solid;
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+.menuTrigger svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.menuContent {
+  min-width: 220px;
+  max-height: var(--radix-dropdown-menu-content-available-height);
+  padding: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border: none;
+  border-radius: 0.125rem;
+  background-color: var(--background);
+  color: var(--foreground);
+  box-shadow: var(--member-menu-shadow);
+  animation-duration: 400ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+.menuContent > *:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+
+.menuContent[data-side="top"] {
+  animation-name: slide-down-and-fade;
+}
+
+.menuContent[data-side="right"] {
+  animation-name: slide-left-and-fade;
+}
+
+.menuContent[data-side="bottom"] {
+  animation-name: slide-up-and-fade;
+}
+
+.menuContent[data-side="left"] {
+  animation-name: slide-right-and-fade;
+}
+
+.menuItem {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0;
+  color: var(--foreground);
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.menuItem.destructiveMenuItem {
+  color: var(--destructive);
+}
+
+.menuItem[data-highlighted] {
+  background-color: var(--primary);
+  color: #000;
+}
+
+.menuItem svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+@keyframes slide-up-and-fade {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-right-and-fade {
+  from {
+    opacity: 0;
+    transform: translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-down-and-fade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-left-and-fade {
+  from {
+    opacity: 0;
+    transform: translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -16,7 +16,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { TableCell, TableRow } from "@/components/ui/table";
@@ -26,6 +25,7 @@ import {
   STATUS_DISPLAY,
   type ReimbursementStatus as Status,
 } from "@/lib/reimbursementStatus";
+import styles from "./ReimbursementRow.module.css";
 
 interface ReimbursementRowProps {
   item: {
@@ -139,48 +139,57 @@ export function ReimbursementRow({
             <Button
               variant="ghost"
               size="icon-sm"
+              className={styles.menuTrigger}
               aria-label="Aktionen anzeigen"
               title="Aktionen anzeigen"
             >
-              <MoreHorizontal className="size-4" />
+              <MoreHorizontal />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuContent sideOffset={0} className={styles.menuContent}>
             {showReviewActions ? (
               <>
-                <DropdownMenuItem onSelect={onApprove}>
-                  <Check className="text-green-600" />
+                <DropdownMenuItem
+                  className={styles.menuItem}
+                  onSelect={onApprove}
+                >
+                  <Check className="text-current" />
                   Genehmigen
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={onRequestChanges}>
-                  <MessageSquareWarning className="text-orange-600" />
+                <DropdownMenuItem
+                  className={styles.menuItem}
+                  onSelect={onRequestChanges}
+                >
+                  <MessageSquareWarning className="text-current" />
                   Änderungen anfordern
                 </DropdownMenuItem>
-                <DropdownMenuItem variant="destructive" onSelect={onReject}>
-                  <X />
+                <DropdownMenuItem
+                  className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
+                  onSelect={onReject}
+                >
+                  <X className="text-current" />
                   Ablehnen
                 </DropdownMenuItem>
-                <DropdownMenuSeparator />
               </>
             ) : null}
             {showEditAction ? (
-              <DropdownMenuItem onSelect={onEdit}>
-                <Pencil />
+              <DropdownMenuItem className={styles.menuItem} onSelect={onEdit}>
+                <Pencil className="text-current" />
                 Bearbeiten
               </DropdownMenuItem>
             ) : null}
-            <DropdownMenuItem onSelect={onOpen}>
-              <ExternalLink />
+            <DropdownMenuItem className={styles.menuItem} onSelect={onOpen}>
+              <ExternalLink className="text-current" />
               Öffnen
             </DropdownMenuItem>
             {showReviewActions ? (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem variant="destructive" onSelect={onDelete}>
-                  <Trash2 />
-                  Löschen
-                </DropdownMenuItem>
-              </>
+              <DropdownMenuItem
+                className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
+                onSelect={onDelete}
+              >
+                <Trash2 className="text-current" />
+                Löschen
+              </DropdownMenuItem>
             ) : null}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/app/globals.css
+++ b/app/globals.css
@@ -44,6 +44,9 @@
   --shadow-spread: 0rem;
   --shadow-opacity: 0.025;
   --shadow-color: #000000;
+  --member-menu-shadow:
+    0 0 1px rgba(66, 71, 76, 0.32), 0 4px 8px rgba(66, 71, 74, 0.06),
+    0 8px 48px #aaaaaa;
   --shadow-2xs: 0rem 0.125rem 1px 0rem hsl(0 0% 0% / 0.01);
   --shadow-xs: 0rem 0.125rem 1px 0rem hsl(0 0% 0% / 0.01);
   --shadow-sm:
@@ -112,6 +115,9 @@
   --shadow-spread: 0rem;
   --shadow-opacity: 0.025;
   --shadow-color: #ffffff;
+  --member-menu-shadow:
+    0 0 1px rgba(0, 0, 0, 0.6), 0 4px 8px rgba(0, 0, 0, 0.4),
+    0 8px 48px rgba(0, 0, 0, 0.8);
   --shadow-2xs: 0rem 0.125rem 1px 0rem hsl(0 0% 100% / 0.01);
   --shadow-xs: 0rem 0.125rem 1px 0rem hsl(0 0% 100% / 0.01);
   --shadow-sm:

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -190,6 +190,31 @@ test.describe.serial("reimbursement flow", () => {
     await expect(page.getByText("Ausstehend")).toBeVisible();
   });
 
+  test("row action menu matches the member platform", async () => {
+    const actionTrigger = page
+      .locator("table tbody tr")
+      .first()
+      .getByRole("button", { name: "Aktionen anzeigen" });
+
+    await expect(actionTrigger.locator("svg")).toHaveCSS("width", "24px");
+    await expect(actionTrigger).toHaveCSS("border-radius", "4px");
+    await actionTrigger.click();
+
+    const actionMenu = page.getByRole("menu");
+    const firstAction = actionMenu.getByRole("menuitem").first();
+
+    await expect(actionMenu).toHaveCSS("min-width", "220px");
+    await expect(actionMenu).toHaveCSS("padding", "0px");
+    await expect(actionMenu).toHaveCSS("border-radius", "2px");
+    await expect(firstAction).toHaveCSS("gap", "16px");
+    await expect(firstAction).toHaveCSS("padding", "12px 16px");
+    await expect(firstAction).toHaveCSS("font-weight", "500");
+
+    await firstAction.hover();
+    await expect(firstAction).toHaveCSS("background-color", "rgb(255, 237, 0)");
+    await page.keyboard.press("Escape");
+  });
+
   test("2. Request changes and resubmit an expense reimbursement", async () => {
     const expenseRow = page.locator("table tbody tr").first();
     await selectRowAction(page, expenseRow, "Änderungen anfordern");


### PR DESCRIPTION
## summary

- align reimbursement row action menu sizing, spacing, icons, shadows, separators, and interaction states with the member platform
- preserve Radix menu behavior and add dark-theme styling plus a browser regression test
- keep travel receipt fields in two columns longer and allow long labels to wrap without overflow across font renderers

## validation

- `pnpm exec prettier --check app/components/Tables/Reimbursements/ReimbursementRow.tsx app/components/Tables/Reimbursements/ReimbursementRow.module.css app/globals.css e2e/reimbursements.spec.ts`
- `pnpm exec prettier --check app/components/Reimbursements/travelForm/ReceiptCard.tsx app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx`
- `pnpm exec biome lint app/components/Tables/Reimbursements/ReimbursementRow.tsx app/components/Tables/Reimbursements/ReimbursementRow.module.css app/globals.css e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Reimbursements/travelForm/ReceiptCard.tsx app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run` (147 passed)
- `pnpm exec playwright test --reporter=list` (8 passed)
- `pnpm build`