### PR TITLE
feat(reimbursements): confirm deletes and support bulk actions

### DIFF
--- a/app/(protected)/reimbursements/DeleteReimbursementsDialog.tsx
+++ b/app/(protected)/reimbursements/DeleteReimbursementsDialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+
+type Props = {
+  count: number;
+  singleItemLabel?: string;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function DeleteReimbursementsDialog({
+  count,
+  singleItemLabel,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const isSingleItem = count === 1;
+  const title = isSingleItem
+    ? `${singleItemLabel ?? "Erstattung"} löschen?`
+    : "Ausgewählte Erstattungen löschen?";
+
+  return (
+    <AlertDialog
+      open={count > 0}
+      onOpenChange={(open) => !open && !isDeleting && onCancel()}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {isSingleItem
+              ? "Die Erstattung und alle zugehörigen Dateien werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
+              : "Die ausgewählten Erstattungen und alle zugehörigen Dateien werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+            disabled={isDeleting}
+            className="bg-destructive text-white hover:bg-destructive/90"
+          >
+            {isDeleting ? <Loader2 className="size-4 animate-spin" /> : null}
+            Löschen
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/(protected)/reimbursements/ReimbursementPageUI.tsx
+++ b/app/(protected)/reimbursements/ReimbursementPageUI.tsx
@@ -10,6 +10,7 @@ import {
   Plus,
   Share2,
   Table2,
+  Trash2,
 } from "lucide-react";
 import { ReimbursementTable } from "./ReimbursementTable";
 import { RejectDialogModal } from "./RejectDialogModal";
@@ -49,6 +50,8 @@ interface Props {
   onEditAllowance: (id: string) => void;
   onDeleteReimbursement: (id: string) => void;
   onDeleteAllowance: (id: string) => void;
+  canDeleteSelected: boolean;
+  onDeleteSelected: () => void;
   onToggleSelect: (key: SelectionKey) => void;
   onToggleSelectAll: () => void;
   onTypeFilterChange: (value: ReimbursementTypeFilter) => void;
@@ -82,6 +85,8 @@ export function ReimbursementPageUI({
   onEditAllowance,
   onDeleteReimbursement,
   onDeleteAllowance,
+  canDeleteSelected,
+  onDeleteSelected,
   onToggleSelect,
   onToggleSelectAll,
   onTypeFilterChange,
@@ -93,7 +98,7 @@ export function ReimbursementPageUI({
     <div className="flex flex-col w-full">
       <PageHeader title="Erstattungen" />
 
-      <div className="flex justify-end gap-2 mb-4">
+      <div className="mb-4 flex flex-wrap justify-end gap-2">
         {selected.size > 0 && (
           <Button
             variant="outline"
@@ -105,9 +110,7 @@ export function ReimbursementPageUI({
             ) : (
               <Download className="h-4 w-4 mr-2" />
             )}
-            {isBulkDownloading
-              ? "Wird erstellt..."
-              : `${selected.size} herunterladen`}
+            {isBulkDownloading ? "Wird erstellt..." : "Herunterladen"}
           </Button>
         )}
         {canManageReimbursements ? (
@@ -121,6 +124,16 @@ export function ReimbursementPageUI({
               SEPA XML
             </Button>
           </>
+        ) : null}
+        {canDeleteSelected ? (
+          <Button
+            variant="outline"
+            className="text-destructive hover:text-destructive"
+            onClick={onDeleteSelected}
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Löschen
+          </Button>
         ) : null}
         <Button variant="primary" onClick={onNewClick}>
           <Plus className="h-4 w-4 mr-2" />

--- a/app/(protected)/reimbursements/ReimbursementsClient.tsx
+++ b/app/(protected)/reimbursements/ReimbursementsClient.tsx
@@ -5,6 +5,7 @@ import type { Project } from "@/lib/db/types";
 import { useCanManageReimbursements } from "@/lib/hooks/useCurrentUserRole";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { DeleteReimbursementsDialog } from "./DeleteReimbursementsDialog";
 import { ReimbursementPageUI } from "./ReimbursementPageUI";
 import type {
   Allowance,
@@ -37,6 +38,7 @@ export function ReimbursementsClient({
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [selected, setSelected] = useState<Set<SelectionKey>>(new Set());
   const [typeFilter, setTypeFilter] = useState<ReimbursementTypeFilter>("all");
+  const [deleteKeys, setDeleteKeys] = useState<SelectionKey[]>([]);
 
   const filteredReimbursements = reimbursements.filter(
     (item) => typeFilter === "all" || item.type === typeFilter,
@@ -45,10 +47,14 @@ export function ReimbursementsClient({
     typeFilter === "all" || typeFilter === "allowance" ? allowances : [];
 
   const actions = useReimbursementActions();
-  const { handleFinomCsv, handleSepaXml } = usePaymentExports(
+  const clearSelection = () => setSelected(new Set());
+  const { handleFinomCsv, handleSepaXml } = usePaymentExports({
     reimbursements,
+    allowances,
+    selected,
     organizationName,
-  );
+    clearSelection,
+  });
   const {
     isBulkDownloading,
     handleOpenReimbursement,
@@ -57,7 +63,7 @@ export function ReimbursementsClient({
   } = usePdfDownloads({
     allowances,
     selected,
-    clearSelection: () => setSelected(new Set()),
+    clearSelection,
   });
 
   const handleToggleSelect = (key: SelectionKey) => {
@@ -83,6 +89,38 @@ export function ReimbursementsClient({
     setTypeFilter(value);
     setSelected(new Set());
   };
+
+  const selectedItems = [
+    ...reimbursements.map((item) => ({ key: `r:${item._id}` as const, item })),
+    ...allowances.map((item) => ({ key: `a:${item._id}` as const, item })),
+  ].filter(({ key }) => selected.has(key));
+  const canDeleteSelected =
+    canManageReimbursements &&
+    selected.size > 0 &&
+    selectedItems.length === selected.size &&
+    selectedItems.every(({ item }) => item.status === "pending");
+
+  const handleConfirmDelete = async () => {
+    const deletedKeys = await actions.handleDelete(deleteKeys);
+    if (deletedKeys.length > 0) {
+      setSelected((current) => {
+        const next = new Set(current);
+        for (const key of deletedKeys) next.delete(key);
+        return next;
+      });
+    }
+    setDeleteKeys([]);
+  };
+
+  const singleDeleteLabel = (() => {
+    if (deleteKeys.length !== 1) return undefined;
+    const key = deleteKeys[0];
+    if (key.startsWith("a:")) return "Ehrenamtspauschale";
+    return reimbursements.find((item) => item._id === key.slice(2))?.type ===
+      "travel"
+      ? "Reisekostenerstattung"
+      : "Auslagenerstattung";
+  })();
 
   return (
     <>
@@ -113,8 +151,10 @@ export function ReimbursementsClient({
         onOpenAllowance={handleOpenAllowance}
         onEditReimbursement={(id) => router.push(`/erstattung/${id}`)}
         onEditAllowance={(id) => router.push(`/ehrenamtspauschale/${id}`)}
-        onDeleteReimbursement={actions.handleDeleteReimbursement}
-        onDeleteAllowance={actions.handleDeleteAllowance}
+        onDeleteReimbursement={(id) => setDeleteKeys([`r:${id}`])}
+        onDeleteAllowance={(id) => setDeleteKeys([`a:${id}`])}
+        canDeleteSelected={canDeleteSelected}
+        onDeleteSelected={() => setDeleteKeys([...selected])}
         onToggleSelect={handleToggleSelect}
         onToggleSelectAll={handleToggleSelectAll}
         onTypeFilterChange={handleTypeFilterChange}
@@ -129,6 +169,13 @@ export function ReimbursementsClient({
           projects={projects}
         />
       ) : null}
+      <DeleteReimbursementsDialog
+        count={deleteKeys.length}
+        singleItemLabel={singleDeleteLabel}
+        isDeleting={actions.isDeleting}
+        onCancel={() => setDeleteKeys([])}
+        onConfirm={handleConfirmDelete}
+      />
     </>
   );
 }

--- a/app/(protected)/reimbursements/buildApprovedPayments.ts
+++ b/app/(protected)/reimbursements/buildApprovedPayments.ts
@@ -1,0 +1,44 @@
+import { buildPaymentReference } from "../../lib/fileHandlers/buildPaymentReference";
+import type { Allowance, Reimbursement, SelectionKey } from "./types";
+
+type PaymentSelection = {
+  reimbursements: Reimbursement[];
+  allowances: Allowance[];
+  selected: Set<SelectionKey>;
+};
+
+export function buildApprovedPayments({
+  reimbursements,
+  allowances,
+  selected,
+}: PaymentSelection) {
+  const hasSelection = selected.size > 0;
+  const sources = [
+    ...reimbursements.map((item) => ({ key: `r:${item._id}` as const, item })),
+    ...allowances.map((item) => ({ key: `a:${item._id}` as const, item })),
+  ];
+
+  return sources
+    .filter(
+      ({ key, item }) =>
+        (!hasSelection || selected.has(key)) &&
+        item.status === "approved" &&
+        Boolean(item.iban && item.accountHolder),
+    )
+    .map(({ item }) => ({
+      id: item._id,
+      name: item.accountHolder,
+      iban: item.iban,
+      bic: item.bic,
+      amount: item.amount,
+      currency: "currency" in item ? (item.currency ?? "EUR") : "EUR",
+      reference: buildPaymentReference({
+        reimbursementId: item._id,
+        projectName: item.projectName,
+        name:
+          "volunteerName" in item
+            ? item.volunteerName || item.creatorName
+            : item.submitterName || item.creatorName,
+      }),
+    }));
+}

--- a/app/(protected)/reimbursements/usePaymentExports.test.ts
+++ b/app/(protected)/reimbursements/usePaymentExports.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import type { Allowance, Reimbursement, SelectionKey } from "./types";
+import { buildApprovedPayments } from "./buildApprovedPayments";
+
+const reimbursement = {
+  _id: "reimbursement-approved",
+  status: "approved",
+  iban: "DE111",
+  accountHolder: "Alex Example",
+  amount: 42,
+  currency: "EUR",
+  projectName: "Projekt A",
+  creatorName: "Alex Example",
+} as Reimbursement;
+
+const allowance = {
+  _id: "allowance-approved",
+  status: "approved",
+  iban: "DE222",
+  accountHolder: "Sam Example",
+  amount: 80,
+  projectName: "Projekt B",
+  volunteerName: "Sam Example",
+  creatorName: "Sam Example",
+} as Allowance;
+
+describe("buildApprovedPayments", () => {
+  test("includes approved reimbursements and allowances without a selection", () => {
+    const payments = buildApprovedPayments({
+      reimbursements: [reimbursement],
+      allowances: [allowance],
+      selected: new Set<SelectionKey>(),
+    });
+
+    expect(payments.map(({ id }) => id)).toEqual([
+      reimbursement._id,
+      allowance._id,
+    ]);
+  });
+
+  test("limits the export to the current multi-selection", () => {
+    const payments = buildApprovedPayments({
+      reimbursements: [reimbursement],
+      allowances: [allowance],
+      selected: new Set<SelectionKey>([`a:${allowance._id}`]),
+    });
+
+    expect(payments).toHaveLength(1);
+    expect(payments[0]).toMatchObject({
+      id: allowance._id,
+      name: allowance.accountHolder,
+      iban: allowance.iban,
+    });
+  });
+
+  test("excludes selected payments that are not approved", () => {
+    const pending = { ...reimbursement, status: "pending" } as Reimbursement;
+    const payments = buildApprovedPayments({
+      reimbursements: [pending],
+      allowances: [],
+      selected: new Set<SelectionKey>([`r:${pending._id}`]),
+    });
+
+    expect(payments).toEqual([]);
+  });
+});

--- a/app/(protected)/reimbursements/usePaymentExports.ts
+++ b/app/(protected)/reimbursements/usePaymentExports.ts
@@ -1,37 +1,40 @@
-import { buildPaymentReference } from "@/lib/fileHandlers/buildPaymentReference";
 import { downloadBlob } from "@/lib/fileHandlers/downloadBlob";
 import { generateFinomCSV } from "@/lib/fileHandlers/generateFinomCSV";
 import { generateSEPAXML } from "@/lib/fileHandlers/generateSEPAXML";
 import toast from "react-hot-toast";
-import type { Reimbursement } from "./types";
+import type { Allowance, Reimbursement, SelectionKey } from "./types";
+import { buildApprovedPayments } from "./buildApprovedPayments";
 
 const today = () => new Date().toISOString().slice(0, 10);
 
-export function usePaymentExports(
-  reimbursements: Reimbursement[] | undefined,
-  organizationName: string,
-) {
-  const buildApprovedPayments = () =>
-    (reimbursements ?? [])
-      .filter((r) => r.status === "approved" && r.iban && r.accountHolder)
-      .map((r) => ({
-        id: r._id,
-        name: r.accountHolder,
-        iban: r.iban,
-        bic: r.bic,
-        amount: r.amount,
-        currency: r.currency ?? "EUR",
-        reference: buildPaymentReference({
-          reimbursementId: r._id,
-          projectName: r.projectName,
-          name: r.submitterName || r.creatorName,
-        }),
-      }));
+type Params = {
+  reimbursements: Reimbursement[];
+  allowances: Allowance[];
+  selected: Set<SelectionKey>;
+  organizationName: string;
+  clearSelection: () => void;
+};
+
+export function usePaymentExports({
+  reimbursements,
+  allowances,
+  selected,
+  organizationName,
+  clearSelection,
+}: Params) {
+  const noPaymentsMessage = () =>
+    selected.size > 0
+      ? "Keine ausgewählten genehmigten Erstattungen mit IBAN vorhanden"
+      : "Keine genehmigten Erstattungen mit IBAN vorhanden";
 
   const handleFinomCsv = () => {
-    const payments = buildApprovedPayments();
+    const payments = buildApprovedPayments({
+      reimbursements,
+      allowances,
+      selected,
+    });
     if (payments.length === 0) {
-      toast.error("Keine genehmigten Erstattungen mit IBAN vorhanden");
+      toast.error(noPaymentsMessage());
       return;
     }
     if (payments.length > 200) {
@@ -42,18 +45,24 @@ export function usePaymentExports(
     const blob = generateFinomCSV(payments);
     downloadBlob(blob, `Finom_Sammelueberweisung_${today()}.csv`);
     toast.success(`${payments.length} Überweisungen exportiert`);
+    if (selected.size > 0) clearSelection();
   };
 
   const handleSepaXml = () => {
-    const payments = buildApprovedPayments();
+    const payments = buildApprovedPayments({
+      reimbursements,
+      allowances,
+      selected,
+    });
     if (payments.length === 0) {
-      toast.error("Keine genehmigten Erstattungen mit IBAN vorhanden");
+      toast.error(noPaymentsMessage());
       return;
     }
 
     const blob = generateSEPAXML({ organizationName, payments });
     downloadBlob(blob, `SEPA_${today()}.xml`);
     toast.success(`${payments.length} Überweisungen exportiert`);
+    if (selected.size > 0) clearSelection();
   };
 
   return { handleFinomCsv, handleSepaXml };

--- a/app/(protected)/reimbursements/usePdfDownloads.ts
+++ b/app/(protected)/reimbursements/usePdfDownloads.ts
@@ -90,21 +90,41 @@ export function usePdfDownloads({
 
     try {
       const zip = new JSZip();
+      const allowanceById = new Map(
+        allowances.map((allowance) => [allowance._id, allowance]),
+      );
+      const pdfs = await Promise.all(
+        [...selected].map(async (key) => {
+          if (key.startsWith("r:")) {
+            const id = key.slice(2);
+            const blob = await getPdfBlobForReimbursement(id);
+            return blob
+              ? { name: `Erstattung_${shortReferenceId(id)}.pdf`, blob }
+              : null;
+          }
 
-      for (const key of selected) {
-        if (key.startsWith("r:")) {
           const id = key.slice(2);
-          const blob = await getPdfBlobForReimbursement(id);
-          if (blob) zip.file(`Erstattung_${shortReferenceId(id)}.pdf`, blob);
-        } else if (key.startsWith("a:")) {
-          const id = key.slice(2);
-          const allowance = allowances.find((item) => item._id === id);
+          const allowance = allowanceById.get(id);
           if (allowance) {
             const blob = await getPdfBlobForAllowance(allowance);
-            if (blob)
-              zip.file(`Ehrenamtspauschale_${shortReferenceId(id)}.pdf`, blob);
+            return blob
+              ? {
+                  name: `Ehrenamtspauschale_${shortReferenceId(id)}.pdf`,
+                  blob,
+                }
+              : null;
           }
-        }
+          return null;
+        }),
+      );
+
+      for (const pdf of pdfs) {
+        if (pdf) zip.file(pdf.name, pdf.blob);
+      }
+
+      if (pdfs.every((pdf) => pdf === null)) {
+        toast.error("Für die Auswahl konnten keine PDFs erstellt werden");
+        return;
       }
 
       const zipBlob = await zip.generateAsync({ type: "blob" });

--- a/app/(protected)/reimbursements/useReimbursementActions.ts
+++ b/app/(protected)/reimbursements/useReimbursementActions.ts
@@ -13,7 +13,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
-import type { RejectDialog } from "./types";
+import type { RejectDialog, SelectionKey } from "./types";
 
 const CLOSED_DIALOG: RejectDialog = {
   open: false,
@@ -27,6 +27,7 @@ export function useReimbursementActions() {
   const router = useRouter();
   const [rejectDialog, setRejectDialog] = useState<RejectDialog>(CLOSED_DIALOG);
   const [isRejecting, setIsRejecting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const run = async (
     action: () => Promise<unknown>,
@@ -86,11 +87,51 @@ export function useReimbursementActions() {
     }
   };
 
+  const handleDelete = async (
+    keys: SelectionKey[],
+  ): Promise<SelectionKey[]> => {
+    if (keys.length === 0 || isDeleting) return [];
+
+    setIsDeleting(true);
+    const results = await Promise.allSettled(
+      keys.map((key) =>
+        key.startsWith("r:")
+          ? deleteReimbursement({ reimbursementId: key.slice(2) })
+          : removeAllowance({ id: key.slice(2) }),
+      ),
+    );
+    const deletedKeys = keys.filter(
+      (_, index) => results[index].status === "fulfilled",
+    );
+    const failedCount = keys.length - deletedKeys.length;
+
+    if (deletedKeys.length > 0) {
+      toast.success(
+        deletedKeys.length === 1
+          ? "Erstattung gelöscht"
+          : `${deletedKeys.length} Erstattungen gelöscht`,
+      );
+      router.refresh();
+    }
+    if (failedCount > 0) {
+      toast.error(
+        failedCount === 1
+          ? "Eine Erstattung konnte nicht gelöscht werden"
+          : `${failedCount} Erstattungen konnten nicht gelöscht werden`,
+      );
+    }
+
+    setIsDeleting(false);
+    return deletedKeys;
+  };
+
   return {
     rejectDialog,
     setRejectDialog,
     isRejecting,
+    isDeleting,
     handleReview,
+    handleDelete,
     handleOpenReviewDialog: (
       action: "changes" | "reject",
       type: "reimbursement" | "allowance",
@@ -108,13 +149,5 @@ export function useReimbursementActions() {
         "Genehmigt",
         "Fehler beim Genehmigen",
       ),
-    handleDeleteReimbursement: (id: string) =>
-      run(
-        () => deleteReimbursement({ reimbursementId: id }),
-        "Gelöscht",
-        "Fehler beim Löschen",
-      ),
-    handleDeleteAllowance: (id: string) =>
-      run(() => removeAllowance({ id }), "Gelöscht", "Fehler beim Löschen"),
   };
 }

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -366,14 +366,23 @@ test.describe.serial("reimbursement flow", () => {
       .getByRole("checkbox", { name: "Antrag auswählen" })
       .check();
     await expect(
-      page.getByRole("button", { name: "1 herunterladen" }),
+      page.getByRole("button", { name: "Herunterladen", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Finom CSV", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "SEPA XML", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Löschen", exact: true }),
     ).toBeVisible();
 
     await page
       .getByRole("tab", { name: "Reisekostenerstattung", exact: true })
       .click();
     await expect(
-      page.getByRole("button", { name: "1 herunterladen" }),
+      page.getByRole("button", { name: "Herunterladen", exact: true }),
     ).not.toBeVisible();
     await expect(tableRows).toHaveCount(1);
     await expect(
@@ -395,6 +404,23 @@ test.describe.serial("reimbursement flow", () => {
 
     await page.getByRole("tab", { name: "Alle", exact: true }).click();
     await expect(tableRows).toHaveCount(2);
+  });
+
+  test("asks for confirmation before deleting a travel reimbursement", async () => {
+    const travelRow = page.locator("table tbody tr").first();
+    await selectRowAction(page, travelRow, "Löschen");
+
+    await expect(
+      page.getByRole("alertdialog", {
+        name: "Reisekostenerstattung löschen?",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Diese Aktion kann nicht rückgängig gemacht werden."),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Abbrechen" }).click();
+
+    await expect(travelRow).toBeVisible();
   });
 
   test("6. Reject travel reimbursement", async () => {


### PR DESCRIPTION
## summary

- add confirmation for single and bulk reimbursement deletion, including partial failure handling
- apply multi-selection to PDF, Finom CSV, and SEPA exports, including volunteer allowances

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/(protected)/reimbursements/usePaymentExports.test.ts`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --project=chromium`
- `pnpm build`