### PR TITLE
feat(analytics): configure posthog tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ OBJECT_STORAGE_FORCE_PATH_STYLE=false
 # Application and email
 SERVICE_STAGE=development
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_POSTHOG_KEY=
 BREVO_API_KEY=XXXXX
 # Required outside production
 BREVO_RECIPIENT_ALLOWLIST=

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN pnpm install --frozen-lockfile
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 

--- a/app/(protected)/OffboardedNotice.tsx
+++ b/app/(protected)/OffboardedNotice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
+import { signOutWithPostHog } from "@/lib/posthog-client";
 
 export function OffboardedNotice() {
   return (
@@ -12,10 +12,7 @@ export function OffboardedNotice() {
           Dein Zugang wurde beendet. Bitte wende dich an People &amp; Culture,
           wenn das ein Fehler ist.
         </p>
-        <Button
-          className="w-full"
-          onClick={() => signOut({ callbackUrl: "/login" })}
-        >
+        <Button className="w-full" onClick={() => void signOutWithPostHog()}>
           Abmelden
         </Button>
       </div>

--- a/app/(protected)/OnboardingNotice.tsx
+++ b/app/(protected)/OnboardingNotice.tsx
@@ -7,8 +7,8 @@ import {
   Clock3,
   LogOut,
 } from "lucide-react";
-import { signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
+import { signOutWithPostHog } from "@/lib/posthog-client";
 import {
   Card,
   CardContent,
@@ -110,10 +110,7 @@ export function OnboardingNotice({ onboardingStatus }: Props) {
               Bei Fragen zu deinen Aufgaben wende dich bitte an People &amp;
               Culture.
             </p>
-            <Button
-              variant="outline"
-              onClick={() => signOut({ callbackUrl: "/login" })}
-            >
+            <Button variant="outline" onClick={() => void signOutWithPostHog()}>
               <LogOut aria-hidden="true" />
               Abmelden
             </Button>

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,4 +1,6 @@
 import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+import { PostHogIdentity } from "@/components/PostHogIdentity";
 import { AppSidebar } from "@/components/Sidebar/AppSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { auth } from "@/lib/auth";
@@ -15,24 +17,37 @@ export default async function ProtectedLayout({
   const session = await auth();
   if (!session?.user) redirect("/login");
   const member = await requireAuthenticatedUser();
-  if (member.memberStatus === "offboarded") return <OffboardedNotice />;
-  if (!member.organizationId) return <OrgOnboarding />;
-  if (member.memberStatus === "onboarding") {
-    return (
-      <OnboardingNotice
-        onboardingStatus={member.teamOnboardingStatus}
-      />
+
+  let content: ReactNode;
+  if (member.memberStatus === "offboarded") {
+    content = <OffboardedNotice />;
+  } else if (!member.organizationId) {
+    content = <OrgOnboarding />;
+  } else if (member.memberStatus === "onboarding") {
+    content = (
+      <OnboardingNotice onboardingStatus={member.teamOnboardingStatus} />
+    );
+  } else {
+    content = (
+      <SidebarProvider className="bg-sidebar">
+        <AppSidebar />
+        <div className="flex flex-col flex-1 min-w-0 p-2 sm:p-3 lg:p-4">
+          <div className="flex-1 rounded-[0.25rem] border bg-background p-4 sm:p-6 lg:p-8">
+            {children}
+          </div>
+        </div>
+      </SidebarProvider>
     );
   }
 
   return (
-    <SidebarProvider className="bg-sidebar">
-      <AppSidebar />
-      <div className="flex flex-col flex-1 min-w-0 p-2 sm:p-3 lg:p-4">
-        <div className="flex-1 rounded-[0.25rem] border bg-background p-4 sm:p-6 lg:p-8">
-          {children}
-        </div>
-      </div>
-    </SidebarProvider>
+    <>
+      <PostHogIdentity
+        userId={member._id}
+        organizationId={member.organizationId}
+        role={member.role}
+      />
+      {content}
+    </>
   );
 }

--- a/app/components/PostHogIdentity.tsx
+++ b/app/components/PostHogIdentity.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect } from "react";
+import type { UserRole } from "@/lib/db/types";
+
+interface Props {
+  userId: string;
+  organizationId?: string;
+  role?: UserRole;
+}
+
+export function PostHogIdentity({ userId, organizationId, role }: Props) {
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+    const properties = {
+      ...(organizationId ? { organization_id: organizationId } : {}),
+      ...(role ? { role } : {}),
+    };
+    posthog.register(properties);
+    posthog.identify(userId, properties);
+  }, [organizationId, role, userId]);
+
+  return null;
+}

--- a/app/components/Sidebar/UserNav.tsx
+++ b/app/components/Sidebar/UserNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronsUpDown, LogOut } from "lucide-react";
-import { signOut, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -18,6 +18,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
+import { signOutWithPostHog } from "@/lib/posthog-client";
 
 type NavUserData = {
   name?: string | null;
@@ -103,9 +104,7 @@ export function NavUser() {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={() => signOut({ callbackUrl: "/login" })}
-            >
+            <DropdownMenuItem onSelect={() => void signOutWithPostHog()}>
               <LogOut />
               Abmelden
             </DropdownMenuItem>

--- a/app/lib/posthog-client.ts
+++ b/app/lib/posthog-client.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import posthog from "posthog-js";
+
+export function signOutWithPostHog() {
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.reset();
+  }
+
+  return signOut({ callbackUrl: "/login" });
+}

--- a/app/lib/posthog-server.ts
+++ b/app/lib/posthog-server.ts
@@ -3,12 +3,16 @@ import { PostHog } from "posthog-node";
 let posthogClient: PostHog | null = null;
 
 export function getPostHogClient() {
+  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!posthogKey) return null;
+
   if (!posthogClient) {
-    posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    posthogClient = new PostHog(posthogKey, {
+      host: "https://eu.i.posthog.com",
       flushAt: 1,
       flushInterval: 0,
     });
+    void posthogClient.register({ app: "ybase" });
     if (process.env.NODE_ENV === "development") {
       posthogClient.debug(true);
     }
@@ -18,6 +22,8 @@ export function getPostHogClient() {
 
 export async function shutdownPostHog() {
   if (posthogClient) {
-    await posthogClient.shutdown();
+    const client = posthogClient;
+    posthogClient = null;
+    await client.shutdown();
   }
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,9 +1,17 @@
 import posthog from "posthog-js";
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-  api_host: "/ingest",
-  ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: "2025-05-24",
-  capture_exceptions: true,
-  debug: process.env.NODE_ENV === "development",
-});
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: "/ingest",
+    ui_host: "https://eu.posthog.com",
+    defaults: "2025-05-24",
+    capture_exceptions: true,
+    debug: process.env.NODE_ENV === "development",
+    before_send: (event) =>
+      event
+        ? { ...event, properties: { ...event.properties, app: "ybase" } }
+        : event,
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -43,6 +43,10 @@ const nextConfig: NextConfig = {
         destination: "https://eu-assets.i.posthog.com/static/:path*",
       },
       {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
         source: "/ingest/:path*",
         destination: "https://eu.i.posthog.com/:path*",
       },


### PR DESCRIPTION
## summary

- configure EU PostHog ingestion through the first-party proxy and Docker build-time token
- identify authenticated users, segment YBase events, and reset analytics identity on logout

## validation

- pnpm exec biome lint <changed files>
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build (passes with existing dependency warnings)