### PR TITLE
fix(reimbursements): restore bulk download and delete actions

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementPageUI.tsx
+++ b/app/(protected)/reimbursements/ReimbursementPageUI.tsx
@@ -2,7 +2,6 @@
 
 import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Download,
@@ -101,15 +100,17 @@ export function ReimbursementPageUI({
 
       <div className="mb-4 flex flex-wrap items-start gap-2">
         {selected.size > 0 && (
-          <ButtonGroup
+          <fieldset
             aria-label={`Aktionen für ${selected.size} ausgewählte ${
               selected.size === 1 ? "Erstattung" : "Erstattungen"
             }`}
+            className="flex w-fit flex-wrap items-center gap-2"
           >
-            <ButtonGroupText className="h-10 border-2 bg-muted px-3">
+            <div className="flex h-10 items-center rounded-md border-2 bg-muted px-3 text-sm font-medium">
               {selected.size} ausgewählt
-            </ButtonGroupText>
+            </div>
             <Button
+              type="button"
               variant="outline"
               onClick={onBulkDownload}
               disabled={isBulkDownloading}
@@ -123,6 +124,7 @@ export function ReimbursementPageUI({
             </Button>
             {canDeleteSelected ? (
               <Button
+                type="button"
                 variant="outline"
                 className="text-destructive hover:text-destructive"
                 onClick={onDeleteSelected}
@@ -131,7 +133,7 @@ export function ReimbursementPageUI({
                 Löschen
               </Button>
             ) : null}
-          </ButtonGroup>
+          </fieldset>
         )}
 
         <div className="ml-auto flex flex-wrap justify-end gap-2">

--- a/app/lib/fileHandlers/downloadBlob.ts
+++ b/app/lib/fileHandlers/downloadBlob.ts
@@ -3,6 +3,10 @@ export function downloadBlob(blob: Blob, filename: string) {
   const link = document.createElement("a");
   link.href = url;
   link.download = filename;
+  link.hidden = true;
+  document.body.append(link);
   link.click();
-  URL.revokeObjectURL(url);
+  link.remove();
+
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -206,6 +206,33 @@ test.describe("critical reimbursement journeys", () => {
     await expect(
       page.getByRole("table").getByText("Genehmigt", { exact: true }),
     ).toBeVisible();
+
+    await page.setViewportSize({ width: 730, height: 628 });
+    const selectedRow = page.locator("table tbody tr").first();
+    await selectedRow
+      .getByRole("checkbox", { name: "Antrag auswählen" })
+      .check();
+
+    const bulkActions = page.getByRole("group", {
+      name: "Aktionen für 1 ausgewählte Erstattung",
+    });
+    await expect(bulkActions).toBeVisible();
+
+    const download = page.waitForEvent("download");
+    await bulkActions.getByRole("button", { name: "Herunterladen" }).click();
+    expect((await download).suggestedFilename()).toMatch(
+      /^Erstattungen_.*\.zip$/,
+    );
+
+    await selectedRow
+      .getByRole("checkbox", { name: "Antrag auswählen" })
+      .check();
+    await bulkActions.getByRole("button", { name: "Löschen" }).click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Löschen" })
+      .click();
+    await expect(page.locator("table tbody tr")).toHaveCount(0);
   });
 
   test("travel reimbursement can be submitted and declined", async ({


### PR DESCRIPTION
## summary

- restores independent, accessible bulk download and delete controls for selected reimbursements
- keeps generated download URLs alive until the browser has started the download
- covers download and confirmed deletion at the reported narrow viewport

## validation

- `pnpm exec biome lint "app/(protected)/reimbursements/ReimbursementPageUI.tsx" app/lib/fileHandlers/downloadBlob.ts e2e/reimbursements.spec.ts`
- `pnpm exec prettier --check "app/(protected)/reimbursements/ReimbursementPageUI.tsx" app/lib/fileHandlers/downloadBlob.ts e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test` (282 tests)
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "expense reimbursement can be revised and approved"`
- `pnpm build` not run (repo-wide; focused type, unit, and browser checks passed)