### PR TITLE
feat(recruiting): separate applications from job postings

### DIFF
--- a/app/(protected)/applications/page.tsx
+++ b/app/(protected)/applications/page.tsx
@@ -1,0 +1,27 @@
+import { ApplicationsPanel } from "@/components/Applications/ApplicationsPanel";
+import { PageHeader } from "@/components/Layout/PageHeader";
+import { AccessDenied } from "@/components/Settings/AccessDenied";
+import { auth } from "@/lib/auth";
+import { hasPermission, USER_PERMISSIONS } from "@/lib/auth/roles";
+
+export default async function ApplicationsPage() {
+  const session = await auth();
+  if (!hasPermission(session?.user?.role, USER_PERMISSIONS.recruiting)) {
+    return <AccessDenied title="Bewerbungen" />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Bewerbungen" />
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Alle Bewerbungen</h2>
+          <p className="text-sm text-muted-foreground">
+            Alle eingegangenen Bewerbungen ausschreibungsübergreifend.
+          </p>
+        </div>
+        <ApplicationsPanel />
+      </section>
+    </div>
+  );
+}

--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CreateJobPostingDialog } from "@/components/Dialogs/CreateJobPostingDialog";
-import { ApplicationsPanel } from "@/components/Applications/ApplicationsPanel";
 import { JobPostingStatusBadge } from "@/components/JobPostings/JobPostingStatusBadge";
 import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -35,18 +34,6 @@ export function RecruitingClient() {
       </div>
 
       <section className="space-y-4">
-        <div>
-          <h2 className="text-lg font-semibold">Bewerbungen</h2>
-          <p className="text-sm text-muted-foreground">
-            Alle eingegangenen Bewerbungen ausschreibungsübergreifend.
-          </p>
-        </div>
-        <ApplicationsPanel />
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Ausschreibungen</h2>
-
         {isLoading ? (
           <p className="text-muted-foreground py-8 text-center">Lädt…</p>
         ) : jobPostings.length === 0 ? (
@@ -72,7 +59,12 @@ export function RecruitingClient() {
                   return (
                     <TableRow key={posting._id}>
                       <TableCell className="font-medium">
-                        {posting.title}
+                        <Link
+                          href={`/recruiting/${posting._id}`}
+                          className="outline-none hover:underline focus-visible:underline"
+                        >
+                          {posting.title}
+                        </Link>
                       </TableCell>
                       <TableCell>{info?.teamName ?? "–"}</TableCell>
                       <TableCell>{info?.departmentName ?? "–"}</TableCell>

--- a/app/(protected)/recruiting/[id]/JobPostingApplications.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingApplications.tsx
@@ -4,8 +4,6 @@ import { ApplicationsPanel } from "@/components/Applications/ApplicationsPanel";
 import type { JobPosting } from "@/lib/db/types";
 
 export function JobPostingApplications({ posting }: { posting: JobPosting }) {
-  if (!posting.tallyFormId) return null;
-
   return (
     <section className="space-y-4 rounded-lg border-2 p-4">
       <div>

--- a/app/(protected)/settings/members/MembersClient.tsx
+++ b/app/(protected)/settings/members/MembersClient.tsx
@@ -41,7 +41,7 @@ export function MembersClient() {
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Teammitglieder" />
+      <PageHeader title="Team" />
 
       <MembersToolbar
         filters={filters}

--- a/app/(protected)/settings/members/page.tsx
+++ b/app/(protected)/settings/members/page.tsx
@@ -6,7 +6,7 @@ import { MembersClient } from "./MembersClient";
 export default async function MembersPage() {
   const session = await auth();
   if (!hasPermission(session?.user?.role, USER_PERMISSIONS.members)) {
-    return <AccessDenied title="Teammitglieder" />;
+    return <AccessDenied title="Team" />;
   }
 
   return <MembersClient />;

--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Megaphone,
   Network,
   ScrollText,
+  UserRoundSearch,
   UserCog,
 } from "lucide-react";
 import Image from "next/image";
@@ -75,7 +76,14 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const mainItems: NavItem[] = [
     ...NAV_ITEMS,
     ...(hasPermission(role, USER_PERMISSIONS.recruiting)
-      ? [{ name: "Ausschreibungen", url: "/recruiting", icon: Megaphone }]
+      ? [
+          { name: "Ausschreibungen", url: "/recruiting", icon: Megaphone },
+          {
+            name: "Bewerbungen",
+            url: "/applications",
+            icon: UserRoundSearch,
+          },
+        ]
       : []),
   ];
   const administrationItems = ADMINISTRATION_NAV_ITEMS.filter(

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -79,6 +79,9 @@ test.describe("Ausschreibungen", () => {
 
     await expect(page).toHaveURL(/\/recruiting\/[^/]+$/);
     await expect(page.getByText(DEPARTMENT)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Bewerbungen", exact: true }),
+    ).toBeVisible();
 
     const description = page.locator('[aria-label="Beschreibung"]');
     await description.click();
@@ -108,9 +111,23 @@ test.describe("Ausschreibungen", () => {
     ).toBeVisible();
 
     await page.goto("/recruiting");
+    await expect(
+      page.getByRole("heading", { name: "Bewerbungen" }),
+    ).toHaveCount(0);
+    await expect(page.getByLabel("Bewerbungen durchsuchen")).toHaveCount(0);
     const row = page.getByRole("row", { name: new RegExp(TITLE) });
     await expect(row).toContainText("Veröffentlicht");
     await expect(row).toContainText(TEAM);
     await expect(row).toContainText(DEPARTMENT);
+    await row.getByRole("link", { name: TITLE }).click();
+    await expect(
+      page.getByRole("heading", { name: "Bewerbungen", exact: true }),
+    ).toBeVisible();
+
+    await page.goto("/applications");
+    await expect(
+      page.getByRole("heading", { name: "Bewerbungen", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Bewerbungen durchsuchen")).toBeVisible();
   });
 });


### PR DESCRIPTION
## summary

- add a dedicated applications page and navigation entry while keeping the recruiting overview focused on job postings
- show posting-specific applications on every job posting detail page and align the team page heading with its sidebar label
- make posting titles directly navigable and cover the new routes in the recruiting end-to-end flow

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/components/Applications/applicationTable.test.ts`
- `pnpm lint:lines`
- `pnpm exec playwright test e2e/recruiting.spec.ts`