### PR TITLE
fix(navigation): move organization above logs

### DIFF
--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -39,12 +39,6 @@ type ProtectedNavItem = NavItem & { permission: UserPermission };
 
 const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
   {
-    name: "Organisation",
-    url: "/settings/organization",
-    icon: Building2,
-    permission: USER_PERMISSIONS.organizationSettings,
-  },
-  {
     name: "Struktur",
     url: "/settings/teams",
     icon: Network,
@@ -61,6 +55,12 @@ const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
     url: "/settings/projects",
     icon: FolderKanban,
     permission: USER_PERMISSIONS.projects,
+  },
+  {
+    name: "Organisation",
+    url: "/settings/organization",
+    icon: Building2,
+    permission: USER_PERMISSIONS.organizationSettings,
   },
   {
     name: "Logs",


### PR DESCRIPTION
## summary

- place organization settings directly above audit logs in the administration sidebar
- preserve existing permissions, routes, and navigation behavior

## validation

- `pnpm exec biome lint app/components/Sidebar/AppSidebar.tsx`
- `pnpm exec prettier --check app/components/Sidebar/AppSidebar.tsx`
- tests not run (static navigation ordering only)