### PR TITLE
fix(reimbursements): improve responsive table controls

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementTable.module.css
+++ b/app/(protected)/reimbursements/ReimbursementTable.module.css
@@ -1,0 +1,127 @@
+.tableShell {
+  container-name: reimbursement-table;
+  container-type: inline-size;
+}
+
+.tableShell :global([data-slot="table-container"]) {
+  overscroll-behavior-inline: contain;
+  overflow-x: scroll;
+  scrollbar-color: var(--muted-foreground) var(--muted);
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+.tableShell :global([data-slot="table-container"]::-webkit-scrollbar) {
+  height: 0.75rem;
+}
+
+.tableShell :global([data-slot="table-container"]::-webkit-scrollbar-track) {
+  background: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+.tableShell :global([data-slot="table-container"]::-webkit-scrollbar-thumb) {
+  min-width: 3rem;
+  border: 3px solid var(--muted);
+  border-radius: 999px;
+  background: var(--muted-foreground);
+}
+
+.tableShell :global([data-reimbursement-column="applicant"]),
+.tableShell :global([data-reimbursement-column="project"]),
+.tableShell :global([data-reimbursement-column="created"]),
+.tableShell :global([data-reimbursement-column="reviewed-by"]) {
+  display: none;
+}
+
+.tableShell :global([data-reimbursement-column="request"]) {
+  min-width: 11rem;
+}
+
+.tableShell :global([data-reimbursement-column="status"]) {
+  min-width: 7.5rem;
+}
+
+.tableShell :global([data-reimbursement-mobile-metadata]) {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.125rem;
+  max-width: 18rem;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tableShell :global([data-reimbursement-metadata-item]) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scrollHint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.scrollHint svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+@container reimbursement-table (min-width: 34rem) {
+  .scrollHint {
+    display: none;
+  }
+}
+
+@container reimbursement-table (min-width: 39rem) {
+  .tableShell :global([data-reimbursement-column="applicant"]) {
+    display: table-cell;
+  }
+
+  .tableShell :global([data-mobile-metadata="applicant"]) {
+    display: none;
+  }
+}
+
+@container reimbursement-table (min-width: 48rem) {
+  .tableShell :global([data-reimbursement-column="created"]) {
+    display: table-cell;
+  }
+
+  .tableShell :global([data-mobile-metadata="created"]) {
+    display: none;
+  }
+}
+
+@container reimbursement-table (min-width: 60rem) {
+  .tableShell :global([data-reimbursement-column="project"]) {
+    display: table-cell;
+  }
+
+  .tableShell :global([data-mobile-metadata="project"]) {
+    display: none;
+  }
+
+  .tableShell :global([data-reimbursement-column="request"]) {
+    min-width: 14rem;
+  }
+
+  .tableShell :global([data-reimbursement-column="status"]) {
+    min-width: 10rem;
+  }
+}
+
+@container reimbursement-table (min-width: 74rem) {
+  .tableShell :global([data-reimbursement-column="reviewed-by"]) {
+    display: table-cell;
+  }
+}

--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MoveHorizontal } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
@@ -9,6 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { ReimbursementRow } from "../../components/Tables/Reimbursements/ReimbursementRow";
+import styles from "./ReimbursementTable.module.css";
 import type { Allowance, Reimbursement, SelectionKey } from "./types";
 
 type Props = {
@@ -70,8 +72,15 @@ export function ReimbursementTable({
   }
 
   return (
-    <div className="rounded-lg border bg-card">
-      <Table>
+    <div className={`${styles.tableShell} rounded-lg border bg-card`}>
+      <span id="reimbursement-table-scroll-description" className="sr-only">
+        Die Tabelle kann bei sehr schmalen Bildschirmen horizontal gescrollt
+        werden.
+      </span>
+      <Table
+        aria-label="Erstattungen"
+        aria-describedby="reimbursement-table-scroll-description"
+      >
         <TableHeader>
           <TableRow>
             <TableHead className="w-[40px] px-2">
@@ -89,13 +98,17 @@ export function ReimbursementTable({
             </TableHead>
             <TableHead>Antrag</TableHead>
             {canManageReimbursements ? (
-              <TableHead>Antragsteller</TableHead>
+              <TableHead data-reimbursement-column="applicant">
+                Antragsteller
+              </TableHead>
             ) : null}
-            <TableHead>Projekt</TableHead>
-            <TableHead>Erstellt</TableHead>
+            <TableHead data-reimbursement-column="project">Projekt</TableHead>
+            <TableHead data-reimbursement-column="created">Erstellt</TableHead>
             <TableHead className="text-right">Betrag</TableHead>
             <TableHead>Status</TableHead>
-            <TableHead>Bearbeitet von</TableHead>
+            <TableHead data-reimbursement-column="reviewed-by">
+              Bearbeitet von
+            </TableHead>
             <TableHead className="w-12 text-right" />
           </TableRow>
         </TableHeader>
@@ -121,9 +134,7 @@ export function ReimbursementTable({
                   ? "Reisekostenerstattung"
                   : "Auslagenerstattung"
               }
-              detail={
-                item.type === "expense" ? item.receiptSummary : undefined
-              }
+              detail={item.type === "expense" ? item.receiptSummary : undefined}
               applicantName={item.submitterName || item.creatorName}
               onClick={() => onRowClick(item._id)}
               onApprove={() => onApproveReimbursement(item._id)}
@@ -168,6 +179,10 @@ export function ReimbursementTable({
           ))}
         </TableBody>
       </Table>
+      <div className={styles.scrollHint} aria-hidden="true">
+        <MoveHorizontal />
+        Seitlich scrollen für weitere Spalten
+      </div>
     </div>
   );
 }

--- a/app/(protected)/reimbursements/ReimbursementToolbar.tsx
+++ b/app/(protected)/reimbursements/ReimbursementToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  ChevronDown,
   Download,
   FileCode2,
   Loader2,
@@ -8,6 +9,13 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 type Props = {
   canManageReimbursements: boolean;
@@ -34,69 +42,102 @@ export function ReimbursementToolbar({
   onFinomCsv,
   onSepaXml,
 }: Props) {
-  return (
-    <div className="mb-4 flex flex-wrap items-start gap-2">
-      {selectedCount > 0 ? (
-        <fieldset
-          aria-label={`Aktionen für ${selectedCount} ausgewählte ${
-            selectedCount === 1 ? "Erstattung" : "Erstattungen"
-          }`}
-          className="flex w-fit flex-wrap items-center gap-2"
+  if (selectedCount > 0) {
+    return (
+      <fieldset
+        aria-label={`Aktionen für ${selectedCount} ausgewählte ${
+          selectedCount === 1 ? "Erstattung" : "Erstattungen"
+        }`}
+        className="mb-4 flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto pb-1"
+      >
+        <div className="flex h-10 shrink-0 items-center rounded-md border-2 bg-muted px-3 text-sm font-medium">
+          {selectedCount} ausgewählt
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onBulkDownload}
+          disabled={isBulkDownloading}
+          aria-busy={isBulkDownloading}
         >
-          <div className="flex h-10 items-center rounded-md border-2 bg-muted px-3 text-sm font-medium">
-            {selectedCount} ausgewählt
-          </div>
+          {isBulkDownloading ? (
+            <Loader2 className="animate-spin" />
+          ) : (
+            <Download />
+          )}
+          {isBulkDownloading ? "Wird erstellt..." : "Herunterladen"}
+        </Button>
+        {canDeleteSelected ? (
           <Button
             type="button"
             variant="outline"
-            onClick={onBulkDownload}
-            disabled={isBulkDownloading}
+            className="text-destructive hover:text-destructive"
+            onClick={onDeleteSelected}
           >
-            {isBulkDownloading ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              <Download />
-            )}
-            {isBulkDownloading ? "Wird erstellt..." : "Herunterladen"}
+            <Trash2 />
+            Löschen
           </Button>
-          {canDeleteSelected ? (
-            <Button
-              type="button"
-              variant="outline"
-              className="text-destructive hover:text-destructive"
-              onClick={onDeleteSelected}
-            >
-              <Trash2 />
-              Löschen
+        ) : null}
+      </fieldset>
+    );
+  }
+
+  return (
+    <div className="mb-4 flex flex-nowrap items-center justify-end gap-2 overflow-x-auto pb-1">
+      {canManageReimbursements ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button type="button" variant="outline">
+              <Table2 />
+              Export
+              <ChevronDown />
             </Button>
-          ) : null}
-        </fieldset>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onFinomCsv}>
+              <Table2 />
+              Finom CSV exportieren
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onSepaXml}>
+              <FileCode2 />
+              SEPA XML exportieren
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       ) : null}
 
-      <div className="ml-auto flex flex-wrap justify-end gap-2">
-        {canManageReimbursements ? (
-          <>
-            <Button variant="outline" onClick={onFinomCsv}>
-              <Table2 />
-              Finom CSV
-            </Button>
-            <Button variant="outline" onClick={onSepaXml}>
-              <FileCode2 />
-              SEPA XML
-            </Button>
-          </>
-        ) : null}
-        <Button variant="primary" onClick={onNewClick}>
+      {canManageReimbursements ? (
+        <ButtonGroup>
+          <Button type="button" variant="primary" onClick={onNewClick}>
+            <Plus />
+            Neue Erstattung
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="primary"
+                size="icon"
+                aria-label="Weitere Erstattungsaktionen"
+                title="Weitere Erstattungsaktionen"
+              >
+                <ChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={onShareClick}>
+                <Share2 />
+                Erstattung anfordern
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </ButtonGroup>
+      ) : (
+        <Button type="button" variant="primary" onClick={onNewClick}>
           <Plus />
           Neue Erstattung
         </Button>
-        {canManageReimbursements ? (
-          <Button variant="outline" onClick={onShareClick}>
-            <Share2 />
-            Erstattung anfordern
-          </Button>
-        ) : null}
-      </div>
+      )}
     </div>
   );
 }

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Check,
   ExternalLink,
@@ -21,11 +19,10 @@ import {
 import { TableCell, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
 import { formatDate } from "@/lib/formatters/formatDate";
-import {
-  STATUS_DISPLAY,
-  type ReimbursementStatus as Status,
-} from "@/lib/reimbursementStatus";
+import { STATUS_DISPLAY } from "@/lib/reimbursementStatus";
+import type { ReimbursementStatus as Status } from "@/lib/reimbursementStatus";
 import styles from "./ReimbursementRow.module.css";
+import { ReimbursementRowMetadata } from "./ReimbursementRowMetadata";
 
 interface ReimbursementRowProps {
   item: {
@@ -68,10 +65,9 @@ export function ReimbursementRow({
   onDelete,
 }: ReimbursementRowProps) {
   const display = STATUS_DISPLAY[item.status];
-  const isPending = item.status === "pending";
-  const showReviewActions = canManageReimbursements && isPending;
+  const showReviewActions =
+    canManageReimbursements && item.status === "pending";
   const showEditAction = canEdit && item.status === "changes_requested";
-  const showDeleteAction = canManageReimbursements;
 
   return (
     <TableRow
@@ -83,7 +79,7 @@ export function ReimbursementRow({
           {selectionCheckbox}
         </TableCell>
       )}
-      <TableCell className="min-w-56 py-3">
+      <TableCell className="py-3" data-reimbursement-column="request">
         <div className="min-w-0">
           <div className="font-medium text-foreground">{title}</div>
           {detail ? (
@@ -91,24 +87,46 @@ export function ReimbursementRow({
               {detail}
             </div>
           ) : null}
+          <ReimbursementRowMetadata
+            canManageReimbursements={canManageReimbursements}
+            applicantName={applicantName}
+            projectName={item.projectName}
+            creationTime={item._creationTime}
+          />
         </div>
       </TableCell>
       {canManageReimbursements ? (
-        <TableCell className="max-w-48 truncate">{applicantName}</TableCell>
+        <TableCell
+          className="max-w-48 truncate"
+          data-reimbursement-column="applicant"
+        >
+          {applicantName}
+        </TableCell>
       ) : null}
-      <TableCell className="max-w-48 truncate">{item.projectName}</TableCell>
-      <TableCell className="text-muted-foreground">
+      <TableCell
+        className="max-w-48 truncate"
+        data-reimbursement-column="project"
+      >
+        {item.projectName}
+      </TableCell>
+      <TableCell
+        className="text-muted-foreground"
+        data-reimbursement-column="created"
+      >
         {formatDate(item._creationTime)}
       </TableCell>
       <TableCell className="text-right font-medium">
         {formatCurrency(item.amount)}
       </TableCell>
-      <TableCell className="min-w-40">
+      <TableCell data-reimbursement-column="status">
         <Badge variant={display.variant} className={display.className}>
           {display.label}
         </Badge>
       </TableCell>
-      <TableCell className="max-w-48 truncate text-muted-foreground">
+      <TableCell
+        className="max-w-48 truncate text-muted-foreground"
+        data-reimbursement-column="reviewed-by"
+      >
         {item.reviewedByName ?? "–"}
       </TableCell>
       <TableCell
@@ -163,7 +181,7 @@ export function ReimbursementRow({
               <ExternalLink className="text-current" />
               Öffnen
             </DropdownMenuItem>
-            {showDeleteAction ? (
+            {canManageReimbursements ? (
               <DropdownMenuItem
                 className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
                 onSelect={onDelete}

--- a/app/components/Tables/Reimbursements/ReimbursementRowMetadata.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRowMetadata.tsx
@@ -1,0 +1,31 @@
+import { formatDate } from "@/lib/formatters/formatDate";
+
+type Props = {
+  canManageReimbursements: boolean;
+  applicantName: string;
+  projectName: string;
+  creationTime: number;
+};
+
+export function ReimbursementRowMetadata({
+  canManageReimbursements,
+  applicantName,
+  projectName,
+  creationTime,
+}: Props) {
+  return (
+    <div data-reimbursement-mobile-metadata>
+      {canManageReimbursements ? (
+        <span data-mobile-metadata="applicant" data-reimbursement-metadata-item>
+          {applicantName}
+        </span>
+      ) : null}
+      <span data-mobile-metadata="project" data-reimbursement-metadata-item>
+        {projectName}
+      </span>
+      <span data-mobile-metadata="created" data-reimbursement-metadata-item>
+        {formatDate(creationTime)}
+      </span>
+    </div>
+  );
+}

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -156,7 +156,13 @@ test.describe("critical reimbursement journeys", () => {
       .click();
     await expectSubmission(page, "Erstattung eingereicht");
     await expect(
-      page.getByRole("cell", { name: "Test Projekt", exact: true }),
+      page
+        .locator("table tbody tr")
+        .first()
+        .locator(
+          '[data-mobile-metadata="project"]:visible, [data-reimbursement-column="project"]:visible',
+        )
+        .filter({ hasText: /^Test Projekt$/ }),
     ).toBeVisible();
     await expect(
       page.getByRole("cell", { name: "Auslagenerstattung" }),
@@ -217,6 +223,27 @@ test.describe("critical reimbursement journeys", () => {
       name: "Aktionen für 1 ausgewählte Erstattung",
     });
     await expect(bulkActions).toBeVisible();
+    expect(
+      await bulkActions
+        .locator(":scope > *")
+        .evaluateAll(
+          (elements) =>
+            new Set(
+              elements.map((element) =>
+                Math.round(element.getBoundingClientRect().top),
+              ),
+            ).size,
+        ),
+    ).toBe(1);
+    await expect
+      .poll(() =>
+        page
+          .locator('[data-slot="table-container"]')
+          .evaluate(
+            (element) => element.scrollWidth <= element.clientWidth + 1,
+          ),
+      )
+      .toBe(true);
 
     const download = page.waitForEvent("download");
     await bulkActions.getByRole("button", { name: "Herunterladen" }).click();


### PR DESCRIPTION
## summary

- keep reimbursement controls on one contextual row by consolidating export and creation actions into menus
- adapt table columns to their container, preserve hidden metadata in the request cell, and expose a visible horizontal scroll affordance on narrow screens
- cover the narrow-screen table and bulk-action layout in the reimbursement browser flow

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm test`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "expense reimbursement can be revised and approved"`