### PR TITLE
fix(teams): keep creation working across deployments

### DIFF
--- a/app/api/teams/route.test.ts
+++ b/app/api/teams/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/server/teams/actions", () => ({
+  createTeam: vi.fn(),
+}));
+
+vi.mock("@/lib/server/teams/data", () => ({
+  getActiveTeams: vi.fn(),
+  getArchivedTeams: vi.fn(),
+}));
+
+import { createTeam } from "@/lib/server/teams/actions";
+import { POST } from "./route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("POST creates a team through a stable HTTP endpoint", async () => {
+  vi.mocked(createTeam).mockResolvedValue("team-1");
+
+  const response = await POST(
+    new Request("http://localhost/api/teams", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "People & Culture", departmentId: "ops" }),
+    }),
+  );
+
+  expect(response.status).toBe(201);
+  await expect(response.json()).resolves.toEqual({ data: "team-1" });
+  expect(createTeam).toHaveBeenCalledWith({
+    name: "People & Culture",
+    departmentId: "ops",
+  });
+});
+
+test("POST returns a safe error response when creation fails", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.mocked(createTeam).mockRejectedValue(new Error("database details"));
+
+  const response = await POST(
+    new Request("http://localhost/api/teams", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "People & Culture", departmentId: "ops" }),
+    }),
+  );
+
+  expect(response.status).toBe(400);
+  await expect(response.json()).resolves.toEqual({
+    error: "Team konnte nicht erstellt werden",
+  });
+});

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -1,3 +1,4 @@
+import { createTeam } from "@/lib/server/teams/actions";
 import { getActiveTeams, getArchivedTeams } from "@/lib/server/teams/data";
 
 export async function GET(request: Request) {
@@ -7,5 +8,18 @@ export async function GET(request: Request) {
     return Response.json({ data });
   } catch {
     return Response.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await createTeam(await request.json());
+    return Response.json({ data }, { status: 201 });
+  } catch (error) {
+    console.error("Team could not be created", error);
+    return Response.json(
+      { error: "Team konnte nicht erstellt werden" },
+      { status: 400 },
+    );
   }
 }

--- a/app/lib/client/teams/hooks/useTeamMutations.ts
+++ b/app/lib/client/teams/hooks/useTeamMutations.ts
@@ -1,10 +1,10 @@
 import {
   archiveTeam,
-  createTeam,
   unarchiveTeam,
   updateTeam,
 } from "@/lib/server/teams/actions";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createTeam } from "../requests/createTeam";
 
 export function useTeamMutations() {
   const queryClient = useQueryClient();

--- a/app/lib/client/teams/requests/createTeam.ts
+++ b/app/lib/client/teams/requests/createTeam.ts
@@ -1,0 +1,21 @@
+interface CreateTeamInput {
+  name: string;
+  departmentId: string;
+}
+
+export async function createTeam(input: CreateTeamInput): Promise<string> {
+  const response = await fetch("/api/teams", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Team konnte nicht erstellt werden (Code ${response.status})`,
+    );
+  }
+
+  const json = await response.json();
+  return json.data as string;
+}


### PR DESCRIPTION
## summary

- route team creation through a stable authenticated HTTP endpoint so open sessions survive deployments
- preserve existing server-side validation and add success and safe-error route coverage

## validation

- `pnpm exec prettier --check app/api/teams/route.ts app/api/teams/route.test.ts app/lib/client/teams/hooks/useTeamMutations.ts app/lib/client/teams/requests/createTeam.ts`
- `pnpm exec biome lint app/api/teams/route.ts app/api/teams/route.test.ts app/lib/client/teams/hooks/useTeamMutations.ts app/lib/client/teams/requests/createTeam.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/api/teams/route.test.ts app/lib/server/teams/teams.test.ts`
- `pnpm exec vitest run` (243 tests)
- `pnpm build`
- `pnpm lint:lines`
- `pnpm lint` (passes with existing informational warnings)