### PR TITLE
feat(navigation): present departments and teams as structure

### DIFF
--- a/app/(protected)/settings/teams/TeamsClient.tsx
+++ b/app/(protected)/settings/teams/TeamsClient.tsx
@@ -7,7 +7,7 @@ import { TeamsSection } from "./TeamsSection";
 export function TeamsClient() {
   return (
     <div className="space-y-10">
-      <PageHeader title="Departments & Teams" />
+      <PageHeader title="Struktur" />
       <DepartmentsSection />
       <TeamsSection />
     </div>

--- a/app/(protected)/settings/teams/page.tsx
+++ b/app/(protected)/settings/teams/page.tsx
@@ -8,7 +8,7 @@ export default async function TeamsPage() {
   if (
     !hasPermission(session?.user?.role, USER_PERMISSIONS.organizationStructure)
   ) {
-    return <AccessDenied title="Departments & Teams" />;
+    return <AccessDenied title="Struktur" />;
   }
 
   return <TeamsClient />;

--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -46,6 +46,12 @@ const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
     permission: USER_PERMISSIONS.organizationSettings,
   },
   {
+    name: "Struktur",
+    url: "/settings/teams",
+    icon: Network,
+    permission: USER_PERMISSIONS.organizationStructure,
+  },
+  {
     name: "Benutzer",
     url: "/settings/users",
     icon: Users,
@@ -56,12 +62,6 @@ const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
     url: "/settings/members",
     icon: UserCog,
     permission: USER_PERMISSIONS.members,
-  },
-  {
-    name: "Teams",
-    url: "/settings/teams",
-    icon: Network,
-    permission: USER_PERMISSIONS.organizationStructure,
   },
   {
     name: "Projekte",


### PR DESCRIPTION
## summary

- Rename the teams navigation entry and page heading to “Struktur”.
- Place the structure entry directly below organization while preserving the existing route and department/team sections.

## validation

- `pnpm exec biome lint app/components/Sidebar/AppSidebar.tsx "app/(protected)/settings/teams/page.tsx" "app/(protected)/settings/teams/TeamsClient.tsx"`
- `pnpm exec prettier --check app/components/Sidebar/AppSidebar.tsx "app/(protected)/settings/teams/page.tsx" "app/(protected)/settings/teams/TeamsClient.tsx"`
- `pnpm exec tsc --noEmit`
- `pnpm run lint:lines`
- Build and tests not run (copy-only navigation change with no focused test).