### PR TITLE
fix(reimbursements): show review notes only in details

### DIFF
--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -32,8 +32,6 @@ interface ReimbursementRowProps {
     _id: string;
     _creationTime: number;
     status: Status;
-    rejectionNote?: string;
-    reviewNote?: string;
     projectName: string;
     amount: number;
     reviewedByName?: string;
@@ -105,27 +103,9 @@ export function ReimbursementRow({
         {formatCurrency(item.amount)}
       </TableCell>
       <TableCell className="min-w-40">
-        <div className="flex flex-col items-start gap-1">
-          <Badge variant={display.variant} className={display.className}>
-            {display.label}
-          </Badge>
-          {item.rejectionNote ? (
-            <span
-              className="max-w-56 truncate text-xs text-red-700"
-              title={`Ablehnungsgrund: ${item.rejectionNote}`}
-            >
-              Grund: {item.rejectionNote}
-            </span>
-          ) : null}
-          {item.reviewNote ? (
-            <span
-              className="max-w-56 truncate text-xs text-orange-700"
-              title={`Angeforderte Änderungen: ${item.reviewNote}`}
-            >
-              Änderung: {item.reviewNote}
-            </span>
-          ) : null}
-        </div>
+        <Badge variant={display.variant} className={display.className}>
+          {display.label}
+        </Badge>
       </TableCell>
       <TableCell className="max-w-48 truncate text-muted-foreground">
         {item.reviewedByName ?? "–"}

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -223,13 +223,17 @@ test.describe.serial("reimbursement flow", () => {
       .fill("Bitte Beschreibung präzisieren");
     await page.getByRole("button", { name: "Änderungen anfordern" }).click();
 
+    await expect(expenseRow.getByText("Änderungen angefordert")).toBeVisible();
     await expect(
       page.getByText("Änderung: Bitte Beschreibung präzisieren"),
-    ).toBeVisible();
-    await expect(expenseRow.getByText("Änderungen angefordert")).toBeVisible();
+    ).toHaveCount(0);
 
     await expenseRow.click();
     await expect(page).toHaveURL(/\/reimbursements\/[^/]+$/);
+    await expect(page.getByText("Angeforderte Änderungen:")).toBeVisible();
+    await expect(
+      page.getByText("Bitte Beschreibung präzisieren"),
+    ).toBeVisible();
     const reimbursementId = page.url().split("/").pop();
     await page.goto(`/erstattung/${reimbursementId}`);
 
@@ -404,12 +408,18 @@ test.describe.serial("reimbursement flow", () => {
       .fill("Falsche Angaben");
     await page.getByRole("button", { name: "Ablehnen" }).click();
 
-    await expect(page.getByText("Grund: Falsche Angaben")).toBeVisible({
-      timeout: 10000,
-    });
     await expect(
       page.locator("table tbody tr").first().getByText("Abgelehnt"),
-    ).toBeVisible();
+    ).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Grund: Falsche Angaben")).toHaveCount(0);
+
+    await page.locator("table tbody tr").first().click();
+    await expect(page).toHaveURL(/\/reimbursements\/[^/]+$/);
+    await expect(page.getByText("Ablehnungsgrund:")).toBeVisible();
+    await expect(page.getByText("Falsche Angaben")).toBeVisible();
+    await page.goto("/reimbursements");
   });
 
   test("7. Request changes and resubmit a volunteer allowance", async () => {


### PR DESCRIPTION
## summary

- keep reimbursement status cells limited to the status badge
- show change requests and rejection reasons only on reimbursement detail pages, with regression coverage

## validation

- `pnpm exec prettier --check app/components/Tables/Reimbursements/ReimbursementRow.tsx e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/components/Tables/Reimbursements/ReimbursementRow.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec playwright test e2e/reimbursements.spec.ts` (8 passed)