### PR TITLE
fix(recruiting): align contact selector with form controls

### DIFF
--- a/app/components/Selectors/MultiSelect.tsx
+++ b/app/components/Selectors/MultiSelect.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { Check, ChevronDown, Search } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Input, inputClassName } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 
 export interface MultiSelectOption {
   value: string;
@@ -90,13 +90,17 @@ export function MultiSelect<TOption extends MultiSelectOption>({
       }}
     >
       <PopoverTrigger asChild>
-        <Button
+        <button
           id={id}
           type="button"
-          variant="outline"
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="min-h-12 h-auto w-full justify-between px-3 py-2 font-normal"
+          data-placeholder={value.length === 0}
+          className={cn(
+            inputClassName,
+            "flex min-h-12 items-center justify-between gap-2 text-left data-[placeholder=true]:text-muted-foreground",
+            open && "border-foreground",
+          )}
         >
           <span className="flex min-w-0 items-center gap-2 truncate">
             {value.length > 0
@@ -104,8 +108,13 @@ export function MultiSelect<TOption extends MultiSelectOption>({
                 `${value.length} ausgewählt`)
               : placeholder}
           </span>
-          <ChevronsUpDown className="size-4 text-muted-foreground" />
-        </Button>
+          <ChevronDown
+            className={cn(
+              "size-4 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </button>
       </PopoverTrigger>
       <PopoverContent
         align="start"
@@ -150,7 +159,7 @@ export function MultiSelect<TOption extends MultiSelectOption>({
                   aria-selected={selected}
                   disabled={disabled}
                   onClick={() => toggleOption(option)}
-                  className="flex w-full items-center gap-3 px-2 py-2 text-left outline-none transition-colors hover:bg-accent focus-visible:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex w-full items-center gap-3 rounded-sm px-2 py-2 text-left outline-none transition-colors hover:bg-accent focus-visible:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <span className="min-w-0 flex-1">
                     {renderOption?.(option) ?? (

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -2,18 +2,18 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+const inputClassName =
+  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground w-full min-w-0 border-2 border-input bg-background px-4 py-3 text-base outline-none transition-colors hover:border-ring focus:border-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm";
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground w-full min-w-0 border-2 border-input bg-background px-4 py-3 text-base outline-none transition-colors hover:border-ring focus:border-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className,
-      )}
+      className={cn(inputClassName, className)}
       {...props}
     />
   );
 }
 
-export { Input };
+export { Input, inputClassName };


### PR DESCRIPTION
## summary

- align the recruiting contact multiselect trigger with the shared input field styling
- match select interactions with a rotating chevron, open-state border, and rounded options

## validation

- `pnpm exec biome lint app/components/ui/input.tsx app/components/Selectors/MultiSelect.tsx`
- `pnpm exec prettier --check app/components/ui/input.tsx app/components/Selectors/MultiSelect.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`