### PR TITLE
fix(reimbursements): let travelers enter travel dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,16 +63,10 @@ pnpm exec playwright test e2e/reimbursements.spec.ts
 
 ## Testing
 
-- **Vitest** for unit/integration tests (`app/**/*.test.ts`)
-- **Playwright** for E2E tests (`e2e/*.spec.ts`)
-- MongoDB integration tests use `mongodb-memory-server`
-- Test observable behavior, risk boundaries, and concrete regressions—not implementation details
-- Require targeted tests for money, permissions, tenant isolation, destructive actions, and external integrations
-- Do not add tests for styling, copy, trivial wiring, or refactors without behavior changes
-- Test each behavior at the lowest stable layer; avoid duplicating it across helpers, actions, routes, and UI
-- Prefer state and user-visible outcomes over exact mock call sequences
-- Run the narrowest relevant test locally; CI owns the complete Vitest and Playwright suites
-- Do not introduce a blanket coverage target
+- Use Vitest for unit/integration tests and Playwright for E2E flows; MongoDB integration tests use `mongodb-memory-server`
+- Add tests for meaningful observable behavior, concrete regressions, and high-risk boundaries such as money, permissions, tenant isolation, destructive actions, and external integrations
+- Do not add tests merely because code changed; skip styling, copy, trivial wiring, implementation details, and refactors without behavior changes
+- Test at the lowest stable layer without duplicating coverage, and run the narrowest relevant test locally
 
 ## Documentation
 

--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -122,9 +122,7 @@ export function ReimbursementTable({
                   : "Auslagenerstattung"
               }
               detail={
-                item.type === "expense"
-                  ? item.description?.trim() || item.receiptSummary
-                  : undefined
+                item.type === "expense" ? item.receiptSummary : undefined
               }
               applicantName={item.submitterName || item.creatorName}
               onClick={() => onRowClick(item._id)}

--- a/app/(public)/_lib/publicApi.ts
+++ b/app/(public)/_lib/publicApi.ts
@@ -34,7 +34,6 @@ export type ReimbursementLink =
       type: "expense" | "travel";
       organizationName: string;
       projectName: string;
-      description?: string;
       invitedName?: string;
       invitedEmail?: string;
       changesRequested?: string;

--- a/app/api/public/reimbursement/[id]/route.ts
+++ b/app/api/public/reimbursement/[id]/route.ts
@@ -40,7 +40,6 @@ export async function GET(_request: Request, context: RouteContext) {
     type: doc.type,
     organizationName: organization?.name || "",
     projectName: project?.name || "",
-    description: doc.description,
     invitedName: doc.invitedName,
     invitedEmail: doc.invitedEmail,
     travelDetails: travel,

--- a/app/components/Reimbursements/shareModal/useShareModal.ts
+++ b/app/components/Reimbursements/shareModal/useShareModal.ts
@@ -20,7 +20,7 @@ export function useShareModal(open: boolean, onClose: () => void) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [allLinks, setAllLinks] = useState<PendingLink[]>([]);
-  const needsDates = type === "travel" || type === "allowance";
+  const needsDates = type === "allowance";
 
   useEffect(() => {
     if (!open) return;
@@ -84,8 +84,6 @@ export function useShareModal(open: boolean, onClose: () => void) {
           ? {
               destination: form.destination,
               purpose: form.purpose,
-              startDate: form.startDate,
-              endDate: form.endDate,
               allowFoodAllowance: form.allowFoodAllowance,
             }
           : undefined,

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -104,7 +104,6 @@ export interface Reimbursement {
   invitedEmail?: string;
   submittedExternally?: boolean;
   requestedExternally?: boolean;
-  description?: string;
   pendingUploadKeys?: string[];
 }
 

--- a/app/lib/server/reimbursements/sharingHelpers.ts
+++ b/app/lib/server/reimbursements/sharingHelpers.ts
@@ -14,7 +14,6 @@ export type PendingReimbursementLink = {
   _creationTime: number;
   type: "expense" | "travel";
   projectName: string;
-  description?: string;
   creatorName: string;
   linkType: "reimbursement";
 };
@@ -51,7 +50,6 @@ export async function insertReimbursementLink(
     createdBy: user._id,
     isSharedLink: true,
     requestedExternally: true,
-    description: args.description || "",
     invitedName: args.invitedName,
     invitedEmail: args.invitedEmail,
   });
@@ -64,8 +62,8 @@ export async function insertReimbursementLink(
     _id: newId(),
     _creationTime: Date.now(),
     reimbursementId,
-    startDate: args.travelDetails.startDate || "",
-    endDate: args.travelDetails.endDate || "",
+    startDate: "",
+    endDate: "",
     destination: args.travelDetails.destination || "",
     purpose: args.travelDetails.purpose || "",
     isInternational: false,
@@ -121,7 +119,6 @@ export async function loadPendingSharedLinks(organizationId: string): Promise<{
       _creationTime: reimbursement._creationTime,
       type: reimbursement.type,
       projectName: projectMap.get(reimbursement.projectId) || "Unknown",
-      description: reimbursement.description,
       creatorName: creatorMap.get(reimbursement.createdBy) || "Unknown",
       linkType: "reimbursement",
     })),

--- a/app/lib/server/reimbursements/validators.ts
+++ b/app/lib/server/reimbursements/validators.ts
@@ -57,15 +57,12 @@ export const createTravelReimbursementSchema = z
 export const createLinkSchema = z.object({
   projectId: z.string(),
   type: z.enum(["expense", "travel"]),
-  description: z.string().optional(),
   invitedName: z.string().trim().optional(),
   invitedEmail: z.string().email().optional(),
   travelDetails: z
     .object({
       destination: z.string().optional(),
       purpose: z.string().optional(),
-      startDate: z.string().optional(),
-      endDate: z.string().optional(),
       allowFoodAllowance: z.boolean().optional(),
     })
     .optional(),


### PR DESCRIPTION
## summary

- let travelers enter their individual travel dates while keeping allowance date ranges in the request dialog
- remove unused reimbursement description plumbing and clarify targeted testing guidance

## validation

- `pnpm exec biome lint <changed code files>`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/lib/server/reimbursements/reimbursements.test.ts app/lib/travelDates.test.ts` (15 tests)
- not run (Playwright E2E: no stable share-modal coverage for this small form change)
