### PR TITLE
style(recruiting): refine job posting status indicator

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx
@@ -43,8 +43,15 @@ export function JobPostingStatusActions({ posting }: { posting: JobPosting }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-muted-foreground">Status</span>
-      <JobPostingStatusBadge status={posting.status} />
+      <div className="flex h-8 items-stretch border-2 border-border bg-background">
+        <span className="flex items-center bg-muted px-2.5 text-xs font-medium text-muted-foreground">
+          Status
+        </span>
+        <JobPostingStatusBadge
+          status={posting.status}
+          className="h-full border-y-0 border-r-0 px-2.5"
+        />
+      </div>
       {posting.status === "draft" ? (
         <Button
           size="sm"

--- a/app/components/JobPostings/JobPostingStatusBadge.tsx
+++ b/app/components/JobPostings/JobPostingStatusBadge.tsx
@@ -1,24 +1,47 @@
 import { Badge } from "@/components/ui/badge";
 import type { JobPostingStatus } from "@/lib/db/types";
 import { JOB_POSTING_STATUS_LABELS } from "@/lib/jobPostings/status";
+import { cn } from "@/lib/utils";
 
-const variants: Record<
-  JobPostingStatus,
-  "outline" | "primary" | "secondary" | "default"
-> = {
-  draft: "outline",
-  published: "primary",
-  closed: "secondary",
-  archived: "default",
+const styles: Record<JobPostingStatus, { badge: string; dot: string }> = {
+  draft: {
+    badge: "border-border bg-muted text-foreground",
+    dot: "bg-muted-foreground",
+  },
+  published: {
+    badge: "border-primary bg-primary text-primary-foreground",
+    dot: "bg-primary-foreground",
+  },
+  closed: {
+    badge: "border-secondary bg-secondary text-secondary-foreground",
+    dot: "bg-secondary-foreground",
+  },
+  archived: {
+    badge: "border-border bg-accent text-muted-foreground",
+    dot: "bg-muted-foreground",
+  },
 };
 
 export function JobPostingStatusBadge({
   status,
+  className,
 }: {
   status: JobPostingStatus;
+  className?: string;
 }) {
   return (
-    <Badge variant={variants[status]}>
+    <Badge
+      variant="outline"
+      className={cn(
+        "h-7 gap-1.5 border-2 px-2.5 py-0 font-semibold",
+        styles[status].badge,
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("size-1.5 shrink-0 rounded-full", styles[status].dot)}
+      />
       {JOB_POSTING_STATUS_LABELS[status]}
     </Badge>
   );


### PR DESCRIPTION
## summary

- group the status label and value into a cohesive control that follows the existing border and spacing system
- add reusable state-specific colors and status dots across recruiting views

## validation

- `pnpm exec prettier --check app/components/JobPostings/JobPostingStatusBadge.tsx app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx`
- `pnpm exec biome lint app/components/JobPostings/JobPostingStatusBadge.tsx app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm test` (272 tests)