### PR TITLE
fix(recruiting): remove location and remote fields

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -77,38 +76,14 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
         </div>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="jp-location">Ort</Label>
-          <Input
-            id="jp-location"
-            value={values.location}
-            onChange={(e) => onChange({ location: e.target.value })}
-            placeholder="z. B. Berlin"
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="jp-contact">Kontakt</Label>
-          <Input
-            id="jp-contact"
-            value={values.contact}
-            onChange={(e) => onChange({ contact: e.target.value })}
-            placeholder="E-Mail oder Ansprechperson"
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Checkbox
-          id="jp-remote"
-          checked={values.isRemote}
-          onCheckedChange={(checked) =>
-            onChange({ isRemote: checked === true })
-          }
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="jp-contact">Kontakt</Label>
+        <Input
+          id="jp-contact"
+          value={values.contact}
+          onChange={(e) => onChange({ contact: e.target.value })}
+          placeholder="E-Mail oder Ansprechperson"
         />
-        <Label htmlFor="jp-remote" className="font-normal">
-          Remote möglich
-        </Label>
       </div>
     </div>
   );

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -83,7 +83,6 @@ test.describe("Ausschreibungen", () => {
     const description = page.locator('[aria-label="Beschreibung"]');
     await description.click();
     await page.keyboard.type(DESCRIPTION);
-    await page.getByLabel("Ort").fill("Berlin");
     await page.getByRole("button", { name: "Speichern" }).click();
     await expect(page.getByText("Ausschreibung gespeichert")).toBeVisible();
 
@@ -91,7 +90,6 @@ test.describe("Ausschreibungen", () => {
     await expect(page.locator('[aria-label="Beschreibung"]')).toContainText(
       DESCRIPTION,
     );
-    await expect(page.getByLabel("Ort")).toHaveValue("Berlin");
 
     await page.getByRole("button", { name: "Veröffentlichen" }).click();
     await expect(page.getByText("Ausschreibung veröffentlicht")).toBeVisible();


### PR DESCRIPTION
## summary

- remove the location and remote controls from the job posting editor
- keep existing persisted fields intact for backward compatibility and simplify the contact field layout

## validation

- `pnpm exec biome lint app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx e2e/recruiting.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm exec playwright test e2e/recruiting.spec.ts`