### PR TITLE
fix(members): differentiate completed onboarding badge colors

### DIFF
--- a/app/(protected)/settings/members/memberLabels.ts
+++ b/app/(protected)/settings/members/memberLabels.ts
@@ -44,7 +44,7 @@ const MEMBER_STATUS_VARIANT: Record<MemberStatus, BadgeVariant> = {
 const TEAM_ONBOARDING_VARIANT: Record<TeamOnboardingStatus, BadgeVariant> = {
   not_started: "outline",
   in_progress: "default",
-  completed: "secondary",
+  completed: "primary",
 };
 
 function labelOf<T extends string>(options: Option<T>[], value: T): string {


### PR DESCRIPTION
## summary

- shows completed onboarding badges in brand yellow while approved member badges remain purple
- reuses the existing primary and secondary theme tokens in light and dark modes

## validation

- `pnpm exec biome lint "app/(protected)/settings/members/memberLabels.ts"`
- `pnpm exec prettier --check "app/(protected)/settings/members/memberLabels.ts"`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test`
- e2e not run (style-only token mapping)