### PR TITLE
fix(recruiting): show create action only once

### DIFF
--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -39,10 +39,6 @@ export function RecruitingClient() {
         <div className="text-center py-10 border rounded-lg">
           <Megaphone className="mx-auto h-10 w-10 text-muted-foreground" />
           <h3 className="mt-3 font-semibold">Keine Ausschreibungen</h3>
-          <Button className="mt-4" onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
-            Neue Ausschreibung
-          </Button>
         </div>
       ) : (
         <div className="rounded-md border overflow-hidden">

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -74,7 +74,11 @@ test.describe("Ausschreibungen", () => {
 
   test("create a draft, edit rich text and persist it", async () => {
     await page.goto("/recruiting");
-    await page.getByRole("button", { name: "Neue Ausschreibung" }).click();
+    const createButton = page.getByRole("button", {
+      name: "Neue Ausschreibung",
+    });
+    await expect(createButton).toHaveCount(1);
+    await createButton.click();
     await page.getByLabel("Titel*").fill(TITLE);
     await selectOption(page, "posting-team", TEAM);
     await page.getByRole("button", { name: "Entwurf erstellen" }).click();


### PR DESCRIPTION
## summary

- keep the single “Neue Ausschreibung” action in the top-right page header
- remove the duplicate empty-state action and assert exactly one create button in the browser flow

## validation

- `git diff --check` (passed)
- `pnpm exec biome lint app/(protected)/recruiting/RecruitingClient.tsx e2e/recruiting.spec.ts` (passed)
- `pnpm exec prettier --check app/(protected)/recruiting/RecruitingClient.tsx e2e/recruiting.spec.ts` (passed)
- `pnpm exec tsc --noEmit` (passed)
- `pnpm exec playwright test e2e/recruiting.spec.ts` (1 passed; the unchanged publish-status test timed out waiting for `#jp-status`)