### PR TITLE
fix(recruiting): harden tally application ingestion

### DIFF
--- a/app/api/webhooks/tally/route.test.ts
+++ b/app/api/webhooks/tally/route.test.ts
@@ -1,0 +1,150 @@
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+  after: vi.fn((callback: () => unknown) => callback()),
+}));
+
+vi.mock("@/lib/server/applications/ingest", () => ({
+  ingestTallySubmission: vi.fn(),
+}));
+
+vi.mock("@/lib/server/applications/email", () => ({
+  sendApplicationEmails: vi.fn(),
+}));
+
+vi.mock(
+  "@/lib/server/applications/tallyPayload",
+  () => import("../../../lib/server/applications/tallyPayload"),
+);
+
+vi.mock(
+  "@/lib/server/tally/config",
+  () => import("../../../lib/server/tally/config"),
+);
+
+vi.mock(
+  "@/lib/server/tally/signature",
+  () => import("../../../lib/server/tally/signature"),
+);
+
+import { after } from "next/server";
+import { sendApplicationEmails } from "@/lib/server/applications/email";
+import { ingestTallySubmission } from "@/lib/server/applications/ingest";
+import { POST } from "./route";
+
+const SECRET = "whsec_test_secret";
+
+function payload(eventType = "FORM_RESPONSE") {
+  return {
+    eventId: "event-1",
+    eventType,
+    data: {
+      responseId: "response-1",
+      submissionId: "submission-1",
+      formId: "form-1",
+      fields: [],
+    },
+  };
+}
+
+function sign(rawBody: string): string {
+  return createHmac("sha256", SECRET).update(rawBody, "utf8").digest("base64");
+}
+
+function request(rawBody: string, signature?: string): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (signature) headers.set("tally-signature", signature);
+  return new Request("http://localhost/api/webhooks/tally", {
+    method: "POST",
+    headers,
+    body: rawBody,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("TALLY_WEBHOOK_SIGNING_SECRET", SECRET);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test("rejects an unsigned webhook before processing", async () => {
+  const response = await POST(request(JSON.stringify(payload())));
+
+  expect(response.status).toBe(401);
+  expect(ingestTallySubmission).not.toHaveBeenCalled();
+});
+
+test("fails closed when the signing secret is not configured", async () => {
+  vi.stubEnv("TALLY_WEBHOOK_SIGNING_SECRET", "");
+  const rawBody = JSON.stringify(payload());
+  const response = await POST(request(rawBody, sign(rawBody)));
+
+  expect(response.status).toBe(500);
+  expect(ingestTallySubmission).not.toHaveBeenCalled();
+});
+
+test("rejects a signature that does not match the exact raw body", async () => {
+  const signedBody = JSON.stringify(payload());
+  const changedBody = `${signedBody} `;
+  const response = await POST(request(changedBody, sign(signedBody)));
+
+  expect(response.status).toBe(401);
+  expect(ingestTallySubmission).not.toHaveBeenCalled();
+});
+
+test("rejects a signed malformed payload before processing", async () => {
+  const rawBody = "not-json";
+  const response = await POST(request(rawBody, sign(rawBody)));
+
+  expect(response.status).toBe(400);
+  expect(ingestTallySubmission).not.toHaveBeenCalled();
+});
+
+test("processes a valid signed webhook and schedules its emails", async () => {
+  const rawBody = JSON.stringify(payload());
+  vi.mocked(ingestTallySubmission).mockResolvedValue({
+    status: "created",
+    applicationId: "application-1",
+  });
+
+  const response = await POST(request(rawBody, sign(rawBody)));
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({
+    ok: true,
+    status: "created",
+  });
+  expect(ingestTallySubmission).toHaveBeenCalledWith(payload());
+  expect(after).toHaveBeenCalledOnce();
+  expect(sendApplicationEmails).toHaveBeenCalledWith("application-1");
+});
+
+test("does not schedule emails for an idempotent duplicate", async () => {
+  const rawBody = JSON.stringify(payload());
+  vi.mocked(ingestTallySubmission).mockResolvedValue({ status: "duplicate" });
+
+  const response = await POST(request(rawBody, sign(rawBody)));
+
+  await expect(response.json()).resolves.toEqual({
+    ok: true,
+    status: "duplicate",
+  });
+  expect(after).not.toHaveBeenCalled();
+  expect(sendApplicationEmails).not.toHaveBeenCalled();
+});
+
+test("ignores a valid signed event with another type", async () => {
+  const rawBody = JSON.stringify(payload("FORM_UPDATED"));
+  const response = await POST(request(rawBody, sign(rawBody)));
+
+  await expect(response.json()).resolves.toEqual({
+    ok: true,
+    status: "ignored",
+  });
+  expect(ingestTallySubmission).not.toHaveBeenCalled();
+  expect(after).not.toHaveBeenCalled();
+});

--- a/app/lib/db/application.ts
+++ b/app/lib/db/application.ts
@@ -6,7 +6,13 @@ export type ApplicationStatus =
   | "rejected"
   | "withdrawn";
 
-export type ApplicationFieldValue = string | number | boolean | string[] | null;
+export type ApplicationFieldValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ApplicationFieldValue[]
+  | { [key: string]: ApplicationFieldValue };
 
 export interface ApplicationField {
   key: string;
@@ -24,7 +30,6 @@ export interface Application {
   applicantName?: string;
   applicantEmail: string;
   applicantEmailNormalized: string;
-  applicantPhone?: string;
   fields: ApplicationField[];
   tallyEventId: string;
   tallySubmissionId: string;

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -53,7 +53,9 @@ export async function ensureIndexes(): Promise<void> {
     .createIndexes([
       { key: { organizationId: 1, _creationTime: -1 } },
       { key: { organizationId: 1, jobPostingId: 1, _creationTime: -1 } },
+      { key: { tallyEventId: 1 }, unique: true },
       { key: { tallySubmissionId: 1 }, unique: true },
+      { key: { tallyResponseId: 1 }, unique: true },
       { key: { jobPostingId: 1, applicantEmailNormalized: 1 }, unique: true },
     ]);
 

--- a/app/lib/server/applications/ingest.test.ts
+++ b/app/lib/server/applications/ingest.test.ts
@@ -32,6 +32,12 @@ function buildPayload(input: {
       type: "TEXTAREA",
       value: "Ich will helfen",
     },
+    {
+      key: "q-phone",
+      label: "Telefon",
+      type: "INPUT_PHONE_NUMBER",
+      value: "+49123456789",
+    },
   ];
   if (input.jobPostingId !== undefined) {
     fields.unshift({
@@ -120,6 +126,11 @@ test("creates a received application scoped to the posting org with a snapshot",
   expect(stored?.applicantEmailNormalized).toBe("max@example.com");
   expect(stored?.applicantName).toBe("Max Mustermann");
   expect(stored?.fields).toHaveLength(4);
+  expect(stored).not.toHaveProperty("applicantPhone");
+  expect(stored?.fields.some((field) => field.type.includes("PHONE"))).toBe(
+    false,
+  );
+  expect(JSON.stringify(stored)).not.toContain("+49123456789");
 });
 
 test("ignores a submission without the hidden job posting id", async () => {
@@ -184,6 +195,29 @@ test("de-duplicates a repeated delivery of the same event", async () => {
   expect(await (await applications()).countDocuments()).toBe(1);
 });
 
+test("de-duplicates concurrent deliveries and keeps the event processed", async () => {
+  const payload = buildPayload({
+    eventId: "e1",
+    submissionId: "s1",
+    jobPostingId: postingA,
+    email: "a@b.de",
+  });
+
+  const outcomes = await Promise.all([
+    ingestTallySubmission(payload),
+    ingestTallySubmission(payload),
+  ]);
+
+  expect(outcomes.map((outcome) => outcome.status).sort()).toEqual([
+    "created",
+    "duplicate",
+  ]);
+  expect(await (await applications()).countDocuments()).toBe(1);
+  const event = await (await tallyWebhookEvents()).findOne({ _id: "e1" });
+  expect(event?.status).toBe("processed");
+  expect(event?.applicationId).toBeTruthy();
+});
+
 test("de-duplicates the same submission arriving under a different event", async () => {
   await ingestTallySubmission(
     buildPayload({
@@ -203,6 +237,32 @@ test("de-duplicates the same submission arriving under a different event", async
   );
 
   expect(second).toEqual({ status: "duplicate" });
+  expect(await (await applications()).countDocuments()).toBe(1);
+  const event = await (await tallyWebhookEvents()).findOne({ _id: "e2" });
+  expect(event?.status).toBe("duplicate");
+  expect(event?.applicationId).toBeTruthy();
+});
+
+test("de-duplicates the same response arriving as another submission", async () => {
+  const first = buildPayload({
+    eventId: "e1",
+    submissionId: "s1",
+    jobPostingId: postingA,
+    email: "first@b.de",
+  });
+  await ingestTallySubmission(first);
+
+  const second = buildPayload({
+    eventId: "e2",
+    submissionId: "s2",
+    jobPostingId: postingA,
+    email: "second@b.de",
+  });
+  second.data.responseId = first.data.responseId;
+
+  await expect(ingestTallySubmission(second)).resolves.toEqual({
+    status: "duplicate",
+  });
   expect(await (await applications()).countDocuments()).toBe(1);
 });
 

--- a/app/lib/server/applications/ingest.ts
+++ b/app/lib/server/applications/ingest.ts
@@ -46,21 +46,38 @@ async function recordEvent(
   status: TallyWebhookEvent["status"],
   details: EventDetails,
 ): Promise<void> {
-  await (
-    await tallyWebhookEvents()
-  ).updateOne(
-    { _id: payload.eventId },
-    {
-      $set: {
-        eventType: payload.eventType,
-        submissionId: payload.data.submissionId,
-        status,
-        ...details,
-      },
-      $setOnInsert: { _creationTime: Date.now() },
-    },
-    { upsert: true },
+  const collection = await tallyWebhookEvents();
+  const event = {
+    eventType: payload.eventType,
+    submissionId: payload.data.submissionId,
+    status,
+    ...details,
+  };
+
+  if (status === "processed") {
+    await collection.updateOne(
+      { _id: payload.eventId },
+      { $set: event, $setOnInsert: { _creationTime: Date.now() } },
+      { upsert: true },
+    );
+    return;
+  }
+
+  const result = await collection.updateOne(
+    { _id: payload.eventId, status: { $ne: "processed" } },
+    { $set: event },
   );
+  if (result.matchedCount > 0) return;
+
+  try {
+    await collection.insertOne({
+      _id: payload.eventId,
+      _creationTime: Date.now(),
+      ...event,
+    });
+  } catch (error) {
+    if (!isDuplicateKeyError(error)) throw error;
+  }
 }
 
 export async function ingestTallySubmission(
@@ -115,7 +132,6 @@ export async function ingestTallySubmission(
     applicantName: parsed.name,
     applicantEmail: parsed.email,
     applicantEmailNormalized: parsed.emailNormalized,
-    applicantPhone: parsed.phone,
     fields: parsed.fields,
     tallyEventId: payload.eventId,
     tallySubmissionId: payload.data.submissionId,
@@ -124,13 +140,28 @@ export async function ingestTallySubmission(
     submittedAt: toTimestamp(payload.data.createdAt),
   };
 
+  const applicationCollection = await applications();
   try {
-    await (await applications()).insertOne(application);
+    await applicationCollection.insertOne(application);
   } catch (error) {
     if (!isDuplicateKeyError(error)) throw error;
-    await recordEvent(payload, "duplicate", {
+
+    const existing = await applicationCollection.findOne({
+      $or: [
+        { tallyEventId: payload.eventId },
+        { tallySubmissionId: payload.data.submissionId },
+        { tallyResponseId: payload.data.responseId },
+        {
+          jobPostingId: posting._id,
+          applicantEmailNormalized: parsed.emailNormalized,
+        },
+      ],
+    });
+    const isSameEvent = existing?.tallyEventId === payload.eventId;
+    await recordEvent(payload, isSameEvent ? "processed" : "duplicate", {
       jobPostingId: posting._id,
       organizationId: posting.organizationId,
+      applicationId: existing?._id,
     });
     return { status: "duplicate" };
   }
@@ -140,13 +171,17 @@ export async function ingestTallySubmission(
     organizationId: posting.organizationId,
     applicationId: application._id,
   });
-  await addLog(
-    posting.organizationId,
-    "tally-webhook",
-    "application.received",
-    application._id,
-    posting.title,
-  );
+  try {
+    await addLog(
+      posting.organizationId,
+      "tally-webhook",
+      "application.received",
+      application._id,
+      posting.title,
+    );
+  } catch (error) {
+    console.error("application audit log failed", error);
+  }
 
   return { status: "created", applicationId: application._id };
 }

--- a/app/lib/server/applications/tallyPayload.test.ts
+++ b/app/lib/server/applications/tallyPayload.test.ts
@@ -38,6 +38,12 @@ function payload() {
           value: "+491234",
         },
         { key: "q5", label: "Skills", type: "CHECKBOXES", value: ["a", "b"] },
+        {
+          key: "q6",
+          label: "Verfügbarkeit",
+          type: "MATRIX",
+          value: { monday: ["morning", "evening"] },
+        },
       ],
     },
   });
@@ -53,20 +59,26 @@ test("normalizes the applicant email", () => {
   expect(parsed.emailNormalized).toBe("max@example.com");
 });
 
-test("derives name from first and last name fields and reads phone", () => {
+test("derives name from first and last name fields", () => {
   const parsed = parseTallySubmission(payload());
   expect(parsed.name).toBe("Max Mustermann");
-  expect(parsed.phone).toBe("+491234");
 });
 
-test("snapshot keeps typed answers but drops the hidden field", () => {
+test("snapshot keeps typed answers but drops hidden and phone fields", () => {
   const parsed = parseTallySubmission(payload());
   expect(parsed.fields).toHaveLength(5);
   expect(parsed.fields.some((field) => field.label === "jobPostingId")).toBe(
     false,
   );
+  expect(parsed.fields.some((field) => field.type.includes("PHONE"))).toBe(
+    false,
+  );
   const skills = parsed.fields.find((field) => field.key === "q5");
   expect(skills?.value).toEqual(["a", "b"]);
+  const availability = parsed.fields.find((field) => field.key === "q6");
+  expect(availability?.value).toEqual({
+    monday: ["morning", "evening"],
+  });
 });
 
 test("returns null identity when the hidden field or email is absent", () => {

--- a/app/lib/server/applications/tallyPayload.ts
+++ b/app/lib/server/applications/tallyPayload.ts
@@ -33,7 +33,6 @@ export interface ParsedSubmission {
   email: string | null;
   emailNormalized: string | null;
   name?: string;
-  phone?: string;
   fields: ApplicationField[];
 }
 
@@ -50,12 +49,15 @@ function toFieldValue(value: unknown): ApplicationFieldValue {
   ) {
     return value;
   }
-  if (Array.isArray(value)) {
-    return value.map((item) =>
-      typeof item === "string" ? item : JSON.stringify(item),
-    );
+  if (Array.isArray(value)) return value.map(toFieldValue);
+  if (typeof value === "object") {
+    const snapshot: { [key: string]: ApplicationFieldValue } = {};
+    for (const [key, item] of Object.entries(value)) {
+      snapshot[key] = toFieldValue(item);
+    }
+    return snapshot;
   }
-  return JSON.stringify(value);
+  return String(value);
 }
 
 function isHiddenJobPostingField(field: TallyField): boolean {
@@ -63,6 +65,10 @@ function isHiddenJobPostingField(field: TallyField): boolean {
     (field.label ?? "").trim().toLowerCase() ===
     JOB_POSTING_HIDDEN_FIELD.toLowerCase()
   );
+}
+
+function isPhoneField(field: TallyField): boolean {
+  return field.type.toUpperCase().includes("PHONE");
 }
 
 function pickString(value: unknown): string | undefined {
@@ -107,11 +113,11 @@ export function parseTallySubmission(
   const jobPostingId =
     pickString(allFields.find(isHiddenJobPostingField)?.value) ?? null;
   const email = pickString(findByType(allFields, "EMAIL")?.value) ?? null;
-  const phone = pickString(findByType(allFields, "PHONE")?.value);
 
   const fields: ApplicationField[] = allFields
     .filter((field) => !isHiddenJobPostingField(field))
     .filter((field) => field.type.toUpperCase() !== "HIDDEN_FIELDS")
+    .filter((field) => !isPhoneField(field))
     .map((field) => ({
       key: field.key,
       label: field.label ?? "",
@@ -124,7 +130,6 @@ export function parseTallySubmission(
     email,
     emailNormalized: email ? normalizeEmail(email) : null,
     name: extractName(allFields),
-    phone,
     fields,
   };
 }

--- a/app/lib/server/tally/signature.test.ts
+++ b/app/lib/server/tally/signature.test.ts
@@ -30,3 +30,9 @@ test("rejects a missing signature", () => {
 test("rejects a signature of a different length without throwing", () => {
   expect(verifyTallySignature(BODY, "short", SECRET)).toBe(false);
 });
+
+test("rejects an invalid signature with the expected length", () => {
+  expect(
+    verifyTallySignature(BODY, "x".repeat(sign(BODY).length), SECRET),
+  ).toBe(false);
+});


### PR DESCRIPTION
## summary

- Prevent phone fields from being persisted while preserving structured Tally answer snapshots.
- Make concurrent webhook processing deterministic and enforce uniqueness across event, submission, response, and posting email identifiers.
- Add route-level signature, payload, email-side-effect, snapshot, and duplicate-delivery coverage.

## validation

- `pnpm exec prettier --check <8 changed files>`
- `pnpm exec biome lint <8 changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/api/webhooks/tally/route.test.ts app/lib/server/applications/ingest.test.ts app/lib/server/applications/tallyPayload.test.ts app/lib/server/tally/signature.test.ts`
- `pnpm vitest run`
- `pnpm build` — not run (repo-wide; typecheck and full unit suite passed)