### PR TITLE
feat(recruiting): add application review workflow

### DIFF
--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CreateJobPostingDialog } from "@/components/Dialogs/CreateJobPostingDialog";
+import { ApplicationsPanel } from "@/components/Applications/ApplicationsPanel";
 import { JobPostingStatusBadge } from "@/components/JobPostings/JobPostingStatusBadge";
 import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -33,53 +34,67 @@ export function RecruitingClient() {
         </Button>
       </div>
 
-      {isLoading ? (
-        <p className="text-muted-foreground py-8 text-center">Lädt…</p>
-      ) : jobPostings.length === 0 ? (
-        <div className="text-center py-10 border rounded-lg">
-          <Megaphone className="mx-auto h-10 w-10 text-muted-foreground" />
-          <h3 className="mt-3 font-semibold">Keine Ausschreibungen</h3>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Bewerbungen</h2>
+          <p className="text-sm text-muted-foreground">
+            Alle eingegangenen Bewerbungen ausschreibungsübergreifend.
+          </p>
         </div>
-      ) : (
-        <div className="rounded-md border overflow-hidden">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Titel</TableHead>
-                <TableHead>Team</TableHead>
-                <TableHead>Department</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="w-px" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {jobPostings.map((posting) => {
-                const info = lookup.get(posting.teamId);
-                return (
-                  <TableRow key={posting._id}>
-                    <TableCell className="font-medium">
-                      {posting.title}
-                    </TableCell>
-                    <TableCell>{info?.teamName ?? "–"}</TableCell>
-                    <TableCell>{info?.departmentName ?? "–"}</TableCell>
-                    <TableCell>
-                      <JobPostingStatusBadge status={posting.status} />
-                    </TableCell>
-                    <TableCell>
-                      <Button variant="ghost" size="sm" asChild>
-                        <Link href={`/recruiting/${posting._id}`}>
-                          <Pencil className="h-4 w-4" />
-                          Bearbeiten
-                        </Link>
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+        <ApplicationsPanel />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Ausschreibungen</h2>
+
+        {isLoading ? (
+          <p className="text-muted-foreground py-8 text-center">Lädt…</p>
+        ) : jobPostings.length === 0 ? (
+          <div className="text-center py-10 border rounded-lg">
+            <Megaphone className="mx-auto h-10 w-10 text-muted-foreground" />
+            <h3 className="mt-3 font-semibold">Keine Ausschreibungen</h3>
+          </div>
+        ) : (
+          <div className="rounded-md border overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Titel</TableHead>
+                  <TableHead>Team</TableHead>
+                  <TableHead>Department</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-px" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {jobPostings.map((posting) => {
+                  const info = lookup.get(posting.teamId);
+                  return (
+                    <TableRow key={posting._id}>
+                      <TableCell className="font-medium">
+                        {posting.title}
+                      </TableCell>
+                      <TableCell>{info?.teamName ?? "–"}</TableCell>
+                      <TableCell>{info?.departmentName ?? "–"}</TableCell>
+                      <TableCell>
+                        <JobPostingStatusBadge status={posting.status} />
+                      </TableCell>
+                      <TableCell>
+                        <Button variant="ghost" size="sm" asChild>
+                          <Link href={`/recruiting/${posting._id}`}>
+                            <Pencil className="h-4 w-4" />
+                            Bearbeiten
+                          </Link>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </section>
 
       <CreateJobPostingDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>

--- a/app/(protected)/recruiting/[id]/JobPostingApplications.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingApplications.tsx
@@ -1,168 +1,20 @@
 "use client";
 
-import { Download, FileText, LoaderCircle, RefreshCw } from "lucide-react";
-import { useState } from "react";
-import toast from "react-hot-toast";
-import { Button } from "@/components/ui/button";
-import { useApplications } from "@/lib/client/applications/hooks/useApplications";
-import { APPLICATION_STATUS_LABELS } from "@/lib/applications/status";
-import type { ApplicationFileView, JobPosting } from "@/lib/db/types";
-
-const FILE_STATUS = {
-  pending: { label: "Import vorgemerkt", className: "text-amber-700" },
-  importing: { label: "Wird importiert", className: "text-amber-700" },
-  imported: { label: "Sicher gespeichert", className: "text-emerald-700" },
-  rejected: { label: "Abgelehnt", className: "text-destructive" },
-  failed: { label: "Import fehlgeschlagen", className: "text-destructive" },
-} as const;
-
-function formatDate(timestamp: number): string {
-  return new Intl.DateTimeFormat("de-DE", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  }).format(new Date(timestamp));
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function ApplicationFileRow({
-  file,
-  isRetrying,
-  onRetry,
-}: {
-  file: ApplicationFileView;
-  isRetrying: boolean;
-  onRetry: (fileId: string) => void;
-}) {
-  const status = FILE_STATUS[file.status];
-  const isBusy = file.status === "pending" || file.status === "importing";
-
-  return (
-    <li className="flex flex-wrap items-center gap-3 rounded-md bg-muted/45 px-3 py-2.5">
-      <div className="flex min-w-0 flex-1 items-center gap-2.5">
-        <FileText className="size-4 shrink-0 text-muted-foreground" />
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">{file.fileName}</p>
-          <p className="text-xs text-muted-foreground">
-            {file.fieldLabel} · {formatFileSize(file.size)}
-          </p>
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <span
-          className={`flex items-center gap-1.5 text-xs ${status.className}`}
-        >
-          {isBusy ? <LoaderCircle className="size-3 animate-spin" /> : null}
-          {status.label}
-        </span>
-        {file.status === "imported" ? (
-          <Button asChild size="sm" variant="outline">
-            <a
-              href={`/api/application-files/${file._id}/download`}
-              aria-label={`${file.fileName} herunterladen`}
-            >
-              <Download />
-              Download
-            </a>
-          </Button>
-        ) : null}
-        {file.status === "failed" ? (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={isRetrying}
-            onClick={() => onRetry(file._id)}
-          >
-            <RefreshCw className={isRetrying ? "animate-spin" : undefined} />
-            Erneut versuchen
-          </Button>
-        ) : null}
-      </div>
-      {file.error ? (
-        <p className="w-full pl-6 text-xs text-destructive">{file.error}</p>
-      ) : null}
-    </li>
-  );
-}
+import { ApplicationsPanel } from "@/components/Applications/ApplicationsPanel";
+import type { JobPosting } from "@/lib/db/types";
 
 export function JobPostingApplications({ posting }: { posting: JobPosting }) {
-  const hasForm = Boolean(posting.tallyFormId);
-  const { applications, isLoading, refetch } = useApplications(
-    posting._id,
-    hasForm,
-  );
-  const [retryingFileId, setRetryingFileId] = useState<string | null>(null);
-
-  async function retryFile(fileId: string) {
-    setRetryingFileId(fileId);
-    try {
-      const response = await fetch(`/api/application-files/${fileId}/retry`, {
-        method: "POST",
-      });
-      if (!response.ok) throw new Error("retry failed");
-      await refetch();
-      toast.success("Dateiimport erneut gestartet");
-    } catch {
-      toast.error("Dateiimport konnte nicht gestartet werden");
-    } finally {
-      setRetryingFileId(null);
-    }
-  }
-
-  if (!hasForm) return null;
+  if (!posting.tallyFormId) return null;
 
   return (
-    <div className="space-y-3 rounded-lg border-2 p-4">
+    <section className="space-y-4 rounded-lg border-2 p-4">
       <div>
         <h2 className="font-medium">Bewerbungen</h2>
         <p className="text-sm text-muted-foreground">
-          {isLoading ? "Wird geladen…" : `${applications.length} Bewerbung(en)`}
+          Bewerbungen für diese Ausschreibung prüfen und bearbeiten.
         </p>
       </div>
-
-      {applications.length > 0 ? (
-        <ul className="divide-y">
-          {applications.map((application) => (
-            <li key={application._id} className="space-y-3 py-3">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div>
-                  <p className="font-medium">
-                    {application.applicantName || application.applicantEmail}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    {application.applicantEmail}
-                  </p>
-                </div>
-                <div className="flex items-center gap-3 text-sm">
-                  <span className="rounded-full border px-2 py-0.5">
-                    {APPLICATION_STATUS_LABELS[application.status]}
-                  </span>
-                  <span className="text-muted-foreground">
-                    {formatDate(application._creationTime)}
-                  </span>
-                </div>
-              </div>
-              {application.files.length > 0 ? (
-                <ul className="space-y-2" aria-label="Bewerbungsdateien">
-                  {application.files.map((file) => (
-                    <ApplicationFileRow
-                      key={file._id}
-                      file={file}
-                      isRetrying={retryingFileId === file._id}
-                      onRetry={retryFile}
-                    />
-                  ))}
-                </ul>
-              ) : null}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
+      <ApplicationsPanel jobPostingId={posting._id} />
+    </section>
   );
 }

--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -42,6 +42,9 @@ const ACTION_LABELS: Record<string, string> = {
   "jobPosting.tally.publish": "Bewerbungsformular veröffentlicht",
   "jobPosting.tally.error": "Tally-Synchronisierung fehlgeschlagen",
   "jobFeedToken.rotate": "Job-Feed-Token rotiert",
+  "application.received": "Bewerbung eingegangen",
+  "application.management_update": "Bewerbung aktualisiert",
+  "application.status_change": "Bewerbungsstatus geändert",
 };
 
 export default async function LogsPage() {

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,0 +1,9 @@
+import { getApplications } from "@/lib/server/applications/data";
+
+export async function GET() {
+  try {
+    return Response.json({ data: await getApplications() });
+  } catch {
+    return Response.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+}

--- a/app/components/Applications/ApplicationActionFooter.tsx
+++ b/app/components/Applications/ApplicationActionFooter.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { SheetFooter } from "@/components/ui/sheet";
+import { useApplicationMutations } from "@/lib/client/applications/hooks/useApplicationMutations";
+import {
+  type ApplicationNextStatus,
+  APPLICATION_STATUS_TRANSITIONS,
+} from "@/lib/applications/transitions";
+import type { ApplicationStatus } from "@/lib/db/types";
+import toast from "react-hot-toast";
+
+interface StatusAction {
+  status: ApplicationStatus;
+  label: string;
+  variant?: "outline" | "destructive";
+}
+
+const STATUS_ACTIONS: Record<ApplicationNextStatus, StatusAction> = {
+  review: { status: "review", label: "In Prüfung nehmen" },
+  interview: { status: "interview", label: "Zum Interview" },
+  accepted: { status: "accepted", label: "Annehmen" },
+  rejected: { status: "rejected", label: "Ablehnen", variant: "destructive" },
+  withdrawn: {
+    status: "withdrawn",
+    label: "Zurückgezogen",
+    variant: "outline",
+  },
+};
+
+export function ApplicationActionFooter({
+  applicationId,
+  status,
+}: {
+  applicationId: string;
+  status: ApplicationStatus;
+}) {
+  const { setStatus } = useApplicationMutations();
+  const actions = APPLICATION_STATUS_TRANSITIONS[status].map(
+    (nextStatus) => STATUS_ACTIONS[nextStatus],
+  );
+
+  async function changeStatus(nextStatus: ApplicationStatus) {
+    try {
+      await setStatus.mutateAsync({ applicationId, status: nextStatus });
+      toast.success("Status aktualisiert");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Status konnte nicht geändert werden",
+      );
+    }
+  }
+
+  return (
+    <SheetFooter className="border-t bg-background">
+      {actions.length > 0 ? (
+        <fieldset
+          className="flex flex-wrap gap-2"
+          aria-label="Bewerbungsaktionen"
+        >
+          {actions.map((action) => (
+            <Button
+              key={action.status}
+              variant={action.variant ?? "primary"}
+              disabled={setStatus.isPending}
+              onClick={() => changeStatus(action.status)}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </fieldset>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Für diese abgeschlossene Bewerbung sind keine weiteren Statuswechsel
+          verfügbar.
+        </p>
+      )}
+    </SheetFooter>
+  );
+}

--- a/app/components/Applications/ApplicationAnswers.tsx
+++ b/app/components/Applications/ApplicationAnswers.tsx
@@ -1,0 +1,29 @@
+import type { ApplicationField } from "@/lib/db/types";
+import { formatFieldValue } from "./applicationPresentation";
+
+export function ApplicationAnswers({
+  title,
+  fields,
+}: {
+  title: string;
+  fields: ApplicationField[];
+}) {
+  if (fields.length === 0) return null;
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <dl className="space-y-3 rounded-lg border p-4">
+        {fields.map((field) => (
+          <div key={field.key}>
+            <dt className="text-xs font-medium text-muted-foreground">
+              {field.label || "Antwort"}
+            </dt>
+            <dd className="mt-1 whitespace-pre-wrap text-sm">
+              {formatFieldValue(field.value)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/app/components/Applications/ApplicationDrawer.tsx
+++ b/app/components/Applications/ApplicationDrawer.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { ApplicationWithFiles, User } from "@/lib/db/types";
+import { CalendarDays, Mail, UserRound } from "lucide-react";
+import { ApplicationActionFooter } from "./ApplicationActionFooter";
+import { ApplicationAnswers } from "./ApplicationAnswers";
+import { ApplicationFiles } from "./ApplicationFiles";
+import { ApplicationHistory } from "./ApplicationHistory";
+import { ApplicationManagement } from "./ApplicationManagement";
+import { DATE_TIME_FORMAT, isStandardField } from "./applicationPresentation";
+import { ApplicationStatusBadge } from "./ApplicationStatusBadge";
+
+interface Props {
+  application: ApplicationWithFiles;
+  owners: User[];
+  ownersById: Map<string, User>;
+  onClose: () => void;
+  onFilesChanged: () => Promise<unknown>;
+}
+
+export function ApplicationDrawer({
+  application,
+  owners,
+  ownersById,
+  onClose,
+  onFilesChanged,
+}: Props) {
+  const standardFields = application.fields.filter(isStandardField);
+  const individualFields = application.fields.filter(
+    (field) => !isStandardField(field),
+  );
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full gap-0 overflow-hidden p-0 sm:max-w-2xl"
+      >
+        <SheetHeader className="border-b pr-12">
+          <div className="flex flex-wrap items-center gap-2">
+            <SheetTitle>{application.applicantName || "Bewerbung"}</SheetTitle>
+            <ApplicationStatusBadge status={application.status} />
+          </div>
+          <SheetDescription>{application.jobPostingTitle}</SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-6 overflow-y-auto p-4">
+          <section className="grid gap-3 rounded-lg bg-muted/40 p-4 sm:grid-cols-2">
+            <div className="flex items-start gap-2">
+              <UserRound className="mt-0.5 size-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">Identität</p>
+                <p className="text-sm font-medium">
+                  {application.applicantName || "Nicht angegeben"}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2">
+              <Mail className="mt-0.5 size-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">E-Mail</p>
+                <a
+                  className="text-sm font-medium underline-offset-4 hover:underline"
+                  href={`mailto:${application.applicantEmail}`}
+                >
+                  {application.applicantEmail}
+                </a>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 sm:col-span-2">
+              <CalendarDays className="mt-0.5 size-4 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">Eingegangen</p>
+                <p className="text-sm">
+                  {DATE_TIME_FORMAT.format(application.submittedAt)}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <ApplicationManagement application={application} owners={owners} />
+          <ApplicationAnswers
+            title="Standardantworten"
+            fields={standardFields}
+          />
+          <ApplicationAnswers
+            title="Individuelle Antworten"
+            fields={individualFields}
+          />
+          <ApplicationFiles
+            files={application.files}
+            onFilesChanged={onFilesChanged}
+          />
+          <ApplicationHistory
+            application={application}
+            ownersById={ownersById}
+          />
+        </div>
+
+        <ApplicationActionFooter
+          applicationId={application._id}
+          status={application.status}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/app/components/Applications/ApplicationFiles.tsx
+++ b/app/components/Applications/ApplicationFiles.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import type { ApplicationFileView } from "@/lib/db/types";
+import { Download, FileText, LoaderCircle, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { formatFileSize } from "./applicationPresentation";
+
+const FILE_STATUS = {
+  pending: { label: "Import vorgemerkt", className: "text-amber-700" },
+  importing: { label: "Wird importiert", className: "text-amber-700" },
+  imported: { label: "Sicher gespeichert", className: "text-emerald-700" },
+  rejected: { label: "Abgelehnt", className: "text-destructive" },
+  failed: { label: "Import fehlgeschlagen", className: "text-destructive" },
+} as const;
+
+function FileRow({
+  file,
+  retrying,
+  onRetry,
+}: {
+  file: ApplicationFileView;
+  retrying: boolean;
+  onRetry: (fileId: string) => void;
+}) {
+  const status = FILE_STATUS[file.status];
+  const busy = file.status === "pending" || file.status === "importing";
+  return (
+    <li className="rounded-lg border p-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <FileText className="size-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{file.fileName}</p>
+          <p className="text-xs text-muted-foreground">
+            {file.fieldLabel} · {formatFileSize(file.size)}
+          </p>
+        </div>
+        <span className={`flex items-center gap-1 text-xs ${status.className}`}>
+          {busy ? <LoaderCircle className="size-3 animate-spin" /> : null}
+          {status.label}
+        </span>
+        {file.status === "imported" ? (
+          <Button asChild size="sm" variant="outline">
+            <a href={`/api/application-files/${file._id}/download`}>
+              <Download />
+              Download
+            </a>
+          </Button>
+        ) : null}
+        {file.status === "failed" ? (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={retrying}
+            onClick={() => onRetry(file._id)}
+          >
+            <RefreshCw className={retrying ? "animate-spin" : undefined} />
+            Erneut versuchen
+          </Button>
+        ) : null}
+      </div>
+      {file.error ? (
+        <p className="mt-2 text-xs text-destructive">{file.error}</p>
+      ) : null}
+    </li>
+  );
+}
+
+export function ApplicationFiles({
+  files,
+  onFilesChanged,
+}: {
+  files: ApplicationFileView[];
+  onFilesChanged: () => Promise<unknown>;
+}) {
+  const [retryingFileId, setRetryingFileId] = useState<string | null>(null);
+
+  async function retryFile(fileId: string) {
+    setRetryingFileId(fileId);
+    try {
+      const response = await fetch(`/api/application-files/${fileId}/retry`, {
+        method: "POST",
+      });
+      if (!response.ok) throw new Error("retry failed");
+      await onFilesChanged();
+      toast.success("Dateiimport erneut gestartet");
+    } catch {
+      toast.error("Dateiimport konnte nicht gestartet werden");
+    } finally {
+      setRetryingFileId(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Anhänge</h3>
+      {files.length > 0 ? (
+        <ul className="space-y-2">
+          {files.map((file) => (
+            <FileRow
+              key={file._id}
+              file={file}
+              retrying={retryingFileId === file._id}
+              onRetry={retryFile}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Keine Anhänge vorhanden.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/components/Applications/ApplicationHistory.tsx
+++ b/app/components/Applications/ApplicationHistory.tsx
@@ -1,0 +1,41 @@
+import type { ApplicationWithFiles, User } from "@/lib/db/types";
+import { DATE_TIME_FORMAT } from "./applicationPresentation";
+
+export function ApplicationHistory({
+  application,
+  ownersById,
+}: {
+  application: ApplicationWithFiles;
+  ownersById: Map<string, User>;
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Verlauf</h3>
+      <ol className="space-y-3 border-l pl-4">
+        {(application.history ?? [])
+          .toSorted((left, right) => right.timestamp - left.timestamp)
+          .map((entry) => {
+            const actor = ownersById.get(entry.actorUserId);
+            return (
+              <li
+                key={entry._id}
+                className="relative text-sm before:absolute before:-left-[21px] before:top-1.5 before:size-2 before:rounded-full before:bg-primary"
+              >
+                <p>{entry.details}</p>
+                <p className="text-xs text-muted-foreground">
+                  {actor?.name || actor?.email || "System"} ·{" "}
+                  {DATE_TIME_FORMAT.format(entry.timestamp)}
+                </p>
+              </li>
+            );
+          })}
+        <li className="relative text-sm before:absolute before:-left-[21px] before:top-1.5 before:size-2 before:rounded-full before:bg-muted-foreground">
+          <p>Bewerbung eingegangen</p>
+          <p className="text-xs text-muted-foreground">
+            System · {DATE_TIME_FORMAT.format(application.submittedAt)}
+          </p>
+        </li>
+      </ol>
+    </section>
+  );
+}

--- a/app/components/Applications/ApplicationManagement.tsx
+++ b/app/components/Applications/ApplicationManagement.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useApplicationMutations } from "@/lib/client/applications/hooks/useApplicationMutations";
+import type { ApplicationWithFiles, User } from "@/lib/db/types";
+import { LoaderCircle } from "lucide-react";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { UNASSIGNED_APPLICATIONS } from "./applicationTable";
+
+function toLocalDateTime(timestamp?: number): string {
+  if (!timestamp) return "";
+  const date = new Date(timestamp);
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(timestamp - offset).toISOString().slice(0, 16);
+}
+
+export function ApplicationManagement({
+  application,
+  owners,
+}: {
+  application: ApplicationWithFiles;
+  owners: User[];
+}) {
+  const { updateManagement } = useApplicationMutations();
+  const [ownerId, setOwnerId] = useState(
+    application.ownerId ?? UNASSIGNED_APPLICATIONS,
+  );
+  const [internalNotes, setInternalNotes] = useState(
+    application.internalNotes ?? "",
+  );
+  const [interviewAt, setInterviewAt] = useState(
+    toLocalDateTime(application.interviewAt),
+  );
+
+  async function saveManagement() {
+    const parsedInterview = interviewAt
+      ? new Date(interviewAt).getTime()
+      : null;
+    if (parsedInterview !== null && Number.isNaN(parsedInterview)) {
+      toast.error("Bitte gib einen gültigen Interviewtermin an");
+      return;
+    }
+    try {
+      await updateManagement.mutateAsync({
+        applicationId: application._id,
+        ownerId: ownerId === UNASSIGNED_APPLICATIONS ? null : ownerId,
+        internalNotes,
+        interviewAt: parsedInterview,
+      });
+      toast.success("Bewerbung aktualisiert");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Fehler beim Speichern",
+      );
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <h3 className="text-sm font-semibold">Interne Bearbeitung</h3>
+      <div className="grid gap-1.5">
+        <Label htmlFor="application-owner">Verantwortlich</Label>
+        <Select value={ownerId} onValueChange={setOwnerId}>
+          <SelectTrigger id="application-owner" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNASSIGNED_APPLICATIONS}>
+              Nicht zugewiesen
+            </SelectItem>
+            {owners.map((owner) => (
+              <SelectItem key={owner._id} value={owner._id}>
+                {owner.name || owner.email || "Unbenannt"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="application-interview">Interviewtermin</Label>
+        <Input
+          id="application-interview"
+          type="datetime-local"
+          value={interviewAt}
+          onChange={(e) => setInterviewAt(e.target.value)}
+        />
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="application-notes">Interne Notizen</Label>
+        <Textarea
+          id="application-notes"
+          value={internalNotes}
+          onChange={(e) => setInternalNotes(e.target.value)}
+          placeholder="Nur für P&C und Admins sichtbar"
+          rows={5}
+        />
+      </div>
+      <Button onClick={saveManagement} disabled={updateManagement.isPending}>
+        {updateManagement.isPending ? (
+          <LoaderCircle className="animate-spin" />
+        ) : null}
+        Bearbeitung speichern
+      </Button>
+    </section>
+  );
+}

--- a/app/components/Applications/ApplicationStatusBadge.tsx
+++ b/app/components/Applications/ApplicationStatusBadge.tsx
@@ -1,0 +1,28 @@
+import { Badge } from "@/components/ui/badge";
+import { APPLICATION_STATUS_LABELS } from "@/lib/applications/status";
+import type { ApplicationStatus } from "@/lib/db/types";
+import { cn } from "@/lib/utils";
+
+const STATUS_STYLES: Record<ApplicationStatus, string> = {
+  received: "border-sky-200 bg-sky-50 text-sky-800",
+  review: "border-amber-200 bg-amber-50 text-amber-800",
+  interview: "border-violet-200 bg-violet-50 text-violet-800",
+  accepted: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  rejected: "border-red-200 bg-red-50 text-red-800",
+  withdrawn: "border-slate-200 bg-slate-50 text-slate-700",
+};
+
+export function ApplicationStatusBadge({
+  status,
+}: {
+  status: ApplicationStatus;
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn("rounded-full", STATUS_STYLES[status])}
+    >
+      {APPLICATION_STATUS_LABELS[status]}
+    </Badge>
+  );
+}

--- a/app/components/Applications/ApplicationsPanel.tsx
+++ b/app/components/Applications/ApplicationsPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useApplications } from "@/lib/client/applications/hooks/useApplications";
+import { useMembers } from "@/lib/client/members/hooks/useMembers";
+import type { ApplicationWithFiles } from "@/lib/db/types";
+import { useMemo, useState } from "react";
+import { ApplicationDrawer } from "./ApplicationDrawer";
+import {
+  ALL_APPLICATIONS,
+  type ApplicationFilters,
+  filterApplications,
+} from "./applicationTable";
+import { ApplicationsTable } from "./ApplicationsTable";
+import { ApplicationsToolbar } from "./ApplicationsToolbar";
+
+interface Props {
+  jobPostingId?: string;
+}
+
+export function ApplicationsPanel({ jobPostingId }: Props) {
+  const { applications, isLoading, refetch } = useApplications(jobPostingId);
+  const { members } = useMembers();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [filters, setFilters] = useState<ApplicationFilters>({
+    search: "",
+    status: ALL_APPLICATIONS,
+    ownerId: ALL_APPLICATIONS,
+    sortDirection: "desc",
+  });
+  const owners = useMemo(
+    () => members.filter((member) => member.memberStatus !== "offboarded"),
+    [members],
+  );
+  const ownersById = useMemo(
+    () => new Map(members.map((member) => [member._id, member])),
+    [members],
+  );
+  const visibleApplications = filterApplications(applications, filters);
+  const selectedApplication = applications.find(
+    (application) => application._id === selectedId,
+  );
+
+  return (
+    <div className="space-y-4">
+      <ApplicationsToolbar
+        filters={filters}
+        owners={owners}
+        onChange={(patch) =>
+          setFilters((current) => ({ ...current, ...patch }))
+        }
+      />
+      <ApplicationsTable
+        applications={visibleApplications}
+        ownersById={ownersById}
+        isLoading={isLoading}
+        showJobPosting={!jobPostingId}
+        sortDirection={filters.sortDirection}
+        onSort={() =>
+          setFilters((current) => ({
+            ...current,
+            sortDirection: current.sortDirection === "desc" ? "asc" : "desc",
+          }))
+        }
+        onSelect={(application: ApplicationWithFiles) =>
+          setSelectedId(application._id)
+        }
+      />
+      {selectedApplication ? (
+        <ApplicationDrawer
+          key={`${selectedApplication._id}-${selectedApplication.updatedAt ?? 0}-${selectedApplication.status}`}
+          application={selectedApplication}
+          owners={owners}
+          ownersById={ownersById}
+          onClose={() => setSelectedId(null)}
+          onFilesChanged={refetch}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/Applications/ApplicationsTable.tsx
+++ b/app/components/Applications/ApplicationsTable.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { ApplicationWithFiles, User } from "@/lib/db/types";
+import { ArrowDown, ArrowUp, Inbox } from "lucide-react";
+import { ApplicationStatusBadge } from "./ApplicationStatusBadge";
+
+const DATE_FORMAT = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+interface Props {
+  applications: ApplicationWithFiles[];
+  ownersById: Map<string, User>;
+  isLoading: boolean;
+  showJobPosting: boolean;
+  sortDirection: "asc" | "desc";
+  onSort: () => void;
+  onSelect: (application: ApplicationWithFiles) => void;
+}
+
+export function ApplicationsTable({
+  applications,
+  ownersById,
+  isLoading,
+  showJobPosting,
+  sortDirection,
+  onSort,
+  onSelect,
+}: Props) {
+  if (!isLoading && applications.length === 0) {
+    return (
+      <div className="rounded-md border py-12 text-center">
+        <Inbox className="mx-auto size-10 text-muted-foreground" />
+        <h3 className="mt-3 font-semibold">Keine Bewerbungen gefunden</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Passe Suche oder Filter an, um Bewerbungen anzuzeigen.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="pl-4">Bewerber:in</TableHead>
+            {showJobPosting ? <TableHead>Ausschreibung</TableHead> : null}
+            <TableHead>Status</TableHead>
+            <TableHead>Verantwortlich</TableHead>
+            <TableHead className="pr-4">
+              <Button variant="ghost" size="sm" onClick={onSort}>
+                Eingang
+                {sortDirection === "desc" ? <ArrowDown /> : <ArrowUp />}
+              </Button>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {applications.map((application) => {
+            const owner = application.ownerId
+              ? ownersById.get(application.ownerId)
+              : undefined;
+            return (
+              <TableRow
+                key={application._id}
+                className="cursor-pointer"
+                onClick={() => onSelect(application)}
+              >
+                <TableCell className="pl-4">
+                  <button
+                    type="button"
+                    className="block font-medium outline-none hover:underline focus-visible:underline"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect(application);
+                    }}
+                  >
+                    {application.applicantName || application.applicantEmail}
+                  </button>
+                  <p className="text-xs text-muted-foreground">
+                    {application.applicantEmail}
+                  </p>
+                </TableCell>
+                {showJobPosting ? (
+                  <TableCell>{application.jobPostingTitle}</TableCell>
+                ) : null}
+                <TableCell>
+                  <ApplicationStatusBadge status={application.status} />
+                </TableCell>
+                <TableCell>{owner?.name || owner?.email || "–"}</TableCell>
+                <TableCell className="pr-4 text-muted-foreground">
+                  {DATE_FORMAT.format(application.submittedAt)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/app/components/Applications/ApplicationsToolbar.tsx
+++ b/app/components/Applications/ApplicationsToolbar.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { APPLICATION_STATUS_LABELS } from "@/lib/applications/status";
+import type { ApplicationStatus, User } from "@/lib/db/types";
+import {
+  ALL_APPLICATIONS,
+  type ApplicationFilters,
+  UNASSIGNED_APPLICATIONS,
+} from "./applicationTable";
+
+const STATUSES = Object.entries(APPLICATION_STATUS_LABELS) as [
+  ApplicationStatus,
+  string,
+][];
+
+interface Props {
+  filters: ApplicationFilters;
+  owners: User[];
+  onChange: (patch: Partial<ApplicationFilters>) => void;
+}
+
+export function ApplicationsToolbar({ filters, owners, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2 lg:flex-row">
+      <Input
+        value={filters.search}
+        onChange={(e) => onChange({ search: e.target.value })}
+        placeholder="Bewerbungen durchsuchen…"
+        aria-label="Bewerbungen durchsuchen"
+        className="lg:max-w-xs"
+      />
+      <Select
+        value={filters.status}
+        onValueChange={(status) =>
+          onChange({ status: status as ApplicationFilters["status"] })
+        }
+      >
+        <SelectTrigger aria-label="Status filtern" className="w-full lg:w-48">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_APPLICATIONS}>Alle Status</SelectItem>
+          {STATUSES.map(([value, label]) => (
+            <SelectItem key={value} value={value}>
+              {label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={filters.ownerId}
+        onValueChange={(ownerId) => onChange({ ownerId })}
+      >
+        <SelectTrigger
+          aria-label="Verantwortung filtern"
+          className="w-full lg:w-56"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_APPLICATIONS}>
+            Alle Verantwortlichen
+          </SelectItem>
+          <SelectItem value={UNASSIGNED_APPLICATIONS}>
+            Nicht zugewiesen
+          </SelectItem>
+          {owners.map((owner) => (
+            <SelectItem key={owner._id} value={owner._id}>
+              {owner.name || owner.email || "Unbenannt"}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/app/components/Applications/applicationPresentation.ts
+++ b/app/components/Applications/applicationPresentation.ts
@@ -1,0 +1,36 @@
+import type { ApplicationField, ApplicationFieldValue } from "@/lib/db/types";
+
+export const DATE_TIME_FORMAT = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function formatFieldValue(value: ApplicationFieldValue): string {
+  if (value === null) return "–";
+  if (typeof value === "boolean") return value ? "Ja" : "Nein";
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(formatFieldValue).join(", ") || "–";
+  }
+  return Object.entries(value)
+    .map(([key, item]) => `${key}: ${formatFieldValue(item)}`)
+    .join(" · ");
+}
+
+export function isStandardField(field: ApplicationField): boolean {
+  const type = field.type.toUpperCase();
+  const label = field.label.trim();
+  return (
+    type.includes("EMAIL") ||
+    type.includes("PHONE") ||
+    /^(vollständiger name|full ?name|name|vorname|nachname)$/i.test(label)
+  );
+}

--- a/app/components/Applications/applicationTable.test.ts
+++ b/app/components/Applications/applicationTable.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import type { ApplicationWithFiles } from "@/lib/db/types";
+import {
+  ALL_APPLICATIONS,
+  type ApplicationFilters,
+  filterApplications,
+  UNASSIGNED_APPLICATIONS,
+} from "./applicationTable";
+
+function application(
+  overrides: Partial<ApplicationWithFiles>,
+): ApplicationWithFiles {
+  return {
+    _id: overrides._id ?? crypto.randomUUID(),
+    _creationTime: overrides._creationTime ?? 1,
+    organizationId: "org-1",
+    jobPostingId: "posting-1",
+    jobPostingTitle: "Fundraising",
+    status: "received",
+    applicantEmail: "alex@example.com",
+    applicantEmailNormalized: "alex@example.com",
+    fields: [],
+    files: [],
+    tallyEventId: "event-1",
+    tallySubmissionId: "submission-1",
+    tallyResponseId: "response-1",
+    tallyFormId: "form-1",
+    submittedAt: 1,
+    ...overrides,
+  };
+}
+
+const filters: ApplicationFilters = {
+  search: "",
+  status: ALL_APPLICATIONS,
+  ownerId: ALL_APPLICATIONS,
+  sortDirection: "desc",
+};
+
+describe("filterApplications", () => {
+  test("searches identity and job title and sorts by submission time", () => {
+    const older = application({
+      _id: "older",
+      applicantName: "Alex Beispiel",
+      submittedAt: 10,
+    });
+    const newer = application({
+      _id: "newer",
+      applicantEmail: "kim@example.com",
+      applicantEmailNormalized: "kim@example.com",
+      jobPostingTitle: "Kommunikation",
+      submittedAt: 20,
+    });
+
+    expect(
+      filterApplications([older, newer], filters).map((item) => item._id),
+    ).toEqual(["newer", "older"]);
+    expect(
+      filterApplications([older, newer], {
+        ...filters,
+        search: "kommunikation",
+      }),
+    ).toEqual([newer]);
+  });
+
+  test("filters status and unassigned applications", () => {
+    const unassigned = application({ _id: "open", status: "review" });
+    const assigned = application({
+      _id: "owned",
+      status: "review",
+      ownerId: "user-1",
+    });
+
+    expect(
+      filterApplications([unassigned, assigned], {
+        ...filters,
+        status: "review",
+        ownerId: UNASSIGNED_APPLICATIONS,
+      }),
+    ).toEqual([unassigned]);
+  });
+});

--- a/app/components/Applications/applicationTable.ts
+++ b/app/components/Applications/applicationTable.ts
@@ -1,0 +1,42 @@
+import type { ApplicationStatus, ApplicationWithFiles } from "@/lib/db/types";
+
+export const ALL_APPLICATIONS = "__all__";
+export const UNASSIGNED_APPLICATIONS = "__unassigned__";
+
+export interface ApplicationFilters {
+  search: string;
+  status: ApplicationStatus | typeof ALL_APPLICATIONS;
+  ownerId: string;
+  sortDirection: "asc" | "desc";
+}
+
+export function filterApplications(
+  applications: ApplicationWithFiles[],
+  filters: ApplicationFilters,
+): ApplicationWithFiles[] {
+  const search = filters.search.trim().toLocaleLowerCase("de");
+  const visible = applications.filter((application) => {
+    const matchesSearch =
+      !search ||
+      [
+        application.applicantName,
+        application.applicantEmail,
+        application.jobPostingTitle,
+      ].some((value) => value?.toLocaleLowerCase("de").includes(search));
+    const matchesStatus =
+      filters.status === ALL_APPLICATIONS ||
+      application.status === filters.status;
+    const matchesOwner =
+      filters.ownerId === ALL_APPLICATIONS ||
+      (filters.ownerId === UNASSIGNED_APPLICATIONS
+        ? !application.ownerId
+        : application.ownerId === filters.ownerId);
+    return matchesSearch && matchesStatus && matchesOwner;
+  });
+
+  return visible.toSorted((left, right) =>
+    filters.sortDirection === "asc"
+      ? left.submittedAt - right.submittedAt
+      : right.submittedAt - left.submittedAt,
+  );
+}

--- a/app/lib/applications/transitions.ts
+++ b/app/lib/applications/transitions.ts
@@ -1,0 +1,22 @@
+import type { ApplicationStatus } from "../db/types";
+
+export type ApplicationNextStatus = Exclude<ApplicationStatus, "received">;
+
+export const APPLICATION_STATUS_TRANSITIONS: Record<
+  ApplicationStatus,
+  readonly ApplicationNextStatus[]
+> = {
+  received: ["review", "rejected", "withdrawn"],
+  review: ["interview", "accepted", "rejected", "withdrawn"],
+  interview: ["accepted", "rejected", "withdrawn"],
+  accepted: [],
+  rejected: [],
+  withdrawn: [],
+};
+
+export function isApplicationStatusTransitionAllowed(
+  from: ApplicationStatus,
+  to: ApplicationNextStatus,
+): boolean {
+  return APPLICATION_STATUS_TRANSITIONS[from].some((status) => status === to);
+}

--- a/app/lib/client/applications/hooks/useApplicationMutations.ts
+++ b/app/lib/client/applications/hooks/useApplicationMutations.ts
@@ -1,0 +1,20 @@
+import { updateApplicationManagement } from "@/lib/server/applications/management";
+import { setApplicationStatus } from "@/lib/server/applications/status";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useApplicationMutations() {
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["applications"] });
+
+  return {
+    updateManagement: useMutation({
+      mutationFn: updateApplicationManagement,
+      onSuccess: invalidate,
+    }),
+    setStatus: useMutation({
+      mutationFn: setApplicationStatus,
+      onSuccess: invalidate,
+    }),
+  };
+}

--- a/app/lib/client/applications/hooks/useApplications.ts
+++ b/app/lib/client/applications/hooks/useApplications.ts
@@ -3,9 +3,9 @@ import { useQuery } from "@tanstack/react-query";
 
 import { fetchApplications } from "../requests/fetchApplications";
 
-export function useApplications(jobPostingId: string, enabled = true) {
+export function useApplications(jobPostingId?: string, enabled = true) {
   const result = useQuery<ApplicationWithFiles[]>({
-    queryKey: ["applications", jobPostingId],
+    queryKey: ["applications", jobPostingId ?? "all"],
     queryFn: () => fetchApplications(jobPostingId),
     enabled,
     refetchInterval: (query) =>

--- a/app/lib/client/applications/requests/fetchApplications.ts
+++ b/app/lib/client/applications/requests/fetchApplications.ts
@@ -1,11 +1,12 @@
 import type { ApplicationWithFiles } from "@/lib/db/types";
 
 export async function fetchApplications(
-  jobPostingId: string,
+  jobPostingId?: string,
 ): Promise<ApplicationWithFiles[]> {
-  const response = await fetch(
-    `/api/job-postings/${jobPostingId}/applications`,
-  );
+  const url = jobPostingId
+    ? `/api/job-postings/${jobPostingId}/applications`
+    : "/api/applications";
+  const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error(

--- a/app/lib/db/application.ts
+++ b/app/lib/db/application.ts
@@ -21,6 +21,18 @@ export interface ApplicationField {
   value: ApplicationFieldValue;
 }
 
+export type ApplicationHistoryType = "status_changed" | "management_updated";
+
+export interface ApplicationHistoryEntry {
+  _id: string;
+  timestamp: number;
+  type: ApplicationHistoryType;
+  actorUserId: string;
+  details: string;
+  fromStatus?: ApplicationStatus;
+  toStatus?: ApplicationStatus;
+}
+
 export type ApplicationFileStatus =
   | "pending"
   | "importing"
@@ -66,10 +78,16 @@ export interface Application {
   tallyResponseId: string;
   tallyFormId: string;
   submittedAt: number;
+  ownerId?: string;
+  internalNotes?: string;
+  interviewAt?: number;
+  updatedAt?: number;
+  history?: ApplicationHistoryEntry[];
 }
 
 export type ApplicationWithFiles = Omit<Application, "files"> & {
   files: ApplicationFileView[];
+  jobPostingTitle: string;
 };
 
 export type TallyWebhookEventStatus = "processed" | "duplicate" | "ignored";

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -58,6 +58,8 @@ export async function ensureIndexes(): Promise<void> {
     .createIndexes([
       { key: { organizationId: 1, _creationTime: -1 } },
       { key: { organizationId: 1, jobPostingId: 1, _creationTime: -1 } },
+      { key: { organizationId: 1, status: 1, _creationTime: -1 } },
+      { key: { organizationId: 1, ownerId: 1, _creationTime: -1 } },
       { key: { organizationId: 1, "files._id": 1 } },
       { key: { tallyEventId: 1 }, unique: true },
       { key: { tallySubmissionId: 1 }, unique: true },

--- a/app/lib/server/applications/access.ts
+++ b/app/lib/server/applications/access.ts
@@ -1,0 +1,15 @@
+import { USER_PERMISSIONS } from "../../auth/roles";
+import { requirePermission } from "../../auth/session";
+import { applications } from "../../db/collections";
+
+export async function loadOwnedApplication(applicationId: string) {
+  const user = await requirePermission(USER_PERMISSIONS.recruiting);
+  const application = await (
+    await applications()
+  ).findOne({
+    _id: applicationId,
+    organizationId: user.organizationId,
+  });
+  if (!application) throw new Error("Bewerbung nicht gefunden");
+  return { user, application };
+}

--- a/app/lib/server/applications/applications.test.ts
+++ b/app/lib/server/applications/applications.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
+
+import { requirePermission } from "../../auth/session";
+import { applications, jobPostings, logs, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Application } from "../../db/types";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { getApplications } from "./data";
+import { updateApplicationManagement } from "./management";
+import { setApplicationStatus } from "./status";
+
+let organizationId: string;
+let foreignOrganizationId: string;
+let actorId: string;
+let postingId: string;
+let applicationId: string;
+let ownerId: string;
+
+setupTestDatabase();
+
+async function insertApplication(
+  overrides: Partial<Application> = {},
+): Promise<Application> {
+  const id = overrides._id ?? newId();
+  const application: Application = {
+    _id: id,
+    _creationTime: Date.now(),
+    organizationId,
+    jobPostingId: postingId,
+    status: "received",
+    applicantName: "Alex Beispiel",
+    applicantEmail: "alex@example.com",
+    applicantEmailNormalized: "alex@example.com",
+    fields: [],
+    files: [],
+    tallyEventId: `event-${id}`,
+    tallySubmissionId: `submission-${id}`,
+    tallyResponseId: `response-${id}`,
+    tallyFormId: "form-1",
+    submittedAt: Date.now(),
+    ...overrides,
+  };
+  await (await applications()).insertOne(application);
+  return application;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  organizationId = newId();
+  foreignOrganizationId = newId();
+  actorId = newId();
+  postingId = newId();
+  applicationId = newId();
+  ownerId = newId();
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({
+      _id: actorId,
+      organizationId,
+      role: "people_culture",
+    }),
+  );
+  await (
+    await jobPostings()
+  ).insertOne({
+    _id: postingId,
+    _creationTime: Date.now(),
+    organizationId,
+    teamId: newId(),
+    status: "published",
+    title: "Fundraising",
+    createdBy: actorId,
+  });
+  await (
+    await users()
+  ).insertOne({
+    _id: ownerId,
+    _creationTime: Date.now(),
+    organizationId,
+    name: "Pat Owner",
+    role: "people_culture",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+  });
+  await insertApplication({ _id: applicationId });
+});
+
+test("lists only applications from the actor organization with posting titles", async () => {
+  await insertApplication({
+    organizationId: foreignOrganizationId,
+    applicantEmail: "foreign@example.com",
+    applicantEmailNormalized: "foreign@example.com",
+  });
+
+  const result = await getApplications();
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toMatchObject({
+    _id: applicationId,
+    jobPostingTitle: "Fundraising",
+  });
+});
+
+test("stores management fields and an internal history entry", async () => {
+  const interviewAt = Date.now() + 86_400_000;
+  await updateApplicationManagement({
+    applicationId,
+    ownerId,
+    internalNotes: "Gute Vorerfahrung",
+    interviewAt,
+  });
+
+  const stored = await (await applications()).findOne({ _id: applicationId });
+  expect(stored).toMatchObject({
+    ownerId,
+    internalNotes: "Gute Vorerfahrung",
+    interviewAt,
+  });
+  expect(stored?.history?.[0]).toMatchObject({
+    actorUserId: actorId,
+    type: "management_updated",
+  });
+  expect(
+    await (await logs()).findOne({ entityId: applicationId }),
+  ).toMatchObject({
+    action: "application.management_update",
+  });
+});
+
+test("removes an assigned owner and interview date", async () => {
+  await updateApplicationManagement({
+    applicationId,
+    ownerId,
+    internalNotes: "",
+    interviewAt: Date.now() + 86_400_000,
+  });
+  await updateApplicationManagement({
+    applicationId,
+    ownerId: null,
+    internalNotes: "",
+    interviewAt: null,
+  });
+
+  const stored = await (await applications()).findOne({ _id: applicationId });
+  expect(stored?.ownerId).toBeUndefined();
+  expect(stored?.interviewAt).toBeUndefined();
+});
+
+test("rejects an owner from another organization", async () => {
+  const foreignOwnerId = newId();
+  await (
+    await users()
+  ).insertOne({
+    _id: foreignOwnerId,
+    _creationTime: Date.now(),
+    organizationId: foreignOrganizationId,
+    role: "member",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+  });
+
+  await expect(
+    updateApplicationManagement({
+      applicationId,
+      ownerId: foreignOwnerId,
+      internalNotes: "",
+      interviewAt: null,
+    }),
+  ).rejects.toThrow("Verantwortliche Person nicht verfügbar");
+});
+
+test("enforces allowed status transitions and records the decision", async () => {
+  await setApplicationStatus({ applicationId, status: "review" });
+  await setApplicationStatus({ applicationId, status: "accepted" });
+
+  const stored = await (await applications()).findOne({ _id: applicationId });
+  expect(stored?.status).toBe("accepted");
+  expect(stored?.history).toHaveLength(2);
+  await expect(
+    setApplicationStatus({ applicationId, status: "review" }),
+  ).rejects.toThrow("nicht zulässig");
+});
+
+test("cannot read or update an application from another organization", async () => {
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({ organizationId: foreignOrganizationId }),
+  );
+
+  await expect(
+    setApplicationStatus({ applicationId, status: "review" }),
+  ).rejects.toThrow("Bewerbung nicht gefunden");
+  await expect(getApplications()).resolves.toEqual([]);
+});

--- a/app/lib/server/applications/data.ts
+++ b/app/lib/server/applications/data.ts
@@ -1,7 +1,43 @@
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
 import { applications, jobPostings } from "../../db/collections";
-import type { ApplicationWithFiles } from "../../db/types";
+import type { Application, ApplicationWithFiles } from "../../db/types";
+
+function toApplicationView(
+  application: Application,
+  jobPostingTitle: string,
+): ApplicationWithFiles {
+  return {
+    ...application,
+    jobPostingTitle,
+    files: (application.files ?? []).map(
+      ({ sourceUrl: _sourceUrl, storageKey: _storageKey, ...file }) => file,
+    ),
+  };
+}
+
+export async function getApplications(): Promise<ApplicationWithFiles[]> {
+  const user = await requirePermission(USER_PERMISSIONS.recruiting);
+  const [records, postings] = await Promise.all([
+    (await applications())
+      .find({ organizationId: user.organizationId })
+      .sort({ _creationTime: -1 })
+      .toArray(),
+    (await jobPostings())
+      .find({ organizationId: user.organizationId })
+      .project({ _id: 1, title: 1 })
+      .toArray(),
+  ]);
+  const titles = new Map(
+    postings.map((posting) => [posting._id, posting.title]),
+  );
+  return records.map((application) =>
+    toApplicationView(
+      application,
+      titles.get(application.jobPostingId) ?? "Unbekannte Ausschreibung",
+    ),
+  );
+}
 
 export async function getApplicationsForJobPosting(
   jobPostingId: string,
@@ -16,10 +52,7 @@ export async function getApplicationsForJobPosting(
     .find({ organizationId: user.organizationId, jobPostingId })
     .sort({ _creationTime: -1 })
     .toArray();
-  return records.map((application) => ({
-    ...application,
-    files: (application.files ?? []).map(
-      ({ sourceUrl: _sourceUrl, storageKey: _storageKey, ...file }) => file,
-    ),
-  }));
+  return records.map((application) =>
+    toApplicationView(application, posting.title),
+  );
 }

--- a/app/lib/server/applications/history.ts
+++ b/app/lib/server/applications/history.ts
@@ -1,0 +1,21 @@
+import { newId } from "../../db/ids";
+import type {
+  ApplicationHistoryEntry,
+  ApplicationStatus,
+} from "../../db/types";
+
+export function createApplicationHistoryEntry(
+  actorUserId: string,
+  type: ApplicationHistoryEntry["type"],
+  details: string,
+  status?: { fromStatus: ApplicationStatus; toStatus: ApplicationStatus },
+): ApplicationHistoryEntry {
+  return {
+    _id: newId(),
+    timestamp: Date.now(),
+    actorUserId,
+    type,
+    details,
+    ...status,
+  };
+}

--- a/app/lib/server/applications/management.ts
+++ b/app/lib/server/applications/management.ts
@@ -1,0 +1,82 @@
+"use server";
+
+import { z } from "zod";
+import { applications, users } from "../../db/collections";
+import type { Application } from "../../db/types";
+import { addLog } from "../logs";
+import { loadOwnedApplication } from "./access";
+import { createApplicationHistoryEntry } from "./history";
+
+export async function updateApplicationManagement(input: {
+  applicationId: string;
+  ownerId: string | null;
+  internalNotes: string;
+  interviewAt: number | null;
+}): Promise<void> {
+  const parsed = z
+    .object({
+      applicationId: z.string().min(1),
+      ownerId: z.string().min(1).nullable(),
+      internalNotes: z.string().max(10_000),
+      interviewAt: z.number().int().positive().nullable(),
+    })
+    .parse(input);
+  const { user, application } = await loadOwnedApplication(
+    parsed.applicationId,
+  );
+
+  if (parsed.ownerId) {
+    const owner = await (
+      await users()
+    ).findOne({
+      _id: parsed.ownerId,
+      organizationId: user.organizationId,
+      memberStatus: { $ne: "offboarded" },
+    });
+    if (!owner) throw new Error("Verantwortliche Person nicht verfügbar");
+  }
+
+  const nextNotes = parsed.internalNotes.trim();
+  const details: string[] = [];
+  if ((application.ownerId ?? null) !== parsed.ownerId)
+    details.push("Verantwortung geändert");
+  if ((application.internalNotes ?? "") !== nextNotes)
+    details.push("Interne Notizen aktualisiert");
+  if ((application.interviewAt ?? null) !== parsed.interviewAt)
+    details.push(
+      parsed.interviewAt
+        ? "Interviewtermin aktualisiert"
+        : "Interviewtermin entfernt",
+    );
+  if (details.length === 0) return;
+
+  const entry = createApplicationHistoryEntry(
+    user._id,
+    "management_updated",
+    details.join(" · "),
+  );
+  const set: Partial<Application> = {
+    internalNotes: nextNotes,
+    updatedAt: entry.timestamp,
+  };
+  const unset: Record<string, ""> = {};
+  if (parsed.ownerId) set.ownerId = parsed.ownerId;
+  else unset.ownerId = "";
+  if (parsed.interviewAt) set.interviewAt = parsed.interviewAt;
+  else unset.interviewAt = "";
+
+  const result = await (
+    await applications()
+  ).updateOne(
+    { _id: application._id, organizationId: user.organizationId },
+    { $set: set, $unset: unset, $push: { history: entry } },
+  );
+  if (result.matchedCount !== 1) throw new Error("Bewerbung nicht gefunden");
+  await addLog(
+    user.organizationId,
+    user._id,
+    "application.management_update",
+    application._id,
+    details.join(", "),
+  );
+}

--- a/app/lib/server/applications/status.ts
+++ b/app/lib/server/applications/status.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { z } from "zod";
+import { APPLICATION_STATUS_LABELS } from "../../applications/status";
+import { isApplicationStatusTransitionAllowed } from "../../applications/transitions";
+import { applications } from "../../db/collections";
+import type { ApplicationStatus } from "../../db/types";
+import { addLog } from "../logs";
+import { loadOwnedApplication } from "./access";
+import { createApplicationHistoryEntry } from "./history";
+
+const statusSchema = z.enum([
+  "received",
+  "review",
+  "interview",
+  "accepted",
+  "rejected",
+  "withdrawn",
+]);
+
+export async function setApplicationStatus(input: {
+  applicationId: string;
+  status: ApplicationStatus;
+}): Promise<void> {
+  const { applicationId, status } = z
+    .object({ applicationId: z.string().min(1), status: statusSchema })
+    .parse(input);
+  const { user, application } = await loadOwnedApplication(applicationId);
+  if (
+    status === "received" ||
+    !isApplicationStatusTransitionAllowed(application.status, status)
+  ) {
+    throw new Error("Dieser Statuswechsel ist nicht zulässig");
+  }
+
+  const entry = createApplicationHistoryEntry(
+    user._id,
+    "status_changed",
+    `${APPLICATION_STATUS_LABELS[application.status]} → ${APPLICATION_STATUS_LABELS[status]}`,
+    { fromStatus: application.status, toStatus: status },
+  );
+  const result = await (
+    await applications()
+  ).updateOne(
+    {
+      _id: application._id,
+      organizationId: user.organizationId,
+      status: application.status,
+    },
+    {
+      $set: { status, updatedAt: entry.timestamp },
+      $push: { history: entry },
+    },
+  );
+  if (result.modifiedCount !== 1)
+    throw new Error("Bewerbung wurde zwischenzeitlich geändert");
+  await addLog(
+    user.organizationId,
+    user._id,
+    "application.status_change",
+    application._id,
+    entry.details,
+  );
+}


### PR DESCRIPTION
## Summary

- Add cross-posting and job-specific application tables with search, status and owner filters, plus sortable submission times.
- Add a detail drawer for answers, attachments, history, ownership, notes, interview scheduling, and guarded status decisions.
- Enforce recruiting permissions and organization scoping for application reads, updates, audit history, and files.

## Validation

- pnpm exec tsc --noEmit
- pnpm exec biome lint (targeted recruiting and application paths)
- pnpm lint:lines
- pnpm exec vitest run (33 targeted tests)
- pnpm build
- pnpm exec playwright test e2e/recruiting.spec.ts