### PR TITLE
feat(recruiting): select organization contacts

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { SelectMembers } from "@/components/Selectors/SelectMembers";
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useMembers } from "@/lib/client/members/hooks/useMembers";
 import { useTeamDirectory } from "@/lib/client/teams/hooks/useTeamDirectory";
 import type { JobPostingFormValues } from "@/lib/jobPostings/form";
 
@@ -14,6 +16,7 @@ interface Props {
 
 export function JobPostingBasicFields({ values, onChange }: Props) {
   const { teams, lookup } = useTeamDirectory();
+  const { members, isLoading: areMembersLoading } = useMembers();
   const departmentName = lookup.get(values.teamId)?.departmentName ?? "–";
 
   return (
@@ -77,12 +80,13 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="jp-contact">Kontakt</Label>
-        <Input
-          id="jp-contact"
-          value={values.contact}
-          onChange={(e) => onChange({ contact: e.target.value })}
-          placeholder="E-Mail oder Ansprechperson"
+        <Label htmlFor="jp-contacts">Ansprechpartner</Label>
+        <SelectMembers
+          id="jp-contacts"
+          members={members}
+          value={values.contactUserIds}
+          isLoading={areMembersLoading}
+          onValueChange={(contactUserIds) => onChange({ contactUserIds })}
         />
       </div>
     </div>

--- a/app/components/Selectors/MultiSelect.tsx
+++ b/app/components/Selectors/MultiSelect.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { type ReactNode, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  description?: string;
+  keywords?: string;
+}
+
+interface Props<TOption extends MultiSelectOption> {
+  id?: string;
+  options: TOption[];
+  value: string[];
+  onValueChange: (value: string[]) => void;
+  placeholder: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  loadingMessage?: string;
+  isLoading?: boolean;
+  maxSelected?: number;
+  renderOption?: (option: TOption) => ReactNode;
+  renderValue?: (options: TOption[], selectedCount: number) => ReactNode;
+}
+
+export function MultiSelect<TOption extends MultiSelectOption>({
+  id,
+  options,
+  value,
+  onValueChange,
+  placeholder,
+  searchPlaceholder = "Suchen …",
+  emptyMessage = "Keine passenden Einträge gefunden.",
+  loadingMessage = "Einträge werden geladen …",
+  isLoading = false,
+  maxSelected = Number.POSITIVE_INFINITY,
+  renderOption,
+  renderValue,
+}: Props<TOption>) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const selectedValues = useMemo(() => new Set(value), [value]);
+  const optionsByValue = useMemo(
+    () => new Map(options.map((option) => [option.value, option])),
+    [options],
+  );
+  const selectedOptions = useMemo(
+    () =>
+      value.flatMap((selectedValue) => {
+        const option = optionsByValue.get(selectedValue);
+        return option ? [option] : [];
+      }),
+    [optionsByValue, value],
+  );
+  const visibleOptions = useMemo(() => {
+    const query = search.trim().toLocaleLowerCase("de");
+    if (!query) return options;
+    return options.filter((option) =>
+      (option.keywords ?? `${option.label} ${option.description ?? ""}`)
+        .toLocaleLowerCase("de")
+        .includes(query),
+    );
+  }, [options, search]);
+
+  const toggleOption = (option: TOption) => {
+    const isSelected = selectedValues.has(option.value);
+    if (!isSelected && value.length >= maxSelected) return;
+    onValueChange(
+      isSelected
+        ? value.filter((selectedValue) => selectedValue !== option.value)
+        : [...value, option.value],
+    );
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setSearch("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className="min-h-12 h-auto w-full justify-between px-3 py-2 font-normal"
+        >
+          <span className="flex min-w-0 items-center gap-2 truncate">
+            {value.length > 0
+              ? (renderValue?.(selectedOptions, value.length) ??
+                `${value.length} ausgewählt`)
+              : placeholder}
+          </span>
+          <ChevronsUpDown className="size-4 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-(--radix-popover-trigger-width) p-0"
+      >
+        <div className="relative border-b p-2">
+          <Search className="pointer-events-none absolute top-1/2 left-5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={searchPlaceholder}
+            aria-label={searchPlaceholder}
+            className="py-2 pr-3 pl-9"
+            autoFocus
+          />
+        </div>
+        <div className="max-h-72 overflow-y-auto">
+          <div
+            role="listbox"
+            aria-label={placeholder}
+            aria-multiselectable="true"
+            className="space-y-1 p-2"
+          >
+            {isLoading ? (
+              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                {loadingMessage}
+              </p>
+            ) : null}
+            {!isLoading && visibleOptions.length === 0 ? (
+              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                {emptyMessage}
+              </p>
+            ) : null}
+            {visibleOptions.map((option) => {
+              const selected = selectedValues.has(option.value);
+              const disabled = !selected && value.length >= maxSelected;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  disabled={disabled}
+                  onClick={() => toggleOption(option)}
+                  className="flex w-full items-center gap-3 px-2 py-2 text-left outline-none transition-colors hover:bg-accent focus-visible:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <span className="min-w-0 flex-1">
+                    {renderOption?.(option) ?? (
+                      <>
+                        <span className="block truncate text-sm font-medium">
+                          {option.label}
+                        </span>
+                        {option.description ? (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {option.description}
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="grid size-5 shrink-0 place-items-center border-2 border-input data-[selected=true]:border-primary data-[selected=true]:bg-primary"
+                    data-selected={selected}
+                  >
+                    {selected ? (
+                      <Check className="size-3.5" strokeWidth={3} />
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/components/Selectors/SelectMembers.tsx
+++ b/app/components/Selectors/SelectMembers.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Users } from "lucide-react";
+import { useMemo } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { User } from "@/lib/db/types";
+import { getInitials } from "@/lib/formatters/getInitials";
+import { MultiSelect, type MultiSelectOption } from "./MultiSelect";
+
+interface MemberOption extends MultiSelectOption {
+  member: User;
+}
+
+interface Props {
+  id?: string;
+  members: User[];
+  value: string[];
+  isLoading?: boolean;
+  onValueChange: (value: string[]) => void;
+  maxSelected?: number;
+}
+
+function memberName(member: User): string {
+  return member.name?.trim() || member.email?.trim() || "Unbekanntes Mitglied";
+}
+
+function renderMemberOption(option: MemberOption) {
+  const { member } = option;
+  return (
+    <span className="flex min-w-0 items-center gap-3">
+      <Avatar className="size-8">
+        <AvatarImage src={member.image} alt="" />
+        <AvatarFallback className="text-xs font-semibold">
+          {getInitials(member.name, member.email)}
+        </AvatarFallback>
+      </Avatar>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium">
+          {option.label}
+        </span>
+        {option.description ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            {option.description}
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+function renderSelectedMembers(options: MemberOption[], selectedCount: number) {
+  return (
+    <>
+      {options.length > 0 ? (
+        <span className="flex -space-x-2">
+          {options.slice(0, 3).map(({ member }) => (
+            <Avatar
+              key={member._id}
+              className="size-7 border-2 border-background"
+            >
+              <AvatarImage src={member.image} alt="" />
+              <AvatarFallback className="text-[10px] font-semibold">
+                {getInitials(member.name, member.email)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+        </span>
+      ) : (
+        <Users className="size-4 text-muted-foreground" />
+      )}
+      <span className="truncate">
+        {selectedCount} {selectedCount === 1 ? "Person" : "Personen"} ausgewählt
+      </span>
+    </>
+  );
+}
+
+export function SelectMembers({
+  id,
+  members,
+  value,
+  isLoading,
+  onValueChange,
+  maxSelected = 20,
+}: Props) {
+  const options = useMemo<MemberOption[]>(
+    () =>
+      members
+        .filter(
+          (member) =>
+            member.memberStatus !== "offboarded" &&
+            Boolean(member.email?.trim()),
+        )
+        .map((member) => ({
+          value: member._id,
+          label: memberName(member),
+          description: member.name ? member.email : undefined,
+          keywords: `${member.name ?? ""} ${member.email ?? ""} ${member.positionTitle ?? ""}`,
+          member,
+        }))
+        .sort((first, second) => first.label.localeCompare(second.label, "de")),
+    [members],
+  );
+
+  return (
+    <MultiSelect
+      id={id}
+      options={options}
+      value={value}
+      onValueChange={onValueChange}
+      placeholder="Ansprechpartner auswählen"
+      searchPlaceholder="Name oder E-Mail suchen"
+      emptyMessage="Keine passenden Mitglieder gefunden."
+      loadingMessage="Mitglieder werden geladen …"
+      isLoading={isLoading}
+      maxSelected={maxSelected}
+      renderOption={renderMemberOption}
+      renderValue={renderSelectedMembers}
+    />
+  );
+}

--- a/app/lib/db/jobPosting.ts
+++ b/app/lib/db/jobPosting.ts
@@ -15,7 +15,7 @@ export interface JobPosting {
   location?: string;
   isRemote?: boolean;
   deadline?: string;
-  contact?: string;
+  contactUserIds?: string[];
   createdBy: string;
   tallyFormId?: string;
   tallyWebhookId?: string;

--- a/app/lib/jobPostings/form.ts
+++ b/app/lib/jobPostings/form.ts
@@ -11,7 +11,7 @@ export interface JobPostingFormValues {
   location: string;
   isRemote: boolean;
   deadline: string;
-  contact: string;
+  contactUserIds: string[];
 }
 
 export function toJobPostingForm(posting: JobPosting): JobPostingFormValues {
@@ -26,6 +26,6 @@ export function toJobPostingForm(posting: JobPosting): JobPostingFormValues {
     location: posting.location ?? "",
     isRemote: posting.isRemote ?? false,
     deadline: posting.deadline ?? "",
-    contact: posting.contact ?? "",
+    contactUserIds: posting.contactUserIds ?? [],
   };
 }

--- a/app/lib/server/applications/email.ts
+++ b/app/lib/server/applications/email.ts
@@ -1,6 +1,11 @@
+import {
+  applications,
+  jobPostings,
+  organizations,
+  users,
+} from "../../db/collections";
 import type { Application, JobPosting } from "../../db/types";
-import { applications, jobPostings, organizations } from "../../db/collections";
-import { sendMail } from "../../email/brevo";
+import { type EmailRecipient, sendMail } from "../../email/brevo";
 import { BREVO_TEMPLATE_IDS } from "../../email/templates";
 import { appUrl } from "../../email/urls";
 
@@ -41,12 +46,29 @@ async function sendContactEmail(
   application: Application,
   posting: JobPosting,
 ): Promise<void> {
-  const contact = posting.contact?.trim();
-  if (!contact || !EMAIL_PATTERN.test(contact)) return;
+  const selectedContacts = posting.contactUserIds?.length
+    ? await (
+        await users()
+      )
+        .find({
+          _id: { $in: posting.contactUserIds },
+          organizationId: posting.organizationId,
+          memberStatus: { $ne: "offboarded" },
+        })
+        .project({ name: 1, email: 1 })
+        .toArray()
+    : [];
+  const recipients: EmailRecipient[] = selectedContacts.flatMap((contact) => {
+    const email = contact.email?.trim();
+    return email && EMAIL_PATTERN.test(email)
+      ? [{ email, name: contact.name }]
+      : [];
+  });
+  if (recipients.length === 0) return;
 
   try {
     await sendMail({
-      to: [{ email: contact }],
+      to: recipients,
       replyTo: { email: application.applicantEmail },
       templateId: BREVO_TEMPLATE_IDS.APPLICATION_RECEIVED_PC,
       params: {

--- a/app/lib/server/jobFeed/feed.ts
+++ b/app/lib/server/jobFeed/feed.ts
@@ -4,8 +4,9 @@ import {
   jobPostings,
   organizations,
   teams,
+  users,
 } from "../../db/collections";
-import type { JobPosting } from "../../db/types";
+import type { JobPosting, User } from "../../db/types";
 
 export const JOB_FEED_TAG = "YFN_TEAM" as const;
 
@@ -71,7 +72,7 @@ export async function getJobFeedV1(
           timeCommitment: 1,
           location: 1,
           deadline: 1,
-          contact: 1,
+          contactUserIds: 1,
           tallyFormId: 1,
         },
       },
@@ -80,9 +81,24 @@ export async function getJobFeedV1(
     .toArray();
 
   const teamIds = [...new Set(postings.map((posting) => posting.teamId))];
-  const ownedTeams = await (await teams())
-    .find({ _id: { $in: teamIds }, organizationId })
-    .toArray();
+  const contactUserIds = [
+    ...new Set(postings.flatMap((posting) => posting.contactUserIds ?? [])),
+  ];
+  const [ownedTeams, contactUsers] = await Promise.all([
+    (await teams()).find({ _id: { $in: teamIds }, organizationId }).toArray(),
+    (await users())
+      .find({
+        _id: { $in: contactUserIds },
+        organizationId,
+        memberStatus: { $ne: "offboarded" },
+      })
+      .project<Pick<User, "_id" | "name" | "email">>({
+        _id: 1,
+        name: 1,
+        email: 1,
+      })
+      .toArray(),
+  ]);
   const departmentIds = [
     ...new Set(ownedTeams.map((team) => team.departmentId)),
   ];
@@ -93,6 +109,9 @@ export async function getJobFeedV1(
   const departmentsById = new Map(
     ownedDepartments.map((department) => [department._id, department]),
   );
+  const contactsById = new Map(
+    contactUsers.map((contact) => [contact._id, contact]),
+  );
 
   return postings.map((posting) =>
     toFeedItem(
@@ -101,6 +120,7 @@ export async function getJobFeedV1(
       organization.name,
       teamsById,
       departmentsById,
+      contactsById,
     ),
   );
 }
@@ -111,6 +131,7 @@ function toFeedItem(
   organizationName: string,
   teamsById: Map<string, { name: string; departmentId: string }>,
   departmentsById: Map<string, { name: string }>,
+  contactsById: Map<string, Pick<User, "_id" | "name" | "email">>,
 ): JobFeedItemV1 {
   const team = teamsById.get(posting.teamId);
   const department = team ? departmentsById.get(team.departmentId) : undefined;
@@ -130,8 +151,22 @@ function toFeedItem(
     timeCommitment: posting.timeCommitment ?? "",
     location: posting.location ?? "",
     deadline: posting.deadline || null,
-    contact: posting.contact ?? "",
+    contact: formatContacts(posting, contactsById),
     tallyUrl: tallyUrl(posting.tallyFormId),
     tags: [JOB_FEED_TAG],
   };
+}
+
+function formatContacts(
+  posting: JobPosting,
+  contactsById: Map<string, Pick<User, "_id" | "name" | "email">>,
+): string {
+  const contacts = (posting.contactUserIds ?? []).flatMap((contactUserId) => {
+    const contact = contactsById.get(contactUserId);
+    return contact ? [contact] : [];
+  });
+  return contacts
+    .map((contact) => contact.name?.trim() || contact.email?.trim())
+    .filter(Boolean)
+    .join(", ");
 }

--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -3,7 +3,7 @@
 import { z } from "zod";
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
-import { jobPostings, teams } from "../../db/collections";
+import { jobPostings, teams, users } from "../../db/collections";
 import { newId } from "../../db/ids";
 import { addLog } from "../logs";
 import { requireOwnedJobPosting } from "./access";
@@ -22,12 +22,12 @@ const contentSchema = z.object({
   location: optionalText,
   isRemote: z.boolean().optional(),
   deadline: optionalText,
-  contact: optionalText,
+  contactUserIds: z.array(z.string().trim().min(1)).max(20).optional(),
 });
 
 type Content = z.infer<typeof contentSchema>;
 
-function toDocumentFields(content: Content) {
+function toDocumentFields(content: Content, contactUserIds: string[]) {
   return {
     title: content.title,
     teamId: content.teamId,
@@ -39,7 +39,7 @@ function toDocumentFields(content: Content) {
     location: content.location ?? "",
     isRemote: content.isRemote ?? false,
     deadline: content.deadline ?? "",
-    contact: content.contact ?? "",
+    contactUserIds,
   };
 }
 
@@ -82,9 +82,14 @@ export async function updateJobPosting(
 
   await requireOwnedJobPosting(jobPostingId, user.organizationId);
   await requireActiveTeam(content.teamId, user.organizationId);
+  const contactUserIds = [...new Set(content.contactUserIds ?? [])];
+  await requireContactMembers(contactUserIds, user.organizationId);
   await (
     await jobPostings()
-  ).updateOne({ _id: jobPostingId }, { $set: toDocumentFields(content) });
+  ).updateOne(
+    { _id: jobPostingId },
+    { $set: toDocumentFields(content, contactUserIds) },
+  );
   await addLog(
     user.organizationId,
     user._id,
@@ -92,6 +97,29 @@ export async function updateJobPosting(
     jobPostingId,
     content.title,
   );
+}
+
+async function requireContactMembers(
+  contactUserIds: string[],
+  organizationId: string,
+) {
+  if (contactUserIds.length === 0) return;
+  const contacts = await (
+    await users()
+  )
+    .find({
+      _id: { $in: contactUserIds },
+      organizationId,
+      memberStatus: { $ne: "offboarded" },
+    })
+    .project({ _id: 1, email: 1 })
+    .toArray();
+  const validContactIds = new Set(
+    contacts.filter((contact) => contact.email?.trim()).map(({ _id }) => _id),
+  );
+  if (contactUserIds.some((id) => !validContactIds.has(id))) {
+    throw new Error("Ansprechpartner nicht verfügbar");
+  }
 }
 
 async function requireActiveTeam(teamId: string, organizationId: string) {

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -6,8 +6,9 @@ vi.mock("../../auth/session", () => ({
 }));
 
 import { requirePermission, requireUser } from "../../auth/session";
-import { departments, jobPostings, teams } from "../../db/collections";
+import { departments, jobPostings, teams, users } from "../../db/collections";
 import { newId } from "../../db/ids";
+import type { User } from "../../db/types";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { createJobPostingDraft, updateJobPosting } from "./actions";
@@ -44,6 +45,25 @@ async function insertTeam(
     organizationId,
     isArchived,
     createdBy: userA,
+  });
+  return _id;
+}
+
+async function insertMember(
+  organizationId: string,
+  overrides: Partial<User> = {},
+): Promise<string> {
+  const _id = overrides._id ?? newId();
+  await (
+    await users()
+  ).insertOne({
+    _id,
+    _creationTime: Date.now(),
+    organizationId,
+    email: `${_id}@example.org`,
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+    ...overrides,
   });
   return _id;
 }
@@ -129,6 +149,46 @@ test("updateJobPosting can edit content while published", async () => {
   const posting = await getJobPostingById(id);
   expect(posting.title).toBe("Neu");
   expect(posting.status).toBe("published");
+});
+
+test("updateJobPosting stores unique organization members as contacts", async () => {
+  const firstContact = await insertMember(orgA, { name: "Erster Kontakt" });
+  const secondContact = await insertMember(orgA, { name: "Zweiter Kontakt" });
+  const id = await createJobPostingDraft({ title: "Alt", teamId: teamA });
+
+  await updateJobPosting({
+    jobPostingId: id,
+    title: "Neu",
+    teamId: teamA,
+    contactUserIds: [firstContact, firstContact, secondContact],
+  });
+
+  const posting = await getJobPostingById(id);
+  expect(posting.contactUserIds).toEqual([firstContact, secondContact]);
+});
+
+test("updateJobPosting rejects unavailable contacts", async () => {
+  const foreignContact = await insertMember(orgB);
+  const offboardedContact = await insertMember(orgA, {
+    memberStatus: "offboarded",
+  });
+  const contactWithoutEmail = await insertMember(orgA, { email: undefined });
+  const id = await createJobPostingDraft({ title: "T", teamId: teamA });
+
+  for (const contactUserId of [
+    foreignContact,
+    offboardedContact,
+    contactWithoutEmail,
+  ]) {
+    await expect(
+      updateJobPosting({
+        jobPostingId: id,
+        title: "T",
+        teamId: teamA,
+        contactUserIds: [contactUserId],
+      }),
+    ).rejects.toThrow("Ansprechpartner nicht verfügbar");
+  }
 });
 
 test("cannot touch or read a posting from another org", async () => {


### PR DESCRIPTION
## summary

- replace free-text job contacts with a searchable organization member multiselect
- validate selected members and use them for job feed output and application notifications

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm build`
- `pnpm lint:lines` fails on unchanged `ReimbursementPageUI.tsx` from `main` (208 lines)
- e2e not run (browser coverage left to CI)