### PR TITLE
feat(teams): group teams by department

### DIFF
--- a/app/(protected)/settings/teams/TeamsSection.tsx
+++ b/app/(protected)/settings/teams/TeamsSection.tsx
@@ -16,6 +16,7 @@ import { useTeams } from "@/lib/client/teams/hooks/useTeams";
 import { Archive, Plus, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "react-hot-toast";
+import { sortTeamsByDepartment } from "./sortTeamsByDepartment";
 import { TeamRow } from "./TeamRow";
 
 export function TeamsSection() {
@@ -37,6 +38,11 @@ export function TeamsSection() {
     }
     return map;
   }, [departments, archivedDepartments]);
+
+  const sortedTeams = useMemo(
+    () => sortTeamsByDepartment(teams, departments),
+    [teams, departments],
+  );
 
   const handleUpdate = async (teamId: string) => {
     const name = editValues.name.trim();
@@ -106,7 +112,7 @@ export function TeamsSection() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {teams.map((team) => (
+              {sortedTeams.map((team) => (
                 <TeamRow
                   key={team._id}
                   team={team}

--- a/app/(protected)/settings/teams/sortTeamsByDepartment.test.ts
+++ b/app/(protected)/settings/teams/sortTeamsByDepartment.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import type { Department, Team } from "@/lib/db/types";
+import { sortTeamsByDepartment } from "./sortTeamsByDepartment";
+
+function department(_id: string): Department {
+  return {
+    _id,
+    _creationTime: 0,
+    name: _id,
+    organizationId: "organization",
+    isArchived: false,
+    createdBy: "user",
+  };
+}
+
+function team(_id: string, departmentId: string): Team {
+  return {
+    _id,
+    _creationTime: 0,
+    name: _id,
+    departmentId,
+    organizationId: "organization",
+    isArchived: false,
+    createdBy: "user",
+  };
+}
+
+describe("sortTeamsByDepartment", () => {
+  test("groups teams in department order while preserving their order within a department", () => {
+    const teams = [
+      team("Operations 1", "operations"),
+      team("Education 1", "education"),
+      team("Operations 2", "operations"),
+    ];
+
+    const sorted = sortTeamsByDepartment(teams, [
+      department("operations"),
+      department("education"),
+    ]);
+
+    expect(sorted.map(({ _id }) => _id)).toEqual([
+      "Operations 1",
+      "Operations 2",
+      "Education 1",
+    ]);
+    expect(teams.map(({ _id }) => _id)).toEqual([
+      "Operations 1",
+      "Education 1",
+      "Operations 2",
+    ]);
+  });
+
+  test("places teams without a listed department last", () => {
+    const sorted = sortTeamsByDepartment(
+      [team("Unknown", "missing"), team("Operations", "operations")],
+      [department("operations")],
+    );
+
+    expect(sorted.map(({ _id }) => _id)).toEqual(["Operations", "Unknown"]);
+  });
+});

--- a/app/(protected)/settings/teams/sortTeamsByDepartment.ts
+++ b/app/(protected)/settings/teams/sortTeamsByDepartment.ts
@@ -1,0 +1,19 @@
+import type { Department, Team } from "@/lib/db/types";
+
+export function sortTeamsByDepartment(
+  teams: Team[],
+  departments: Department[],
+) {
+  const departmentOrder = new Map(
+    departments.map((department, index) => [department._id, index]),
+  );
+
+  return [...teams].sort((first, second) => {
+    const firstDepartment =
+      departmentOrder.get(first.departmentId) ?? Number.MAX_SAFE_INTEGER;
+    const secondDepartment =
+      departmentOrder.get(second.departmentId) ?? Number.MAX_SAFE_INTEGER;
+
+    return firstDepartment - secondDepartment;
+  });
+}


### PR DESCRIPTION
## summary

- Group teams by the configured department order so newly created teams appear alongside their department peers.
- Preserve team creation order within each department and place teams with unavailable departments last.
- Add regression coverage for department grouping and input immutability.

## validation

- `pnpm exec prettier --check app/(protected)/settings/teams/TeamsSection.tsx app/(protected)/settings/teams/sortTeamsByDepartment.ts app/(protected)/settings/teams/sortTeamsByDepartment.test.ts`
- `pnpm exec biome lint app/(protected)/settings/teams/TeamsSection.tsx app/(protected)/settings/teams/sortTeamsByDepartment.ts app/(protected)/settings/teams/sortTeamsByDepartment.test.ts`
- `pnpm exec vitest run app/(protected)/settings/teams/sortTeamsByDepartment.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test` (284 tests)