### PR TITLE
feat(reimbursements): simplify refund request type selection

### DIFF
--- a/app/components/Reimbursements/shareModal/ShareForm.tsx
+++ b/app/components/Reimbursements/shareModal/ShareForm.tsx
@@ -54,9 +54,10 @@ export function ShareForm({
           <Button
             key={linkType}
             type="button"
-            variant={type === linkType ? "default" : "outline"}
+            variant={type === linkType ? "primary" : "outline"}
             onClick={() => onTypeChange(linkType)}
             className="h-12 flex-1"
+            aria-pressed={type === linkType}
           >
             {TYPE_LABELS[linkType]}
           </Button>
@@ -72,22 +73,18 @@ export function ShareForm({
         />
       </div>
 
-      <div>
-        <Label>
-          {type === "allowance" ? "Tätigkeitsbeschreibung" : "Beschreibung"}
-        </Label>
-        <Textarea
-          value={form.description}
-          onChange={(e) => onFormUpdate({ description: e.target.value })}
-          placeholder={
-            type === "allowance"
-              ? "z.B. Jugendarbeit, Vorstandstätigkeit"
-              : "z.B. Einkäufe für Workshop"
-          }
-          rows={2}
-          className="resize-none"
-        />
-      </div>
+      {type === "allowance" && (
+        <div>
+          <Label>Tätigkeitsbeschreibung</Label>
+          <Textarea
+            value={form.description}
+            onChange={(e) => onFormUpdate({ description: e.target.value })}
+            placeholder="z.B. Jugendarbeit, Vorstandstätigkeit"
+            rows={2}
+            className="resize-none"
+          />
+        </div>
+      )}
 
       {type === "travel" && (
         <>

--- a/app/components/Reimbursements/shareModal/constants.ts
+++ b/app/components/Reimbursements/shareModal/constants.ts
@@ -13,8 +13,8 @@ export const INITIAL_FORM: FormState = {
 };
 
 export const TYPE_LABELS: Record<LinkType, string> = {
-  expense: "Auslagenerstattung",
   travel: "Reisekostenerstattung",
+  expense: "Auslagenerstattung",
   allowance: "Ehrenamtspauschale",
 };
 

--- a/app/components/Reimbursements/shareModal/useShareModal.ts
+++ b/app/components/Reimbursements/shareModal/useShareModal.ts
@@ -79,7 +79,6 @@ export function useShareModal(open: boolean, onClose: () => void) {
     const id = await createReimbursementLink({
       projectId: form.projectId ?? "",
       type,
-      description: form.description,
       travelDetails:
         type === "travel"
           ? {


### PR DESCRIPTION
## summary

- highlight the selected reimbursement type with the yellow primary style
- place travel reimbursements first and remove the redundant description from expense and travel requests
- keep the required activity description for volunteer allowances

## validation

- `pnpm exec prettier --check app/components/Reimbursements/shareModal/ShareForm.tsx app/components/Reimbursements/shareModal/constants.ts app/components/Reimbursements/shareModal/useShareModal.ts`
- `pnpm exec biome lint app/components/Reimbursements/shareModal/ShareForm.tsx app/components/Reimbursements/shareModal/constants.ts app/components/Reimbursements/shareModal/useShareModal.ts`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/lib/server/reimbursements/reimbursements.test.ts app/lib/server/volunteerAllowance/volunteerAllowance.test.ts`