### PR TITLE
feat(job-feed): expose authenticated organization feed

### DIFF
--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -41,6 +41,7 @@ const ACTION_LABELS: Record<string, string> = {
   "jobPosting.archive": "Ausschreibung archiviert",
   "jobPosting.tally.publish": "Bewerbungsformular veröffentlicht",
   "jobPosting.tally.error": "Tally-Synchronisierung fehlgeschlagen",
+  "jobFeedToken.rotate": "Job-Feed-Token rotiert",
 };
 
 export default async function LogsPage() {

--- a/app/api/job-feed-token/route.ts
+++ b/app/api/job-feed-token/route.ts
@@ -1,0 +1,18 @@
+import { rotateJobFeedToken } from "../../lib/server/jobFeed/token";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  try {
+    const data = await rotateJobFeedToken();
+    return Response.json(
+      { data },
+      { status: 201, headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    return Response.json(
+      { error: "Nicht autorisiert" },
+      { status: 401, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/app/api/test/clear/route.ts
+++ b/app/api/test/clear/route.ts
@@ -1,6 +1,7 @@
 import { isTestMode } from "@/lib/auth/environment";
 import {
   departments,
+  jobFeedTokens,
   jobPostings,
   logs,
   organizations,
@@ -39,6 +40,7 @@ export async function POST(request: Request) {
     }
     await (await reimbursements()).deleteMany({ organizationId: org._id });
     await (await volunteerAllowance()).deleteMany({ organizationId: org._id });
+    await (await jobFeedTokens()).deleteMany({ organizationId: org._id });
     await (await jobPostings()).deleteMany({ organizationId: org._id });
     await (await teams()).deleteMany({ organizationId: org._id });
     await (await departments()).deleteMany({ organizationId: org._id });

--- a/app/api/v1/job-postings/route.ts
+++ b/app/api/v1/job-postings/route.ts
@@ -1,0 +1,34 @@
+import { getJobFeedV1 } from "../../../lib/server/jobFeed/feed";
+import { authenticateJobFeedToken } from "../../../lib/server/jobFeed/token";
+
+export const runtime = "nodejs";
+
+const RESPONSE_HEADERS = {
+  "Cache-Control": "private, no-store",
+  Vary: "Authorization",
+};
+
+function bearerToken(request: Request): string | null {
+  const authorization = request.headers.get("authorization");
+  const match = authorization?.match(/^Bearer ([^\s]+)$/);
+  return match?.[1] ?? null;
+}
+
+export async function GET(request: Request) {
+  const token = bearerToken(request);
+  const organizationId = token ? await authenticateJobFeedToken(token) : null;
+  if (!organizationId) {
+    return Response.json(
+      { error: "Nicht autorisiert" },
+      { status: 401, headers: RESPONSE_HEADERS },
+    );
+  }
+
+  const data = await getJobFeedV1(organizationId);
+  return Response.json(
+    { version: "v1", data },
+    {
+      headers: RESPONSE_HEADERS,
+    },
+  );
+}

--- a/app/lib/db/collections.ts
+++ b/app/lib/db/collections.ts
@@ -2,6 +2,7 @@ import { getDb } from "./client";
 import type {
   Application,
   Department,
+  JobFeedToken,
   JobPosting,
   Log,
   Organization,
@@ -38,6 +39,10 @@ export async function teams() {
 
 export async function jobPostings() {
   return (await getDb()).collection<JobPosting>("jobPostings");
+}
+
+export async function jobFeedTokens() {
+  return (await getDb()).collection<JobFeedToken>("jobFeedTokens");
 }
 
 export async function applications() {

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -48,6 +48,11 @@ export async function ensureIndexes(): Promise<void> {
       { key: { tallyFormId: 1 }, sparse: true },
     ]);
 
+  await db.collection("jobFeedTokens").createIndexes([
+    { key: { organizationId: 1 }, unique: true },
+    { key: { tokenHash: 1 }, unique: true },
+  ]);
+
   await db
     .collection("applications")
     .createIndexes([

--- a/app/lib/db/jobFeedToken.ts
+++ b/app/lib/db/jobFeedToken.ts
@@ -1,0 +1,8 @@
+export interface JobFeedToken {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  tokenHash: string;
+  rotatedAt: number;
+  rotatedBy: string;
+}

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -16,6 +16,7 @@ export type CostType =
   | "accommodation";
 
 export type { JobPosting, JobPostingStatus } from "./jobPosting";
+export type { JobFeedToken } from "./jobFeedToken";
 
 export type {
   Application,

--- a/app/lib/server/jobFeed/feed.ts
+++ b/app/lib/server/jobFeed/feed.ts
@@ -1,0 +1,137 @@
+import { berlinToday } from "../../jobPostings/deadline";
+import {
+  departments,
+  jobPostings,
+  organizations,
+  teams,
+} from "../../db/collections";
+import type { JobPosting } from "../../db/types";
+
+export const JOB_FEED_TAG = "YFN_TEAM" as const;
+
+export interface JobFeedItemV1 {
+  id: string;
+  title: string;
+  yfn: string;
+  shortText: string;
+  content: {
+    description: string;
+    tasks: string;
+    requirements: string;
+  };
+  team: string;
+  department: string;
+  timeCommitment: string;
+  location: string;
+  deadline: string | null;
+  contact: string;
+  tallyUrl: string;
+  tags: [typeof JOB_FEED_TAG];
+}
+
+function namespacedId(organizationId: string, postingId: string): string {
+  return `ybase:${organizationId}:job-posting:${postingId}`;
+}
+
+function tallyUrl(formId: string | undefined): string {
+  return formId ? `https://tally.so/r/${encodeURIComponent(formId)}` : "";
+}
+
+export async function getJobFeedV1(
+  organizationId: string,
+  today: string = berlinToday(),
+): Promise<JobFeedItemV1[]> {
+  const organization = await (
+    await organizations()
+  ).findOne({ _id: organizationId }, { projection: { name: 1 } });
+  if (!organization) return [];
+
+  const postings = await (
+    await jobPostings()
+  )
+    .find(
+      {
+        organizationId,
+        status: "published",
+        $or: [
+          { deadline: { $exists: false } },
+          { deadline: "" },
+          { deadline: { $gte: today } },
+        ],
+      },
+      {
+        projection: {
+          _id: 1,
+          title: 1,
+          shortText: 1,
+          description: 1,
+          tasks: 1,
+          requirements: 1,
+          teamId: 1,
+          timeCommitment: 1,
+          location: 1,
+          deadline: 1,
+          contact: 1,
+          tallyFormId: 1,
+        },
+      },
+    )
+    .sort({ _creationTime: -1 })
+    .toArray();
+
+  const teamIds = [...new Set(postings.map((posting) => posting.teamId))];
+  const ownedTeams = await (await teams())
+    .find({ _id: { $in: teamIds }, organizationId })
+    .toArray();
+  const departmentIds = [
+    ...new Set(ownedTeams.map((team) => team.departmentId)),
+  ];
+  const ownedDepartments = await (await departments())
+    .find({ _id: { $in: departmentIds }, organizationId })
+    .toArray();
+  const teamsById = new Map(ownedTeams.map((team) => [team._id, team]));
+  const departmentsById = new Map(
+    ownedDepartments.map((department) => [department._id, department]),
+  );
+
+  return postings.map((posting) =>
+    toFeedItem(
+      posting,
+      organizationId,
+      organization.name,
+      teamsById,
+      departmentsById,
+    ),
+  );
+}
+
+function toFeedItem(
+  posting: JobPosting,
+  organizationId: string,
+  organizationName: string,
+  teamsById: Map<string, { name: string; departmentId: string }>,
+  departmentsById: Map<string, { name: string }>,
+): JobFeedItemV1 {
+  const team = teamsById.get(posting.teamId);
+  const department = team ? departmentsById.get(team.departmentId) : undefined;
+
+  return {
+    id: namespacedId(organizationId, posting._id),
+    title: posting.title,
+    yfn: organizationName,
+    shortText: posting.shortText ?? "",
+    content: {
+      description: posting.description ?? "",
+      tasks: posting.tasks ?? "",
+      requirements: posting.requirements ?? "",
+    },
+    team: team?.name ?? "",
+    department: department?.name ?? "",
+    timeCommitment: posting.timeCommitment ?? "",
+    location: posting.location ?? "",
+    deadline: posting.deadline || null,
+    contact: posting.contact ?? "",
+    tallyUrl: tallyUrl(posting.tallyFormId),
+    tags: [JOB_FEED_TAG],
+  };
+}

--- a/app/lib/server/jobFeed/token.ts
+++ b/app/lib/server/jobFeed/token.ts
@@ -1,0 +1,67 @@
+import { createHash, randomBytes } from "node:crypto";
+import { USER_PERMISSIONS } from "../../auth/roles";
+import { requirePermission } from "../../auth/session";
+import { jobFeedTokens } from "../../db/collections";
+import { newId } from "../../db/ids";
+import { addLog } from "../logs";
+
+const TOKEN_PREFIX = "ybase_feed_";
+const TOKEN_PATTERN = /^ybase_feed_[A-Za-z0-9_-]{43}$/;
+
+export function hashJobFeedToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+function createJobFeedToken(): string {
+  return `${TOKEN_PREFIX}${randomBytes(32).toString("base64url")}`;
+}
+
+export async function authenticateJobFeedToken(
+  token: string,
+): Promise<string | null> {
+  if (!TOKEN_PATTERN.test(token)) return null;
+
+  const storedToken = await (
+    await jobFeedTokens()
+  ).findOne(
+    { tokenHash: hashJobFeedToken(token) },
+    { projection: { organizationId: 1 } },
+  );
+  return storedToken?.organizationId ?? null;
+}
+
+export async function rotateJobFeedToken(): Promise<{
+  token: string;
+  rotatedAt: number;
+}> {
+  const user = await requirePermission(USER_PERMISSIONS.organizationSettings);
+  const token = createJobFeedToken();
+  const rotatedAt = Date.now();
+
+  await (
+    await jobFeedTokens()
+  ).updateOne(
+    { organizationId: user.organizationId },
+    {
+      $set: {
+        tokenHash: hashJobFeedToken(token),
+        rotatedAt,
+        rotatedBy: user._id,
+      },
+      $setOnInsert: {
+        _id: newId(),
+        _creationTime: rotatedAt,
+        organizationId: user.organizationId,
+      },
+    },
+    { upsert: true },
+  );
+
+  await addLog(
+    user.organizationId,
+    user._id,
+    "jobFeedToken.rotate",
+    user.organizationId,
+  );
+  return { token, rotatedAt };
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -11,6 +11,7 @@ erDiagram
     organizations ||--o{ reimbursements : has
     organizations ||--o{ volunteerAllowance : has
     organizations ||--o{ logs : has
+    organizations ||--o| jobFeedTokens : authenticates
     reimbursements ||--o{ receipts : has
     reimbursements ||--o| travelDetails : has
 
@@ -20,6 +21,14 @@ erDiagram
         string domain
         string accountingEmail
         string createdBy
+    }
+
+    jobFeedTokens {
+        string _id
+        string organizationId
+        string tokenHash
+        number rotatedAt
+        string rotatedBy
     }
 
     users {


### PR DESCRIPTION
## summary

- expose a versioned, bearer-authenticated YFN team job feed scoped to one organization
- rotate high-entropy organization tokens while persisting only SHA-256 hashes and returning an explicit safe field allowlist

## validation

- `pnpm exec biome lint <changed TypeScript paths>`
- `pnpm exec tsc --noEmit`
- `pnpm run lint:lines`
- `pnpm exec vitest run app/lib/server/jobPostings/jobPostings.test.ts app/lib/server/jobPostings/lifecycle.test.ts app/lib/jobPostings/deadline.test.ts`
- `pnpm build`
- `pnpm exec prettier --check <changed paths except app/api/test/clear/route.ts>`; the excluded file has a pre-existing formatting difference on `origin/main`