### PR TITLE
fix(members): remove redundant onboarding hints

### DIFF
--- a/app/(protected)/settings/members/MemberDrawer.tsx
+++ b/app/(protected)/settings/members/MemberDrawer.tsx
@@ -159,11 +159,6 @@ export function MemberDrawer({
             }
             options={TEAM_ONBOARDING_OPTIONS}
             disabled={member.memberStatus === "active"}
-            hint={
-              member.memberStatus === "active"
-                ? "Nach der Freigabe ist das Onboarding abgeschlossen."
-                : undefined
-            }
           />
 
           <LabeledSelect

--- a/app/(protected)/settings/members/MemberStatusField.tsx
+++ b/app/(protected)/settings/members/MemberStatusField.tsx
@@ -24,7 +24,7 @@ export function MemberStatusField({ status, onboarding, onChange }: Props) {
       options={options}
       hint={
         isApprovalAllowed
-          ? "Die Freigabe durch People & Culture schaltet Erstattungen frei."
+          ? undefined
           : "Die Freigabe ist erst möglich, wenn alle Onboarding-Aufgaben abgeschlossen sind."
       }
     />


### PR DESCRIPTION
## summary

- remove redundant approval and completed-onboarding hints from member settings
- preserve the guidance shown while approval is still unavailable

## validation

- `pnpm exec biome lint "app/(protected)/settings/members/MemberDrawer.tsx" "app/(protected)/settings/members/MemberStatusField.tsx"`
- `pnpm exec prettier --check "app/(protected)/settings/members/MemberDrawer.tsx" "app/(protected)/settings/members/MemberStatusField.tsx"`
- tests not run (copy-only change; repository guidance excludes copy tests)