### PR TITLE
feat(members): align member drawer with platform

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -18,17 +18,16 @@ export default async function ProtectedLayout({
   if (member.memberStatus === "offboarded") return <OffboardedNotice />;
   if (!member.organizationId) return <OrgOnboarding />;
   if (member.memberStatus === "onboarding") {
-    return (
-      <OnboardingNotice
-        onboardingStatus={member.teamOnboardingStatus}
-      />
-    );
+    return <OnboardingNotice onboardingStatus={member.teamOnboardingStatus} />;
   }
 
   return (
     <SidebarProvider className="bg-sidebar">
       <AppSidebar />
-      <div className="flex flex-col flex-1 min-w-0 p-2 sm:p-3 lg:p-4">
+      <div
+        data-app-content
+        className="flex flex-col flex-1 min-w-0 p-2 sm:p-3 lg:p-4"
+      >
         <div className="flex-1 rounded-[0.25rem] border bg-background p-4 sm:p-6 lg:p-8">
           {children}
         </div>

--- a/app/(protected)/settings/members/MemberDrawer.module.css
+++ b/app/(protected)/settings/members/MemberDrawer.module.css
@@ -1,0 +1,37 @@
+.drawerRail {
+  --member-drawer-width: max(26rem, 28vw);
+
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 40;
+  width: var(--member-drawer-width);
+  overflow: hidden;
+  animation: reveal-drawer 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.drawerSurface {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  display: flex;
+  width: var(--member-drawer-width);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  background: var(--background);
+}
+
+@keyframes reveal-drawer {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawerRail {
+    animation: none;
+  }
+}

--- a/app/(protected)/settings/members/MemberDrawer.tsx
+++ b/app/(protected)/settings/members/MemberDrawer.tsx
@@ -1,190 +1,72 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Sheet,
   SheetContent,
   SheetDescription,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { useMemberMutations } from "@/lib/client/members/hooks/useMemberMutations";
-import type {
-  Department,
-  MemberStatus,
-  Team,
-  TeamOnboardingStatus,
-  User,
-  UserRole,
-} from "@/lib/db/types";
-import { Loader2 } from "lucide-react";
-import { useState } from "react";
-import toast from "react-hot-toast";
-import { LabeledSelect } from "./LabeledSelect";
-import { MemberStatusField } from "./MemberStatusField";
-import { ROLE_OPTIONS, TEAM_ONBOARDING_OPTIONS } from "./memberLabels";
+import { XIcon } from "lucide-react";
+import { MemberDrawerPanel } from "./MemberDrawerPanel";
+import styles from "./MemberDrawer.module.css";
+import type { MemberDrawerProps } from "./MemberDrawer.types";
+import { useDesktopDrawer } from "./useDesktopDrawer";
+import { useMemberDrawerForm } from "./useMemberDrawerForm";
 
-const LAST_ADMIN_MESSAGE =
-  "Der letzte Admin kann nicht entfernt werden. Mindestens ein Admin ist erforderlich.";
-
-interface Props {
-  member: User;
-  teams: Team[];
-  departments: Department[];
-  canEditRoles: boolean;
-  adminCount: number;
-  onClose: () => void;
-}
-
-export function MemberDrawer({
-  member,
-  teams,
-  departments,
-  canEditRoles,
-  adminCount,
-  onClose,
-}: Props) {
-  const { updateProfile, setStatus, setOnboarding, updateRole } =
-    useMemberMutations();
-
-  const [teamId, setTeamId] = useState(member.teamId ?? "");
-  const [position, setPosition] = useState(member.positionTitle ?? "");
-  const [status, setStatusDraft] = useState<MemberStatus>(member.memberStatus);
-  const [onboarding, setOnboardingDraft] = useState<TeamOnboardingStatus>(
-    member.teamOnboardingStatus,
+export function MemberDrawer(props: MemberDrawerProps) {
+  const { member, onClose } = props;
+  const isDesktopDrawer = useDesktopDrawer();
+  const form = useMemberDrawerForm(props);
+  const displayName =
+    member.name ||
+    [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+    "Teammitglied";
+  const content = (
+    <MemberDrawerPanel
+      member={member}
+      displayName={displayName}
+      form={form}
+      onClose={onClose}
+    />
   );
-  const [role, setRole] = useState<UserRole>(member.role ?? "member");
 
-  const activeTeams = teams.filter((team) => !team.isArchived);
-  const teamOptions = activeTeams.map((team) => ({
-    value: team._id,
-    label: team.name,
-  }));
-  const selectedTeam = activeTeams.find((team) => team._id === teamId);
-  const department = selectedTeam
-    ? departments.find((entry) => entry._id === selectedTeam.departmentId)
-    : undefined;
-
-  const isSaving =
-    updateProfile.isPending ||
-    setStatus.isPending ||
-    setOnboarding.isPending ||
-    updateRole.isPending;
-  const handleSave = async () => {
-    try {
-      const profile: {
-        userId: string;
-        teamId?: string;
-        positionTitle?: string;
-      } = { userId: member._id };
-      if (teamId && teamId !== member.teamId) profile.teamId = teamId;
-      const trimmed = position.trim();
-      if (trimmed && trimmed !== member.positionTitle)
-        profile.positionTitle = trimmed;
-      if (profile.teamId || profile.positionTitle)
-        await updateProfile.mutateAsync(profile);
-
-      if (onboarding !== member.teamOnboardingStatus)
-        await setOnboarding.mutateAsync({
-          userId: member._id,
-          status: onboarding,
-        });
-
-      if (status !== member.memberStatus)
-        await setStatus.mutateAsync({ userId: member._id, status });
-
-      if (canEditRoles && role !== (member.role ?? "member")) {
-        const demotesLastAdmin =
-          member.role === "admin" && role !== "admin" && adminCount <= 1;
-        if (demotesLastAdmin) {
-          toast.error(LAST_ADMIN_MESSAGE);
-          return;
-        }
-        await updateRole.mutateAsync({ userId: member._id, role });
-      }
-
-      toast.success("Teammitglied aktualisiert");
-      onClose();
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Fehler beim Speichern",
-      );
-    }
-  };
+  if (isDesktopDrawer) {
+    return (
+      <aside
+        data-member-drawer
+        className={styles.drawerRail}
+        aria-label={`Teammitglied ${displayName} bearbeiten`}
+      >
+        <div className={styles.drawerSurface}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="absolute top-3 right-3 z-10"
+            onClick={onClose}
+            disabled={form.isSaving}
+            aria-label="Sidebar schließen"
+          >
+            <XIcon />
+          </Button>
+          {content}
+        </div>
+      </aside>
+    );
+  }
 
   return (
     <Sheet open onOpenChange={(nextOpen) => !nextOpen && onClose()}>
-      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>{member.name || "Teammitglied"}</SheetTitle>
-          <SheetDescription>{member.email || "Keine E-Mail"}</SheetDescription>
+      <SheetContent side="right" className="w-full overflow-hidden sm:max-w-md">
+        <SheetHeader className="sr-only">
+          <SheetTitle>{displayName}</SheetTitle>
+          <SheetDescription>
+            Teammitglied {displayName} bearbeiten
+          </SheetDescription>
         </SheetHeader>
-
-        <div className="flex flex-col gap-4 px-4">
-          <LabeledSelect
-            id="member-team"
-            label="Team"
-            value={teamId}
-            onValueChange={setTeamId}
-            options={teamOptions}
-            placeholder="Team wählen"
-            hint={`Department: ${department?.name ?? "—"}`}
-          />
-
-          <div className="grid gap-1.5">
-            <Label htmlFor="member-position">Position</Label>
-            <Input
-              id="member-position"
-              value={position}
-              onChange={(e) => setPosition(e.target.value)}
-              placeholder="z. B. Tech Lead"
-            />
-          </div>
-
-          <MemberStatusField
-            status={status}
-            onboarding={onboarding}
-            onChange={setStatusDraft}
-          />
-
-          <LabeledSelect
-            id="member-onboarding"
-            label="Onboarding-Aufgaben"
-            value={onboarding}
-            onValueChange={(value) =>
-              setOnboardingDraft(value as TeamOnboardingStatus)
-            }
-            options={TEAM_ONBOARDING_OPTIONS}
-            disabled={member.memberStatus === "active"}
-          />
-
-          <LabeledSelect
-            id="member-role"
-            label="Rolle"
-            value={role}
-            onValueChange={(value) => setRole(value as UserRole)}
-            options={ROLE_OPTIONS}
-            disabled={!canEditRoles}
-            hint={
-              canEditRoles
-                ? undefined
-                : "Rollen können nur von Admins geändert werden."
-            }
-          />
-        </div>
-
-        <SheetFooter>
-          <Button variant="primary" onClick={handleSave} disabled={isSaving}>
-            {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Speichern
-          </Button>
-          <Button variant="outline" onClick={onClose} disabled={isSaving}>
-            Abbrechen
-          </Button>
-        </SheetFooter>
+        {content}
       </SheetContent>
     </Sheet>
   );

--- a/app/(protected)/settings/members/MemberDrawer.types.ts
+++ b/app/(protected)/settings/members/MemberDrawer.types.ts
@@ -1,0 +1,10 @@
+import type { Department, Team, User } from "@/lib/db/types";
+
+export interface MemberDrawerProps {
+  member: User;
+  teams: Team[];
+  departments: Department[];
+  canEditRoles: boolean;
+  adminCount: number;
+  onClose: () => void;
+}

--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -1,0 +1,123 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SheetFooter } from "@/components/ui/sheet";
+import type { TeamOnboardingStatus, User, UserRole } from "@/lib/db/types";
+import { getInitials } from "@/lib/formatters/getInitials";
+import { Loader2 } from "lucide-react";
+import { LabeledSelect } from "./LabeledSelect";
+import { MemberStatusField } from "./MemberStatusField";
+import {
+  memberStatusLabel,
+  memberStatusVariant,
+  ROLE_OPTIONS,
+  TEAM_ONBOARDING_OPTIONS,
+} from "./memberLabels";
+import type { MemberDrawerFormState } from "./useMemberDrawerForm";
+
+interface Props {
+  member: User;
+  displayName: string;
+  form: MemberDrawerFormState;
+  onClose: () => void;
+}
+
+export function MemberDrawerPanel({
+  member,
+  displayName,
+  form,
+  onClose,
+}: Props) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-row items-center gap-5 px-6 pt-8 pb-6 text-left">
+        <Avatar className="size-24">
+          <AvatarImage
+            src={member.image}
+            alt={`Profilbild von ${displayName}`}
+            className="object-cover"
+          />
+          <AvatarFallback className="text-2xl font-semibold">
+            {getInitials(displayName, member.email)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+          <h2 className="text-[1.625rem] leading-tight font-semibold break-words">
+            {displayName}
+          </h2>
+          <p className="text-muted-foreground max-w-full truncate text-base">
+            {member.email || "Keine E-Mail hinterlegt"}
+          </p>
+          <Badge className="mt-1" variant={memberStatusVariant(form.status)}>
+            {memberStatusLabel(form.status)}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-4 px-6">
+        <LabeledSelect
+          id="member-team"
+          label="Team"
+          value={form.teamId}
+          onValueChange={form.setTeamId}
+          options={form.teamOptions}
+          placeholder="Team wählen"
+          hint={`Department: ${form.department?.name ?? "—"}`}
+        />
+        <div className="grid gap-1.5">
+          <Label htmlFor="member-position">Position</Label>
+          <Input
+            id="member-position"
+            value={form.position}
+            onChange={(event) => form.setPosition(event.target.value)}
+            placeholder="z. B. Tech Lead"
+          />
+        </div>
+        <MemberStatusField
+          status={form.status}
+          onboarding={form.onboarding}
+          onChange={form.setStatus}
+        />
+        <LabeledSelect
+          id="member-onboarding"
+          label="Onboarding-Aufgaben"
+          value={form.onboarding}
+          onValueChange={(value) =>
+            form.setOnboarding(value as TeamOnboardingStatus)
+          }
+          options={TEAM_ONBOARDING_OPTIONS}
+          disabled={member.memberStatus === "active"}
+        />
+        <LabeledSelect
+          id="member-role"
+          label="Rolle"
+          value={form.role}
+          onValueChange={(value) => form.setRole(value as UserRole)}
+          options={ROLE_OPTIONS}
+          disabled={!form.canEditRoles}
+          hint={
+            form.canEditRoles
+              ? undefined
+              : "Rollen können nur von Admins geändert werden."
+          }
+        />
+      </div>
+
+      <SheetFooter className="mt-6 border-t px-6 pt-6 pb-6">
+        <Button
+          variant="primary"
+          onClick={form.handleSave}
+          disabled={form.isSaving}
+        >
+          {form.isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Speichern
+        </Button>
+        <Button variant="outline" onClick={onClose} disabled={form.isSaving}>
+          Abbrechen
+        </Button>
+      </SheetFooter>
+    </div>
+  );
+}

--- a/app/(protected)/settings/members/useDesktopDrawer.ts
+++ b/app/(protected)/settings/members/useDesktopDrawer.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+const DESKTOP_DRAWER_QUERY = "(min-width: 1200px)";
+
+export function useDesktopDrawer() {
+  const [isDesktop, setIsDesktop] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(DESKTOP_DRAWER_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(DESKTOP_DRAWER_QUERY);
+    const update = () => setIsDesktop(mediaQuery.matches);
+
+    mediaQuery.addEventListener("change", update);
+    update();
+    return () => mediaQuery.removeEventListener("change", update);
+  }, []);
+
+  return isDesktop;
+}

--- a/app/(protected)/settings/members/useMemberDrawerForm.ts
+++ b/app/(protected)/settings/members/useMemberDrawerForm.ts
@@ -1,0 +1,111 @@
+import { useMemberMutations } from "@/lib/client/members/hooks/useMemberMutations";
+import type {
+  MemberStatus,
+  TeamOnboardingStatus,
+  UserRole,
+} from "@/lib/db/types";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import type { MemberDrawerProps } from "./MemberDrawer.types";
+
+const LAST_ADMIN_MESSAGE =
+  "Der letzte Admin kann nicht entfernt werden. Mindestens ein Admin ist erforderlich.";
+
+export function useMemberDrawerForm({
+  member,
+  teams,
+  departments,
+  canEditRoles,
+  adminCount,
+  onClose,
+}: MemberDrawerProps) {
+  const {
+    updateProfile,
+    setStatus: setStatusMutation,
+    setOnboarding: setOnboardingMutation,
+    updateRole,
+  } = useMemberMutations();
+  const [teamId, setTeamId] = useState(member.teamId ?? "");
+  const [position, setPosition] = useState(member.positionTitle ?? "");
+  const [status, setStatus] = useState<MemberStatus>(member.memberStatus);
+  const [onboarding, setOnboarding] = useState<TeamOnboardingStatus>(
+    member.teamOnboardingStatus,
+  );
+  const [role, setRole] = useState<UserRole>(member.role ?? "member");
+
+  const activeTeams = teams.filter((team) => !team.isArchived);
+  const teamOptions = activeTeams.map((team) => ({
+    value: team._id,
+    label: team.name,
+  }));
+  const selectedTeam = activeTeams.find((team) => team._id === teamId);
+  const department = selectedTeam
+    ? departments.find((entry) => entry._id === selectedTeam.departmentId)
+    : undefined;
+  const isSaving =
+    updateProfile.isPending ||
+    setStatusMutation.isPending ||
+    setOnboardingMutation.isPending ||
+    updateRole.isPending;
+
+  const handleSave = async () => {
+    try {
+      const profile: {
+        userId: string;
+        teamId?: string;
+        positionTitle?: string;
+      } = { userId: member._id };
+      if (teamId && teamId !== member.teamId) profile.teamId = teamId;
+      const trimmed = position.trim();
+      if (trimmed && trimmed !== member.positionTitle)
+        profile.positionTitle = trimmed;
+      if (profile.teamId || profile.positionTitle)
+        await updateProfile.mutateAsync(profile);
+
+      if (onboarding !== member.teamOnboardingStatus)
+        await setOnboardingMutation.mutateAsync({
+          userId: member._id,
+          status: onboarding,
+        });
+      if (status !== member.memberStatus)
+        await setStatusMutation.mutateAsync({ userId: member._id, status });
+
+      if (canEditRoles && role !== (member.role ?? "member")) {
+        const demotesLastAdmin =
+          member.role === "admin" && role !== "admin" && adminCount <= 1;
+        if (demotesLastAdmin) {
+          toast.error(LAST_ADMIN_MESSAGE);
+          return;
+        }
+        await updateRole.mutateAsync({ userId: member._id, role });
+      }
+
+      toast.success("Teammitglied aktualisiert");
+      onClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Fehler beim Speichern",
+      );
+    }
+  };
+
+  return {
+    teamId,
+    setTeamId,
+    position,
+    setPosition,
+    status,
+    setStatus,
+    onboarding,
+    setOnboarding,
+    role,
+    setRole,
+    teamOptions,
+    department,
+    canEditRoles,
+    isSaving,
+    handleSave,
+  };
+}
+
+export type MemberDrawerFormState = ReturnType<typeof useMemberDrawerForm>;

--- a/app/globals.css
+++ b/app/globals.css
@@ -230,6 +230,22 @@
   }
 }
 
+[data-app-content] {
+  transition: padding-right 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (min-width: 1200px) {
+  [data-app-content]:has([data-member-drawer]) {
+    padding-right: calc(max(26rem, 28vw) + 2rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-app-content] {
+    transition: none;
+  }
+}
+
 .tiptap {
   min-height: 8rem;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## summary

- replace the desktop member editor overlay with a responsive side panel that shifts the page content using the member-platform motion and dimensions
- add an avatar-led profile header with status context while preserving the mobile sheet flow and reduced-motion support
- split drawer state, presentation, responsive behavior, and types into focused files below the 200-line project limit

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed TypeScript files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm test` (272 tests)
- `pnpm build` (passes with a postcss externalization warning)
- Playwright smoke checks at 1440px and 474px