### PR TITLE
fix(recruiting): align department field with form controls

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -50,7 +50,7 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
         </div>
         <div className="flex flex-col gap-2">
           <Label>Department</Label>
-          <div className="flex h-10 items-center border-2 border-input bg-muted px-3 text-sm text-muted-foreground">
+          <div className="flex h-12 items-center border-2 border-input bg-muted px-4 text-sm text-muted-foreground">
             {departmentName}
           </div>
         </div>


### PR DESCRIPTION
## summary

- Match the read-only department field height to adjacent recruiting form controls.
- Align its horizontal padding with the shared input and select styling.

## validation

- `pnpm exec prettier --check app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx`
- `pnpm exec biome lint app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- Automated UI tests not run (presentation-only Tailwind class adjustment).