### PR TITLE
fix(reimbursements): default requests to travel reimbursements

### DIFF
--- a/app/components/Reimbursements/shareModal/constants.ts
+++ b/app/components/Reimbursements/shareModal/constants.ts
@@ -1,5 +1,7 @@
 import type { FormState, LinkKind, LinkType } from "./types";
 
+export const DEFAULT_LINK_TYPE: LinkType = "travel";
+
 export const INITIAL_FORM: FormState = {
   projectId: null,
   description: "",

--- a/app/components/Reimbursements/shareModal/useShareModal.ts
+++ b/app/components/Reimbursements/shareModal/useShareModal.ts
@@ -10,12 +10,12 @@ import {
   getPendingSharedLinks,
 } from "@/lib/server/reimbursements/sharing";
 import { createLink as createAllowanceLink } from "@/lib/server/volunteerAllowance/sharing";
-import { INITIAL_FORM, linkUrl } from "./constants";
+import { DEFAULT_LINK_TYPE, INITIAL_FORM, linkUrl } from "./constants";
 import type { LinkKind, LinkType, PendingLink } from "./types";
 
 export function useShareModal(open: boolean, onClose: () => void) {
   const router = useRouter();
-  const [type, setType] = useState<LinkType>("expense");
+  const [type, setType] = useState<LinkType>(DEFAULT_LINK_TYPE);
   const [form, setForm] = useState(INITIAL_FORM);
   const [isGenerating, setIsGenerating] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -53,7 +53,7 @@ export function useShareModal(open: boolean, onClose: () => void) {
 
   const handleClose = () => {
     setForm(INITIAL_FORM);
-    setType("expense");
+    setType(DEFAULT_LINK_TYPE);
     onClose();
   };
 


### PR DESCRIPTION
## summary

- select travel reimbursement by default when the request dialog opens
- restore the travel reimbursement default whenever the dialog closes

## validation

- `pnpm exec prettier --check app/components/Reimbursements/shareModal/constants.ts app/components/Reimbursements/shareModal/useShareModal.ts`
- `pnpm exec biome lint app/components/Reimbursements/shareModal/constants.ts app/components/Reimbursements/shareModal/useShareModal.ts`
- `pnpm exec tsc --noEmit`
- build not run (repo-wide and unnecessary for this state-only change)
- tests not run (repository guidance excludes tests for trivial UI wiring)