### PR TITLE
fix(auth): remove local development login bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ MONGODB_DB=ybase
 AUTH_SECRET=
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
-AUTH_DEV_LOGIN=false
 
 # Hetzner Object Storage
 OBJECT_STORAGE_ENDPOINT=https://nbg1.your-objectstorage.com

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { LoginForm } from "@/components/Auth/LoginForm";
 import { TestAuthForm } from "@/components/Auth/TestAuthForm";
 import { auth } from "@/lib/auth";
-import { isDevelopmentLoginEnabled, isTestMode } from "@/lib/auth/environment";
+import { isTestMode } from "@/lib/auth/environment";
 
 export default async function LoginPage() {
   const session = await auth();
@@ -11,7 +11,7 @@ export default async function LoginPage() {
   const loginForm = isTestMode() ? (
     <TestAuthForm />
   ) : (
-    <LoginForm isDevelopmentLoginEnabled={isDevelopmentLoginEnabled()} />
+    <LoginForm />
   );
 
   return (

--- a/app/components/Auth/LoginForm.tsx
+++ b/app/components/Auth/LoginForm.tsx
@@ -7,28 +7,11 @@ import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
-type LoginFormProps = {
-  isDevelopmentLoginEnabled: boolean;
-};
-
-const DEVELOPMENT_USER = {
-  email: "info@youngfounders.network",
-  name: "Local Developer",
-};
-
-export function LoginForm({ isDevelopmentLoginEnabled }: LoginFormProps) {
+export function LoginForm() {
   const [isSigningIn, setIsSigningIn] = useState(false);
 
   function handleSignIn() {
     setIsSigningIn(true);
-    if (isDevelopmentLoginEnabled) {
-      void signIn("development", {
-        ...DEVELOPMENT_USER,
-        callbackUrl: "/dashboard",
-      });
-      return;
-    }
-
     void signIn("google", { callbackUrl: "/dashboard" });
   }
 
@@ -46,9 +29,7 @@ export function LoginForm({ isDevelopmentLoginEnabled }: LoginFormProps) {
           Willkommen bei <span className="text-primary">YBase</span>
         </h1>
         <p className="text-muted-foreground text-sm">
-          {isDevelopmentLoginEnabled
-            ? "Lokale Entwicklungsumgebung"
-            : "Melde dich mit deinem Google Konto an, um direkt loszulegen."}
+          Melde dich mit deinem Google Konto an, um direkt loszulegen.
         </p>
       </div>
 
@@ -60,20 +41,18 @@ export function LoginForm({ isDevelopmentLoginEnabled }: LoginFormProps) {
         disabled={isSigningIn}
       >
         {isSigningIn && <Loader2 className="size-4 animate-spin" />}
-        {isDevelopmentLoginEnabled ? null : (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            className="size-5"
-            aria-hidden="true"
-          >
-            <path
-              d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-              fill="currentColor"
-            />
-          </svg>
-        )}
-        {isDevelopmentLoginEnabled ? "Lokal anmelden" : "Mit Google anmelden"}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          className="size-5"
+          aria-hidden="true"
+        >
+          <path
+            d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+            fill="currentColor"
+          />
+        </svg>
+        Mit Google anmelden
       </Button>
 
       <p className="text-xs text-muted-foreground">

--- a/app/components/Auth/TestAuthForm.tsx
+++ b/app/components/Auth/TestAuthForm.tsx
@@ -15,7 +15,7 @@ export function TestAuthForm() {
 
   async function handleSubmit() {
     setStatus("Authenticating...");
-    const result = await signIn("development", {
+    const result = await signIn("testing", {
       email,
       name,
       redirect: false,

--- a/app/lib/auth/config.test.ts
+++ b/app/lib/auth/config.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./environment", () => ({
-  isLocalCredentialsEnabled: () => false,
+  isTestMode: () => false,
 }));
 vi.mock("./provisioning", () => ({
   ensureAppUser: mocks.ensureAppUser,

--- a/app/lib/auth/config.ts
+++ b/app/lib/auth/config.ts
@@ -1,7 +1,7 @@
 import type { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import Google from "next-auth/providers/google";
-import { isLocalCredentialsEnabled } from "./environment";
+import { isTestMode } from "./environment";
 import { ensureAppUser } from "./provisioning";
 import { normalizeOptionalUserRole } from "./roles";
 
@@ -11,7 +11,7 @@ function isAllowedEmail(email: string | null | undefined): boolean {
   return Boolean(email?.toLowerCase().endsWith(`@${ALLOWED_EMAIL_DOMAIN}`));
 }
 
-const isLocalLoginEnabled = isLocalCredentialsEnabled();
+const isTestLoginEnabled = isTestMode();
 
 const google = Google({
   authorization: {
@@ -35,12 +35,12 @@ const google = Google({
   },
 });
 
-const developmentProvider = Credentials({
-  id: "development",
-  name: "Local development",
+const testProvider = Credentials({
+  id: "testing",
+  name: "Testing",
   credentials: { email: {}, name: {} },
   authorize(credentials) {
-    if (!isLocalLoginEnabled) return null;
+    if (!isTestLoginEnabled) return null;
     const email = (credentials?.email as string | undefined)
       ?.trim()
       .toLowerCase();
@@ -49,7 +49,7 @@ const developmentProvider = Credentials({
       id: email,
       email,
       name:
-        (credentials?.name as string | undefined)?.trim() || "Local Developer",
+        (credentials?.name as string | undefined)?.trim() || "Test User",
     };
   },
 });
@@ -57,10 +57,10 @@ const developmentProvider = Credentials({
 export const authConfig = {
   session: { strategy: "jwt" },
   pages: { signIn: "/login" },
-  providers: isLocalLoginEnabled ? [developmentProvider] : [google],
+  providers: isTestLoginEnabled ? [testProvider] : [google],
   callbacks: {
     signIn({ user }) {
-      if (isLocalLoginEnabled) return true;
+      if (isTestLoginEnabled) return true;
       return isAllowedEmail(user.email);
     },
     async jwt({ token, user }) {

--- a/app/lib/auth/environment.test.ts
+++ b/app/lib/auth/environment.test.ts
@@ -1,38 +1,17 @@
 import { describe, expect, it } from "vitest";
-import {
-  isDevelopmentLoginEnabled,
-  isLocalCredentialsEnabled,
-  isTestMode,
-} from "./environment";
+import { isTestMode } from "./environment";
 
 describe("auth environment", () => {
-  it("enables the development login only when explicitly requested", () => {
-    expect(
-      isDevelopmentLoginEnabled({
-        AUTH_DEV_LOGIN: "true",
-        NODE_ENV: "development",
-      }),
-    ).toBe(true);
-    expect(isDevelopmentLoginEnabled({ NODE_ENV: "development" })).toBe(false);
-  });
-
-  it("keeps test mode independent from the development login", () => {
+  it("enables test mode only when explicitly requested", () => {
     const env = { IS_TEST: "true", NODE_ENV: "test" };
 
     expect(isTestMode(env)).toBe(true);
-    expect(isDevelopmentLoginEnabled(env)).toBe(false);
-    expect(isLocalCredentialsEnabled(env)).toBe(true);
+    expect(isTestMode({ NODE_ENV: "test" })).toBe(false);
   });
 
-  it("never enables local credentials in production", () => {
-    const env = {
-      AUTH_DEV_LOGIN: "true",
-      IS_TEST: "true",
-      NODE_ENV: "production",
-    };
+  it("never enables test mode in production", () => {
+    const env = { IS_TEST: "true", NODE_ENV: "production" };
 
-    expect(isDevelopmentLoginEnabled(env)).toBe(false);
     expect(isTestMode(env)).toBe(false);
-    expect(isLocalCredentialsEnabled(env)).toBe(false);
   });
 });

--- a/app/lib/auth/environment.ts
+++ b/app/lib/auth/environment.ts
@@ -1,5 +1,4 @@
 type AuthEnvironment = {
-  AUTH_DEV_LOGIN?: string;
   IS_TEST?: string;
   NODE_ENV?: string;
 };
@@ -8,18 +7,6 @@ function isNonProduction(env: AuthEnvironment): boolean {
   return env.NODE_ENV !== "production";
 }
 
-export function isDevelopmentLoginEnabled(
-  env: AuthEnvironment = process.env,
-): boolean {
-  return env.AUTH_DEV_LOGIN === "true" && isNonProduction(env);
-}
-
 export function isTestMode(env: AuthEnvironment = process.env): boolean {
   return env.IS_TEST === "true" && isNonProduction(env);
-}
-
-export function isLocalCredentialsEnabled(
-  env: AuthEnvironment = process.env,
-): boolean {
-  return isDevelopmentLoginEnabled(env) || isTestMode(env);
 }


### PR DESCRIPTION
## summary

- remove the `AUTH_DEV_LOGIN` bypass so normal local sessions always use Google OAuth
- keep credentials authentication isolated behind `IS_TEST` for Playwright only

## validation

- `pnpm exec biome lint` on all changed TypeScript files
- `pnpm vitest run` (259 tests passed)
- `pnpm exec playwright test --reporter=list` (12 tests passed)
- `pnpm build`
- `pnpm lint:lines` (fails on the pre-existing 204-line `app/lib/server/applications/ingest.ts` from `main`)