### PR TITLE
test: streamline the test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ pnpm build                   # Production build
 pnpm lint                    # Biome linting
 pnpm lint:fix                # Biome linting with auto-fix
 pnpm format                  # Prettier formatting
-pnpm test                    # Run all tests (Vitest + Playwright)
-pnpm vitest run              # Unit/integration tests only
+pnpm test                    # Unit/integration tests (Vitest)
+pnpm test:e2e                # E2E tests (Playwright)
+pnpm test:all                # Run Vitest and Playwright
 pnpm coverage                # Tests with coverage report
-pnpm exec playwright test    # E2E tests only
 ```
 
 **Run a single test file:**
@@ -66,7 +66,13 @@ pnpm exec playwright test e2e/reimbursements.spec.ts
 - **Vitest** for unit/integration tests (`app/**/*.test.ts`)
 - **Playwright** for E2E tests (`e2e/*.spec.ts`)
 - MongoDB integration tests use `mongodb-memory-server`
-- Shared test setup lives in `vitest.setup.ts`
+- Test observable behavior, risk boundaries, and concrete regressions—not implementation details
+- Require targeted tests for money, permissions, tenant isolation, destructive actions, and external integrations
+- Do not add tests for styling, copy, trivial wiring, or refactors without behavior changes
+- Test each behavior at the lowest stable layer; avoid duplicating it across helpers, actions, routes, and UI
+- Prefer state and user-visible outcomes over exact mock call sequences
+- Run the narrowest relevant test locally; CI owns the complete Vitest and Playwright suites
+- Do not introduce a blanket coverage target
 
 ## Documentation
 

--- a/app/lib/db/foundation.test.ts
+++ b/app/lib/db/foundation.test.ts
@@ -1,28 +1,11 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
+import { expect, test } from "vitest";
 import { ensureAppUser } from "../auth/provisioning";
-import { getClient, getDb } from "./client";
+import { setupTestDatabase } from "../test/setupTestDatabase";
+import { getDb } from "./client";
 import { organizations } from "./collections";
 import { newId } from "./ids";
 
-let mongod: MongoMemoryServer;
-
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
-
-beforeEach(async () => {
-  const db = await getDb();
-  await db.dropDatabase();
-});
+setupTestDatabase();
 
 test("ensureAppUser creates a user and auto-joins an existing org by domain", async () => {
   const organizationId = newId();

--- a/app/lib/server/applications/ingest.test.ts
+++ b/app/lib/server/applications/ingest.test.ts
@@ -1,6 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
-import { getClient, getDb } from "../../db/client";
+import { beforeEach, expect, test } from "vitest";
 import {
   applications,
   jobPostings,
@@ -8,11 +6,11 @@ import {
 } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { JobPosting } from "../../db/types";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { ensureIndexes } from "../../db/indexes";
 import { ingestTallySubmission } from "./ingest";
 import { tallyWebhookSchema } from "./tallyPayload";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let postingA: string;
 let postingA2: string;
@@ -89,20 +87,9 @@ async function insertPosting(
   return _id;
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   await ensureIndexes();
   orgA = newId();
   postingA = await insertPosting(orgA);

--- a/app/lib/server/departments/departments.test.ts
+++ b/app/lib/server/departments/departments.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -8,9 +7,10 @@ vi.mock("../../auth/session", () => ({
 
 import { requirePermission, requireUser } from "../../auth/session";
 import { USER_PERMISSIONS } from "../../auth/roles";
-import { getClient, getDb } from "../../db/client";
 import { departments, organizations } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import {
   archiveDepartment,
   createDepartment,
@@ -19,25 +19,13 @@ import {
 } from "./actions";
 import { getActiveDepartments, getArchivedDepartments } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
@@ -60,14 +48,11 @@ beforeEach(async () => {
       createdBy: newId(),
     },
   ]);
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "people_culture" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+    role: "people_culture",
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requirePermission).mockResolvedValue(actor);
 });

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -7,13 +6,13 @@ vi.mock("../../auth/session", () => ({
 }));
 
 import { requirePermission, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { departments, jobPostings, teams } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { createJobPostingDraft, updateJobPosting } from "./actions";
 import { getJobPostingById, getJobPostings } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
@@ -49,32 +48,18 @@ async function insertTeam(
   return _id;
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "people_culture" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+    role: "people_culture",
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requirePermission).mockResolvedValue(actor);
   teamA = await insertTeam(orgA);

--- a/app/lib/server/jobPostings/lifecycle.test.ts
+++ b/app/lib/server/jobPostings/lifecycle.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -8,9 +7,10 @@ vi.mock("../../auth/session", () => ({
 vi.mock("../tally/client", () => ({ createConfiguredTallyClient: vi.fn() }));
 
 import { requirePermission } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { jobPostings, logs } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import type { JobPosting } from "../../db/types";
 import { createConfiguredTallyClient } from "../tally/client";
 import {
@@ -21,7 +21,6 @@ import {
 } from "./lifecycle";
 import { closeExpiredJobPostings } from "./tallySync";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
@@ -68,32 +67,18 @@ async function logsFor(id: string) {
   return (await logs()).find({ entityId: id }).toArray();
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "people_culture" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+    role: "people_culture",
+  });
   vi.mocked(requirePermission).mockResolvedValue(actor);
   fakeClient();
 });

--- a/app/lib/server/jobPostings/tallyForm.test.ts
+++ b/app/lib/server/jobPostings/tallyForm.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -9,15 +8,15 @@ vi.mock("../tally/client", () => ({ createConfiguredTallyClient: vi.fn() }));
 vi.mock("../tally/config", () => ({ loadTallyFormConfig: vi.fn() }));
 
 import { requirePermission } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { jobPostings, logs } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import type { JobPosting } from "../../db/types";
 import { createConfiguredTallyClient } from "../tally/client";
 import { loadTallyFormConfig } from "../tally/config";
 import { generateTallyForm } from "./tallyForm";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
@@ -77,32 +76,20 @@ function find(id: string) {
   return jobPostings().then((c) => c.findOne({ _id: id }));
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  vi.mocked(requirePermission).mockResolvedValue({
-    _id: userA,
-    _creationTime: Date.now(),
-    organizationId: orgA,
-    role: "people_culture" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  });
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({
+      _id: userA,
+      organizationId: orgA,
+      role: "people_culture",
+    }),
+  );
   vi.mocked(loadTallyFormConfig).mockReturnValue({
     workspaceId: "ws",
     templateFormId: "tpl",

--- a/app/lib/server/logs/logs.test.ts
+++ b/app/lib/server/logs/logs.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -7,51 +6,52 @@ vi.mock("../../auth/session", () => ({
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { logs, organizations } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { getLogs } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  await (await organizations()).insertMany([
-    { _id: orgA, _creationTime: Date.now(), name: "A", domain: "a.org", createdBy: userA },
-    { _id: orgB, _creationTime: Date.now(), name: "B", domain: "b.org", createdBy: newId() },
+  await (
+    await organizations()
+  ).insertMany([
+    {
+      _id: orgA,
+      _creationTime: Date.now(),
+      name: "A",
+      domain: "a.org",
+      createdBy: userA,
+    },
+    {
+      _id: orgB,
+      _creationTime: Date.now(),
+      name: "B",
+      domain: "b.org",
+      createdBy: newId(),
+    },
   ]);
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "admin" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
 });
 
 test("getLogs returns only the caller's org logs, newest-first", async () => {
-  await (await logs()).insertMany([
+  await (
+    await logs()
+  ).insertMany([
     {
       _id: newId(),
       _creationTime: 1000,

--- a/app/lib/server/organizations/organizations.test.ts
+++ b/app/lib/server/organizations/organizations.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireAuthenticatedUser: vi.fn(),
@@ -12,39 +11,45 @@ import {
   requireRole,
   requireUser,
 } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
+import { getDb } from "../../db/client";
 import { organizations, projects, users } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { initializeOrganization, updateOrganization } from "./actions";
 import { getOrganization, getOrganizationByDomain } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  await (await organizations()).insertMany([
-    { _id: orgA, _creationTime: Date.now(), name: "A", domain: "a.org", createdBy: userA },
-    { _id: orgB, _creationTime: Date.now(), name: "B", domain: "b.org", createdBy: newId() },
+  await (
+    await organizations()
+  ).insertMany([
+    {
+      _id: orgA,
+      _creationTime: Date.now(),
+      name: "A",
+      domain: "a.org",
+      createdBy: userA,
+    },
+    {
+      _id: orgB,
+      _creationTime: Date.now(),
+      name: "B",
+      domain: "b.org",
+      createdBy: newId(),
+    },
   ]);
-  await (await users()).insertOne({
+  await (
+    await users()
+  ).insertOne({
     _id: userA,
     _creationTime: Date.now(),
     email: "boss@a.org",
@@ -53,15 +58,11 @@ beforeEach(async () => {
     memberStatus: "active",
     teamOnboardingStatus: "completed",
   });
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     email: "boss@a.org",
     organizationId: orgA,
-    role: "admin" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+  });
   vi.mocked(requireAuthenticatedUser).mockResolvedValue(actor);
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
@@ -124,7 +125,9 @@ test("initializeOrganization returns the existing org when the caller already ha
 
 test("initializeOrganization joins an existing org by email domain", async () => {
   const newUser = newId();
-  await (await users()).insertOne({
+  await (
+    await users()
+  ).insertOne({
     _id: newUser,
     _creationTime: Date.now(),
     email: "member@b.org",
@@ -149,7 +152,9 @@ test("initializeOrganization joins an existing org by email domain", async () =>
 
 test("initializeOrganization creates a new org with an Allgemein project", async () => {
   const founder = newId();
-  await (await users()).insertOne({
+  await (
+    await users()
+  ).insertOne({
     _id: founder,
     _creationTime: Date.now(),
     email: "founder@fresh.org",
@@ -164,16 +169,22 @@ test("initializeOrganization creates a new org with an Allgemein project", async
     teamOnboardingStatus: "not_started",
   });
 
-  const result = await initializeOrganization({ organizationName: "Fresh e.V." });
+  const result = await initializeOrganization({
+    organizationName: "Fresh e.V.",
+  });
   expect(result.isNew).toBe(true);
 
-  const created = await (await organizations()).findOne({
+  const created = await (
+    await organizations()
+  ).findOne({
     _id: result.organizationId,
   });
   expect(created?.name).toBe("Fresh e.V.");
   expect(created?.domain).toBe("fresh.org");
 
-  const project = await (await projects()).findOne({
+  const project = await (
+    await projects()
+  ).findOne({
     organizationId: result.organizationId,
   });
   expect(project?.name).toBe("Allgemein");

--- a/app/lib/server/projects/projects.test.ts
+++ b/app/lib/server/projects/projects.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -7,9 +6,10 @@ vi.mock("../../auth/session", () => ({
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { organizations, projects, reimbursements } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import {
   archiveProject,
   createProject,
@@ -19,25 +19,13 @@ import {
 } from "./actions";
 import { getAllProjects, getArchivedProjects } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
@@ -60,14 +48,10 @@ beforeEach(async () => {
       createdBy: newId(),
     },
   ]);
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "admin" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
 });

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -1,13 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  expect,
-  test,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -34,16 +25,15 @@ vi.mock("./email", () => ({
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
-import {
-  organizations,
-  projects,
-  receipts,
-  reimbursements,
-  users,
-} from "../../db/collections";
+import { receipts, reimbursements, users } from "../../db/collections";
 import { newId } from "../../db/ids";
+import {
+  createTestActor,
+  insertTestOrganization,
+  insertTestProject,
+} from "../../test/fixtures";
 import { deleteObject, getDownloadInfo } from "../../s3/storage";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import {
   approve,
   createReimbursement,
@@ -61,62 +51,39 @@ import {
 } from "./email";
 import { createReimbursementLink } from "./sharing";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
 let projectA: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
   projectA = newId();
-  await (
-    await organizations()
-  ).insertMany([
-    {
-      _id: orgA,
-      _creationTime: Date.now(),
-      name: "A",
-      domain: "a.org",
-      createdBy: userA,
-      accountingEmail: "accounting@a.org",
-    },
-    {
-      _id: orgB,
-      _creationTime: Date.now(),
-      name: "B",
-      domain: "b.org",
-      createdBy: newId(),
-    },
-  ]);
-  await (
-    await projects()
-  ).insertOne({
+  await insertTestOrganization({
+    _id: orgA,
+    name: "A",
+    domain: "a.org",
+    createdBy: userA,
+    accountingEmail: "accounting@a.org",
+  });
+  await insertTestOrganization({
+    _id: orgB,
+    name: "B",
+    domain: "b.org",
+  });
+  await insertTestProject({
     _id: projectA,
-    _creationTime: Date.now(),
     name: "Projekt A",
     organizationId: orgA,
-    isArchived: false,
     createdBy: userA,
   });
   await (
@@ -131,14 +98,11 @@ beforeEach(async () => {
     memberStatus: "active",
     teamOnboardingStatus: "completed",
   });
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "finance" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+    role: "finance",
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
 });

--- a/app/lib/server/teams/teams.test.ts
+++ b/app/lib/server/teams/teams.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -7,13 +6,13 @@ vi.mock("../../auth/session", () => ({
 }));
 
 import { requirePermission, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { departments, organizations, teams } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { archiveTeam, createTeam, unarchiveTeam, updateTeam } from "./actions";
 import { getActiveTeams, getArchivedTeams } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
@@ -37,20 +36,9 @@ async function insertDepartment(
   return _id;
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
@@ -73,14 +61,11 @@ beforeEach(async () => {
       createdBy: newId(),
     },
   ]);
-  const actor = {
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "people_culture" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+    role: "people_culture",
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requirePermission).mockResolvedValue(actor);
   departmentA = await insertDepartment(orgA);

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -12,9 +11,10 @@ import {
   requireRole,
   requireUser,
 } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { logs, organizations, teams, users } from "../../db/collections";
 import { newId } from "../../db/ids";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import {
   addUserToOrganization,
   setMemberStatus,
@@ -25,27 +25,15 @@ import {
 } from "./actions";
 import { listMembers } from "./data";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let adminA: string;
 let memberA: string;
 let memberB: string;
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   orgA = newId();
   orgB = newId();
   adminA = newId();
@@ -103,14 +91,10 @@ beforeEach(async () => {
       teamOnboardingStatus: "completed",
     },
   ]);
-  const actor = {
+  const actor = createTestActor({
     _id: adminA,
-    _creationTime: Date.now(),
     organizationId: orgA,
-    role: "admin" as const,
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
+  });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
   vi.mocked(requirePermission).mockResolvedValue(actor);

--- a/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
+++ b/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -20,15 +19,15 @@ vi.mock("./email", () => ({
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
-import {
-  organizations,
-  projects,
-  users,
-  volunteerAllowance,
-} from "../../db/collections";
+import { users, volunteerAllowance } from "../../db/collections";
 import { newId } from "../../db/ids";
+import {
+  createTestActor,
+  insertTestOrganization,
+  insertTestProject,
+} from "../../test/fixtures";
 import { deleteObject } from "../../s3/storage";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { create, remove } from "./actions";
 import { getAll } from "./data";
 import {
@@ -41,7 +40,6 @@ import {
 import { createLink } from "./sharing";
 import { approve, decline, requestChanges } from "./reviewActions";
 
-let mongod: MongoMemoryServer;
 let orgA: string;
 let orgB: string;
 let userA: string;
@@ -63,80 +61,52 @@ function newAllowanceInput(projectId: string) {
   };
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_test";
-}, 120_000);
+async function insertProject(): Promise<string> {
+  const project = await insertTestProject({
+    name: "Projekt A",
+    organizationId: orgA,
+    createdBy: userA,
+  });
+  return project._id;
+}
 
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   vi.clearAllMocks();
   orgA = newId();
   orgB = newId();
   userA = newId();
-  await (
-    await organizations()
-  ).insertMany([
-    {
-      _id: orgA,
-      _creationTime: Date.now(),
-      name: "A",
-      domain: "a.org",
-      createdBy: userA,
-      accountingEmail: "accounting@a.org",
-    },
-    {
-      _id: orgB,
-      _creationTime: Date.now(),
-      name: "B",
-      domain: "b.org",
-      createdBy: newId(),
-    },
-  ]);
-  const actor = {
+  await insertTestOrganization({
+    _id: orgA,
+    name: "A",
+    domain: "a.org",
+    createdBy: userA,
+    accountingEmail: "accounting@a.org",
+  });
+  await insertTestOrganization({
+    _id: orgB,
+    name: "B",
+    domain: "b.org",
+  });
+  const actor = createTestActor({
     _id: userA,
-    _creationTime: Date.now(),
-    organizationId: orgA,
-    role: "finance" as const,
-    email: "actor@a.org",
-    memberStatus: "active" as const,
-    teamOnboardingStatus: "completed" as const,
-  };
-  await (
-    await users()
-  ).insertOne({
-    _id: userA,
-    _creationTime: Date.now(),
-    name: "Actor",
     organizationId: orgA,
     role: "finance",
     email: "actor@a.org",
-    memberStatus: "active",
-    teamOnboardingStatus: "completed",
+  });
+  await (
+    await users()
+  ).insertOne({
+    ...actor,
+    name: "Actor",
   });
   vi.mocked(requireUser).mockResolvedValue(actor);
   vi.mocked(requireRole).mockResolvedValue(actor);
 });
 
 test("create + getAll stay scoped to the caller's org", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   await create(newAllowanceInput(projectA));
 
@@ -205,17 +175,7 @@ test("create rejects missing bank details", async () => {
 });
 
 test("create persists the allowance as pending", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   const id = await create(newAllowanceInput(projectA));
   const doc = await (await volunteerAllowance()).findOne({ _id: id });
@@ -239,17 +199,7 @@ test("creating an emailed allowance request sends the request template", async (
 });
 
 test("approve sets status approved", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   const id = await create(newAllowanceInput(projectA));
   await approve({ id });
@@ -262,17 +212,7 @@ test("approve sets status approved", async () => {
 });
 
 test("decline sets status and sends the review email", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   const id = await create(newAllowanceInput(projectA));
   await decline({ id, rejectionNote: "Angaben fehlen" });
@@ -284,17 +224,7 @@ test("decline sets status and sends the review email", async () => {
 });
 
 test("requestChanges opens the allowance for editing and sends an email", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   const id = await create(newAllowanceInput(projectA));
   await requestChanges({ id, reviewNote: "Zeitraum korrigieren" });
@@ -307,17 +237,7 @@ test("requestChanges opens the allowance for editing and sends an email", async 
 });
 
 test("remove deletes the signature from S3 and the document", async () => {
-  const projectA = newId();
-  await (
-    await projects()
-  ).insertOne({
-    _id: projectA,
-    _creationTime: Date.now(),
-    name: "Projekt A",
-    organizationId: orgA,
-    isArchived: false,
-    createdBy: userA,
-  });
+  const projectA = await insertProject();
 
   const id = await create(newAllowanceInput(projectA));
   await remove({ id });

--- a/app/lib/test/fixtures.ts
+++ b/app/lib/test/fixtures.ts
@@ -1,0 +1,52 @@
+import { organizations, projects } from "../db/collections";
+import { newId } from "../db/ids";
+import type { Organization, Project, User, UserRole } from "../db/types";
+
+export type TestActor = User & {
+  organizationId: string;
+  role: UserRole;
+};
+
+export function createTestActor(
+  overrides: Pick<TestActor, "organizationId"> & Partial<TestActor>,
+): TestActor {
+  return {
+    _id: newId(),
+    _creationTime: Date.now(),
+    role: "admin",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+    registeredAt: Date.now(),
+    ...overrides,
+  };
+}
+
+export async function insertTestOrganization(
+  overrides: Partial<Organization> = {},
+): Promise<Organization> {
+  const id = overrides._id ?? newId();
+  const organization: Organization = {
+    _id: id,
+    _creationTime: Date.now(),
+    name: "Test Organization",
+    domain: `${id}.test`,
+    createdBy: newId(),
+    ...overrides,
+  };
+  await (await organizations()).insertOne(organization);
+  return organization;
+}
+
+export async function insertTestProject(
+  overrides: Pick<Project, "organizationId" | "createdBy"> & Partial<Project>,
+): Promise<Project> {
+  const project: Project = {
+    _id: newId(),
+    _creationTime: Date.now(),
+    name: "Test Project",
+    isArchived: false,
+    ...overrides,
+  };
+  await (await projects()).insertOne(project);
+  return project;
+}

--- a/app/lib/test/setupTestDatabase.ts
+++ b/app/lib/test/setupTestDatabase.ts
@@ -1,0 +1,23 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { afterAll, beforeAll, beforeEach } from "vitest";
+import { getClient, getDb } from "../db/client";
+
+export function setupTestDatabase() {
+  let server: MongoMemoryServer;
+
+  beforeAll(async () => {
+    server = await MongoMemoryServer.create();
+    process.env.MONGODB_URI = server.getUri();
+    process.env.MONGODB_DB = "ybase_test";
+  }, 120_000);
+
+  afterAll(async () => {
+    const client = await getClient();
+    await client.close();
+    await server.stop();
+  }, 30_000);
+
+  beforeEach(async () => {
+    await (await getDb()).dropDatabase();
+  });
+}

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -26,14 +26,9 @@ async function selectOption(page: Page, triggerId: string, option: string) {
 }
 
 test.describe("Ausschreibungen", () => {
-  let page: Page;
-
-  test.beforeAll(async ({ browser }) => {
+  test.beforeEach(async ({ page }) => {
     await cleanup();
-    page = await browser.newPage();
-    await page.context().clearCookies();
     await page.goto("/login");
-    await page.evaluate(() => localStorage.clear());
     await page.getByTestId("test-auth-email").fill(TEST_EMAIL);
     await page.getByTestId("test-auth-submit").click();
 
@@ -67,12 +62,11 @@ test.describe("Ausschreibungen", () => {
     await expect(page.getByText("Team erstellt")).toBeVisible();
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await cleanup();
-    await page.close();
   });
 
-  test("create a draft, edit rich text and persist it", async () => {
+  test("create, edit and manage a job posting", async ({ page }) => {
     await page.goto("/recruiting");
     const createButton = page.getByRole("button", {
       name: "Neue Ausschreibung",
@@ -98,9 +92,7 @@ test.describe("Ausschreibungen", () => {
       DESCRIPTION,
     );
     await expect(page.getByLabel("Ort")).toHaveValue("Berlin");
-  });
 
-  test("publish, close and reopen with the status actions", async () => {
     await page.getByRole("button", { name: "Veröffentlichen" }).click();
     await expect(page.getByText("Ausschreibung veröffentlicht")).toBeVisible();
     await expect(

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -60,20 +60,33 @@ async function addSignature(page: Page) {
   await expect(saved.locator("..").locator(".animate-spin")).toHaveCount(0);
 }
 
+async function saveBankDetails(page: Page) {
+  await page.getByPlaceholder("Vor- und Nachname").last().fill("Test User");
+  await page
+    .getByPlaceholder("DE12 3456 7890 0000 0000 00")
+    .fill("DE89370400440532013000");
+  await page.getByRole("button", { name: "Speichern" }).click();
+  await expect(page.getByText("Bankverbindung gespeichert")).toBeVisible();
+}
+
+async function expectSubmission(page: Page, successMessage: string) {
+  const success = page.getByText(successMessage);
+  const failure = page.getByText(/Fehler beim Einreichen|Bitte .*auswählen/);
+  await expect(success.or(failure)).toBeVisible();
+  if (await failure.isVisible()) {
+    throw new Error(await failure.innerText());
+  }
+}
+
 async function selectRowAction(page: Page, row: Locator, action: string) {
   await row.getByRole("button", { name: "Aktionen anzeigen" }).click();
   await page.getByRole("menuitem", { name: action, exact: true }).click();
 }
 
-test.describe.serial("reimbursement flow", () => {
-  let page: Page;
-
-  test.beforeAll(async ({ browser }) => {
+test.describe("critical reimbursement journeys", () => {
+  test.beforeEach(async ({ page }) => {
     await cleanup();
-    page = await browser.newPage();
-    await page.context().clearCookies();
     await page.goto("/login");
-    await page.evaluate(() => localStorage.clear());
     await page.getByTestId("test-auth-email").fill(TEST_EMAIL);
     await page.getByTestId("test-auth-submit").click();
 
@@ -89,29 +102,15 @@ test.describe.serial("reimbursement flow", () => {
     });
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await cleanup();
-    await page.close();
   });
 
-  test("1. Create expense reimbursement with JPG receipt", async () => {
+  test("expense reimbursement can be revised and approved", async ({
+    page,
+  }) => {
     await page.getByRole("link", { name: "Erstattungen" }).click();
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
-    const reimbursementTabs = page.getByRole("tab");
-    await expect(reimbursementTabs).toHaveCount(3);
-    expect(await reimbursementTabs.allTextContents()).toEqual([
-      "Reisekostenerstattung",
-      "Auslagenerstattung",
-      "Ehrenamtspauschale",
-    ]);
-    await expect(
-      page.getByRole("tab", { name: "Reisekostenerstattung" }),
-    ).toHaveAttribute("data-state", "active");
-    await page.getByRole("tab", { name: "Auslagenerstattung" }).click();
-    await expect(page.getByRole("note")).toContainText(
-      "Falls möglich, gib bei Rechnungen im Feld „Unternehmen/Institution“ Test Verein an.",
-    );
-
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Neues Projekt erstellen" }).click();
     await page
@@ -123,6 +122,9 @@ test.describe.serial("reimbursement flow", () => {
       .fill("Team-Wochenende");
     await page.getByRole("button", { name: "Projekt erstellen" }).click();
     await expect(page.getByText("Projekt erstellt")).toBeVisible();
+    await page.getByRole("tab", { name: "Auslagenerstattung" }).click();
+    await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
+    await page.getByRole("button", { name: "Test Projekt" }).click();
 
     await page
       .getByRole("textbox", {
@@ -138,28 +140,6 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("textbox", { name: "TT.MM.JJJJ" }).fill("01.01.2025");
     await page.getByPlaceholder("119,95").fill("100");
 
-    const receiptDropzone = page.getByRole("region", {
-      name: "Beleg hochladen",
-    });
-    await expect(receiptDropzone).toHaveCSS("display", "flex");
-    const receiptDropzoneBorder = receiptDropzone.locator(
-      '[data-slot="receipt-dropzone-border"]',
-    );
-    await expect(receiptDropzoneBorder).toHaveCSS("position", "absolute");
-    await expect(receiptDropzoneBorder).toHaveCSS("border-style", "dashed");
-    await expect(receiptDropzoneBorder).toHaveCSS("border-radius", "8px");
-    await expect(receiptDropzoneBorder).toHaveCSS("inset", "0px");
-    await expect(receiptDropzoneBorder).toHaveCount(1);
-    await expect(receiptDropzoneBorder).toBeVisible();
-    expect(await receiptDropzoneBorder.boundingBox()).toEqual(
-      await receiptDropzone.boundingBox(),
-    );
-    const selectReceiptButton = page.getByRole("button", {
-      name: "Datei auswählen",
-    });
-    await expect(selectReceiptButton).toBeVisible();
-    await expect(selectReceiptButton).toHaveCSS("border-radius", "0px");
-
     await page.locator('input[type="file"]').setInputFiles(IMAGE_FILE);
     await expect(page.getByText("Beleg hochgeladen")).toBeVisible({
       timeout: 10000,
@@ -168,19 +148,13 @@ test.describe.serial("reimbursement flow", () => {
     await page.getByRole("button", { name: "Beleg speichern" }).click();
     await expect(page.getByText("Test Firma")).toBeVisible();
 
-    await page.getByPlaceholder("Vor- und Nachname").fill("Test User");
-    await page
-      .getByPlaceholder("DE12 3456 7890 0000 0000 00")
-      .fill("DE89370400440532013000");
-    await page.getByRole("button", { name: "Speichern" }).click();
-    await expect(page.getByText("Bankverbindung gespeichert")).toBeVisible();
-
+    await saveBankDetails(page);
     await addSignature(page);
 
     await page
       .getByRole("button", { name: "Zur Genehmigung einreichen" })
       .click();
-    await expect(page.getByText("Erstattung eingereicht")).toBeVisible();
+    await expectSubmission(page, "Erstattung eingereicht");
     await expect(
       page.getByRole("cell", { name: "Test Projekt", exact: true }),
     ).toBeVisible();
@@ -188,34 +162,7 @@ test.describe.serial("reimbursement flow", () => {
       page.getByRole("cell", { name: "Auslagenerstattung" }),
     ).toBeVisible();
     await expect(page.getByText("Ausstehend")).toBeVisible();
-  });
 
-  test("row action menu matches the member platform", async () => {
-    const actionTrigger = page
-      .locator("table tbody tr")
-      .first()
-      .getByRole("button", { name: "Aktionen anzeigen" });
-
-    await expect(actionTrigger.locator("svg")).toHaveCSS("width", "24px");
-    await expect(actionTrigger).toHaveCSS("border-radius", "4px");
-    await actionTrigger.click();
-
-    const actionMenu = page.getByRole("menu");
-    const firstAction = actionMenu.getByRole("menuitem").first();
-
-    await expect(actionMenu).toHaveCSS("min-width", "220px");
-    await expect(actionMenu).toHaveCSS("padding", "0px");
-    await expect(actionMenu).toHaveCSS("border-radius", "2px");
-    await expect(firstAction).toHaveCSS("gap", "16px");
-    await expect(firstAction).toHaveCSS("padding", "12px 16px");
-    await expect(firstAction).toHaveCSS("font-weight", "500");
-
-    await firstAction.hover();
-    await expect(firstAction).toHaveCSS("background-color", "rgb(255, 237, 0)");
-    await page.keyboard.press("Escape");
-  });
-
-  test("2. Request changes and resubmit an expense reimbursement", async () => {
     const expenseRow = page.locator("table tbody tr").first();
     await selectRowAction(page, expenseRow, "Änderungen anfordern");
     await page
@@ -251,9 +198,6 @@ test.describe.serial("reimbursement flow", () => {
     await expect(
       page.locator("table tbody tr").first().getByText("Ausstehend"),
     ).toBeVisible();
-  });
-
-  test("3. Approve expense reimbursement", async () => {
     await selectRowAction(
       page,
       page.locator("table tbody tr").first(),
@@ -264,11 +208,14 @@ test.describe.serial("reimbursement flow", () => {
     ).toBeVisible();
   });
 
-  test("4. Create travel reimbursement with PDF receipt", async () => {
+  test("travel reimbursement can be submitted and declined", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "Erstattungen" }).click();
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
 
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
-    await page.getByRole("button", { name: "Test Projekt" }).click();
+    await page.getByRole("button", { name: "Allgemein" }).click();
 
     const destination = page.getByRole("textbox", {
       name: "z.B. München, Berlin",
@@ -276,8 +223,6 @@ test.describe.serial("reimbursement flow", () => {
     const purpose = page.getByRole("textbox", {
       name: "z.B. Kundentermin, Konferenz",
     });
-    await expect(destination).toHaveValue("Köln");
-    await expect(purpose).toHaveValue("Team-Wochenende");
     await destination.fill("Berlin");
     await purpose.fill("Event");
     await page
@@ -287,34 +232,10 @@ test.describe.serial("reimbursement flow", () => {
     await page
       .getByRole("textbox", { name: "TT.MM.JJJJ" })
       .nth(1)
-      .fill("20.05.2025");
-    await page.getByRole("textbox", { name: "TT.MM.JJJJ" }).nth(1).blur();
-    await expect(
-      page.getByText(
-        "Das Reiseende muss am oder nach dem Reisebeginn liegen. Korrigiere das Datum, um die Kostenarten anzuzeigen.",
-      ),
-    ).toBeVisible();
-
-    await page
-      .getByRole("textbox", { name: "TT.MM.JJJJ" })
-      .nth(1)
       .fill("20.05.2026");
     await page.getByRole("textbox", { name: "TT.MM.JJJJ" }).nth(1).blur();
 
     await page.getByRole("button", { name: "PKW" }).click();
-
-    const receiptCard = page
-      .getByRole("heading", { name: /^PKW/ })
-      .locator("..")
-      .locator("..");
-    const overflowingLabels = await receiptCard
-      .locator("label")
-      .evaluateAll((labels) =>
-        labels
-          .filter((label) => label.scrollWidth > label.clientWidth)
-          .map((label) => label.textContent),
-      );
-    expect(overflowingLabels).toEqual([]);
 
     await page.getByPlaceholder("Eigenfahrt, Miles, Sixt, etc.").fill("Miles");
     await page
@@ -339,91 +260,22 @@ test.describe.serial("reimbursement flow", () => {
     await expect(page.getByText("PKW500 km × 0,30 €")).toBeVisible();
     await expect(page.getByText("Brutto gesamt192,00 €")).toBeVisible();
 
+    await saveBankDetails(page);
     await addSignature(page);
 
     await page
       .getByRole("button", { name: "Zur Genehmigung einreichen" })
       .click();
-    await expect(
-      page.getByText("Reisekostenerstattung eingereicht"),
-    ).toBeVisible();
+    await expectSubmission(page, "Reisekostenerstattung eingereicht");
     const travelRow = page.locator("table tbody tr").first();
     await expect(
       travelRow.getByText("Reisekostenerstattung", { exact: true }),
     ).toBeVisible();
     await expect(
-      travelRow.getByText("Test Projekt", { exact: true }),
+      travelRow.getByText("Allgemein", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText("Ausstehend")).toBeVisible();
-  });
 
-  test("5. Filter reimbursements by type", async () => {
-    const tableRows = page.locator("table tbody tr");
-
-    await expect(tableRows).toHaveCount(2);
-    await tableRows
-      .first()
-      .getByRole("checkbox", { name: "Antrag auswählen" })
-      .check();
-    await expect(
-      page.getByRole("button", { name: "Herunterladen", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Finom CSV", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "SEPA XML", exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Löschen", exact: true }),
-    ).toBeVisible();
-
-    await page
-      .getByRole("tab", { name: "Reisekostenerstattung", exact: true })
-      .click();
-    await expect(
-      page.getByRole("button", { name: "Herunterladen", exact: true }),
-    ).not.toBeVisible();
-    await expect(tableRows).toHaveCount(1);
-    await expect(
-      page.getByRole("cell", { name: "Reisekostenerstattung" }),
-    ).toBeVisible();
-
-    await page
-      .getByRole("tab", { name: "Auslagenerstattung", exact: true })
-      .click();
-    await expect(tableRows).toHaveCount(1);
-    await expect(
-      page.getByRole("cell", { name: "Auslagenerstattung" }),
-    ).toBeVisible();
-
-    await page
-      .getByRole("tab", { name: "Ehrenamtspauschale", exact: true })
-      .click();
-    await expect(page.getByText("Keine Erstattungen gefunden.")).toBeVisible();
-
-    await page.getByRole("tab", { name: "Alle", exact: true }).click();
-    await expect(tableRows).toHaveCount(2);
-  });
-
-  test("asks for confirmation before deleting a travel reimbursement", async () => {
-    const travelRow = page.locator("table tbody tr").first();
-    await selectRowAction(page, travelRow, "Löschen");
-
-    await expect(
-      page.getByRole("alertdialog", {
-        name: "Reisekostenerstattung löschen?",
-      }),
-    ).toBeVisible();
-    await expect(
-      page.getByText("Diese Aktion kann nicht rückgängig gemacht werden."),
-    ).toBeVisible();
-    await page.getByRole("button", { name: "Abbrechen" }).click();
-
-    await expect(travelRow).toBeVisible();
-  });
-
-  test("6. Reject travel reimbursement", async () => {
     await selectRowAction(
       page,
       page.locator("table tbody tr").first(),
@@ -448,42 +300,18 @@ test.describe.serial("reimbursement flow", () => {
     await page.goto("/reimbursements");
   });
 
-  test("admin can delete processed reimbursements individually and in bulk", async () => {
-    const travelRow = page.locator("table tbody tr").first();
-
-    await page.getByRole("checkbox", { name: "Alle auswählen" }).check();
-    await page.getByRole("button", { name: "Löschen", exact: true }).click();
-    await expect(
-      page.getByRole("alertdialog", {
-        name: "Ausgewählte Erstattungen löschen?",
-      }),
-    ).toBeVisible();
-    await page.getByRole("button", { name: "Abbrechen" }).click();
-
-    await selectRowAction(page, travelRow, "Löschen");
-    await expect(
-      page.getByRole("alertdialog", {
-        name: "Reisekostenerstattung löschen?",
-      }),
-    ).toBeVisible();
-    await page.getByRole("button", { name: "Abbrechen" }).click();
-    await page.getByRole("checkbox", { name: "Alle auswählen" }).uncheck();
-  });
-
-  test("7. Request changes and resubmit a volunteer allowance", async () => {
+  test("volunteer allowance can be revised and resubmitted", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "Erstattungen" }).click();
     await page.getByRole("button", { name: "Neue Erstattung" }).click();
     await expect(page).toHaveURL(/\/reimbursements\/new$/);
-    await expect(
-      page.getByRole("heading", { name: "Reiseangaben" }),
-    ).toBeVisible();
-    const allowanceTab = page.getByRole("tab", { name: "Ehrenamtspauschale" });
-    await allowanceTab.click();
-    await expect(allowanceTab).toHaveAttribute("data-state", "active");
+    await page.getByRole("tab", { name: "Ehrenamtspauschale" }).click();
     await expect(
       page.getByRole("heading", { name: "Persönliche Daten" }),
     ).toBeVisible();
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
-    await page.getByRole("button", { name: "Test Projekt" }).click();
+    await page.getByRole("button", { name: "Allgemein" }).click();
 
     await page.getByPlaceholder("Vor- und Nachname").first().fill("Test User");
     await page.getByPlaceholder("Musterstraße 123").fill("Teststraße 1");
@@ -502,13 +330,12 @@ test.describe.serial("reimbursement flow", () => {
       .fill("31.01.2026");
     await page.getByPlaceholder("0,00").fill("120");
     await page.getByRole("checkbox").check();
+    await saveBankDetails(page);
     await addSignature(page);
     await page
       .getByRole("button", { name: "Zur Genehmigung einreichen" })
       .click();
-    await expect(
-      page.getByText("Ehrenamtspauschale eingereicht"),
-    ).toBeVisible();
+    await expectSubmission(page, "Ehrenamtspauschale eingereicht");
 
     const allowanceRow = page
       .locator("table tbody tr")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "lint:lines": "node scripts/check-file-lines.mjs",
-    "test": "vitest run && pnpm exec playwright test",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:all": "pnpm test && pnpm test:e2e",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Centralizes MongoDB lifecycle and reusable fixtures across integration tests.
- Reduces Playwright coverage to four independent critical user journeys while preserving the latest recruiting lifecycle flow.
- Documents risk-based testing rules and separates Vitest, Playwright, and combined commands.

## Validation
- Passed pnpm test, Playwright, Biome, and pnpm build; lint:lines only reports the unchanged app/lib/server/applications/ingest.ts already present on main.