### PR TITLE
fix(reimbursements): honor admin and finance deletion permissions

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementsClient.tsx
+++ b/app/(protected)/reimbursements/ReimbursementsClient.tsx
@@ -90,15 +90,7 @@ export function ReimbursementsClient({
     setSelected(new Set());
   };
 
-  const selectedItems = [
-    ...reimbursements.map((item) => ({ key: `r:${item._id}` as const, item })),
-    ...allowances.map((item) => ({ key: `a:${item._id}` as const, item })),
-  ].filter(({ key }) => selected.has(key));
-  const canDeleteSelected =
-    canManageReimbursements &&
-    selected.size > 0 &&
-    selectedItems.length === selected.size &&
-    selectedItems.every(({ item }) => item.status === "pending");
+  const canDeleteSelected = canManageReimbursements && selected.size > 0;
 
   const handleConfirmDelete = async () => {
     const deletedKeys = await actions.handleDelete(deleteKeys);

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -71,6 +71,7 @@ export function ReimbursementRow({
   const isPending = item.status === "pending";
   const showReviewActions = canManageReimbursements && isPending;
   const showEditAction = canEdit && item.status === "changes_requested";
+  const showDeleteAction = canManageReimbursements;
 
   return (
     <TableRow
@@ -162,7 +163,7 @@ export function ReimbursementRow({
               <ExternalLink className="text-current" />
               Öffnen
             </DropdownMenuItem>
-            {showReviewActions ? (
+            {showDeleteAction ? (
               <DropdownMenuItem
                 className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
                 onSelect={onDelete}

--- a/app/lib/auth/roles.ts
+++ b/app/lib/auth/roles.ts
@@ -10,23 +10,16 @@ export type UserPermission =
   | "manage_projects"
   | "view_audit_logs";
 
-const rolePermissions: Record<UserRole, readonly UserPermission[]> = {
+const rolePermissions: Record<
+  Exclude<UserRole, "admin">,
+  readonly UserPermission[]
+> = {
   member: [],
   finance: ["manage_finance"],
   people_culture: [
     "manage_recruiting",
     "manage_members",
     "manage_organization_structure",
-  ],
-  admin: [
-    "manage_finance",
-    "manage_recruiting",
-    "manage_members",
-    "manage_organization_structure",
-    "manage_roles",
-    "manage_organization_settings",
-    "manage_projects",
-    "view_audit_logs",
   ],
 };
 
@@ -70,5 +63,7 @@ export function hasPermission(
   role: unknown,
   permission: UserPermission,
 ): boolean {
-  return rolePermissions[normalizeUserRole(role)].includes(permission);
+  const normalizedRole = normalizeUserRole(role);
+  if (normalizedRole === "admin") return true;
+  return rolePermissions[normalizedRole].includes(permission);
 }

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -448,6 +448,28 @@ test.describe.serial("reimbursement flow", () => {
     await page.goto("/reimbursements");
   });
 
+  test("admin can delete processed reimbursements individually and in bulk", async () => {
+    const travelRow = page.locator("table tbody tr").first();
+
+    await page.getByRole("checkbox", { name: "Alle auswählen" }).check();
+    await page.getByRole("button", { name: "Löschen", exact: true }).click();
+    await expect(
+      page.getByRole("alertdialog", {
+        name: "Ausgewählte Erstattungen löschen?",
+      }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Abbrechen" }).click();
+
+    await selectRowAction(page, travelRow, "Löschen");
+    await expect(
+      page.getByRole("alertdialog", {
+        name: "Reisekostenerstattung löschen?",
+      }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Abbrechen" }).click();
+    await page.getByRole("checkbox", { name: "Alle auswählen" }).uncheck();
+  });
+
   test("7. Request changes and resubmit a volunteer allowance", async () => {
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
     await expect(page).toHaveURL(/\/reimbursements\/new$/);


### PR DESCRIPTION
## summary

- grant admins every defined permission automatically
- allow admin and finance users to delete processed reimbursements individually or in bulk
- cover confirmation flows for processed reimbursement deletion

## validation

- `pnpm exec prettier --check app/lib/auth/roles.ts app/(protected)/reimbursements/ReimbursementsClient.tsx app/components/Tables/Reimbursements/ReimbursementRow.tsx e2e/reimbursements.spec.ts`
- `pnpm exec biome lint app/lib/auth/roles.ts app/(protected)/reimbursements/ReimbursementsClient.tsx app/components/Tables/Reimbursements/ReimbursementRow.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/auth/roles.test.ts app/lib/auth/session.test.ts app/lib/server/reimbursements/reimbursements.test.ts app/lib/server/volunteerAllowance/volunteerAllowance.test.ts`
- `pnpm exec playwright test e2e/reimbursements.spec.ts`