### PR TITLE
fix(navigation): shorten members sidebar label

### DIFF
--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -51,7 +51,7 @@ const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
     permission: USER_PERMISSIONS.organizationStructure,
   },
   {
-    name: "Teammitglieder",
+    name: "Team",
     url: "/settings/members",
     icon: UserCog,
     permission: USER_PERMISSIONS.members,


### PR DESCRIPTION
## summary\n\n- Rename the members sidebar entry from "Teammitglieder" to "Team".\n\n## validation\n\n- pnpm exec biome lint app/components/Sidebar/AppSidebar.tsx\n- pnpm exec prettier --check app/components/Sidebar/AppSidebar.tsx\n- Tests not run (copy-only change; repository guidance excludes tests for copy).