### PR TITLE
feat(recruiting): filter teams by selected department

### DIFF
--- a/app/components/Dialogs/CreateJobPostingDialog.tsx
+++ b/app/components/Dialogs/CreateJobPostingDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SelectDepartment } from "@/components/Selectors/SelectDepartment";
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useDepartments } from "@/lib/client/departments/hooks/useDepartments";
 import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPostingMutations";
 import { useTeams } from "@/lib/client/teams/hooks/useTeams";
 import { Loader2 } from "lucide-react";
@@ -25,13 +27,25 @@ interface Props {
 
 export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
   const router = useRouter();
+  const { departments } = useDepartments();
   const { teams } = useTeams();
   const { create } = useJobPostingMutations();
   const [title, setTitle] = useState("");
+  const [departmentId, setDepartmentId] = useState("");
   const [teamId, setTeamId] = useState("");
+  const departmentTeams = teams.filter(
+    (team) => team.departmentId === departmentId,
+  );
+  const hasDepartmentTeams = departmentTeams.length > 0;
 
   const reset = () => {
     setTitle("");
+    setDepartmentId("");
+    setTeamId("");
+  };
+
+  const handleDepartmentChange = (value: string) => {
+    setDepartmentId(value);
     setTeamId("");
   };
 
@@ -62,12 +76,42 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
           <DialogTitle>Neue Ausschreibung</DialogTitle>
         </DialogHeader>
 
-        {teams.length === 0 ? (
+        {departments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Bitte lege zuerst ein aktives Department an.
+          </p>
+        ) : teams.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Bitte lege zuerst ein aktives Team an.
           </p>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="posting-department">Department*</Label>
+              <SelectDepartment
+                id="posting-department"
+                departments={departments}
+                value={departmentId || undefined}
+                onValueChange={handleDepartmentChange}
+                autoFocus
+              />
+            </div>
+            {departmentId && hasDepartmentTeams ? (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="posting-team">Team*</Label>
+                <SelectTeam
+                  id="posting-team"
+                  teams={departmentTeams}
+                  value={teamId || undefined}
+                  onValueChange={setTeamId}
+                />
+              </div>
+            ) : null}
+            {departmentId && !hasDepartmentTeams ? (
+              <p className="text-sm text-muted-foreground">
+                In diesem Department gibt es kein aktives Team.
+              </p>
+            ) : null}
             <div className="flex flex-col gap-2">
               <Label htmlFor="posting-title">Titel*</Label>
               <Input
@@ -75,16 +119,6 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
                 placeholder="Wonach suchst du?"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                autoFocus
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="posting-team">Team*</Label>
-              <SelectTeam
-                id="posting-team"
-                teams={teams}
-                value={teamId || undefined}
-                onValueChange={setTeamId}
               />
             </div>
             <DialogFooter>

--- a/app/components/Selectors/SelectDepartment.tsx
+++ b/app/components/Selectors/SelectDepartment.tsx
@@ -14,6 +14,7 @@ interface Props {
   value: string | undefined;
   onValueChange: (value: string) => void;
   id?: string;
+  autoFocus?: boolean;
 }
 
 export function SelectDepartment({
@@ -21,12 +22,13 @@ export function SelectDepartment({
   value,
   onValueChange,
   id,
+  autoFocus,
 }: Props) {
   const active = departments.filter((department) => !department.isArchived);
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger id={id} className="w-full">
+      <SelectTrigger id={id} className="w-full" autoFocus={autoFocus}>
         <SelectValue placeholder="Department wählen" />
       </SelectTrigger>
       <SelectContent>

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -9,6 +9,8 @@ const BASE_URL =
 
 const DEPARTMENT = "Vorstand";
 const TEAM = "Öffentlichkeitsarbeit";
+const OTHER_DEPARTMENT = "Finanzen";
+const OTHER_TEAM = "Buchhaltung";
 const TITLE = "Social Media Manager:in";
 const DESCRIPTION = "Wir suchen Unterstützung für unsere Kanäle.";
 
@@ -60,6 +62,23 @@ test.describe("Ausschreibungen", () => {
       .getByRole("button", { name: "Team erstellen" })
       .click();
     await expect(page.getByText("Team erstellt")).toBeVisible();
+
+    await page.getByRole("button", { name: "Department erstellen" }).click();
+    await page.getByLabel("Department-Name*").fill(OTHER_DEPARTMENT);
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Department erstellen" })
+      .click();
+    await expect(page.getByText("Department erstellt")).toBeVisible();
+
+    await page.getByRole("button", { name: "Team erstellen" }).click();
+    await page.getByLabel("Team-Name*").fill(OTHER_TEAM);
+    await selectOption(page, "team-department", OTHER_DEPARTMENT);
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Team erstellen" })
+      .click();
+    await expect(page.getByText("Team erstellt")).toBeVisible();
   });
 
   test.afterEach(async () => {
@@ -73,8 +92,14 @@ test.describe("Ausschreibungen", () => {
     });
     await expect(createButton).toHaveCount(1);
     await createButton.click();
+    await expect(page.locator("#posting-team")).toHaveCount(0);
+    await selectOption(page, "posting-department", DEPARTMENT);
+    await expect(page.locator("#posting-team")).toBeVisible();
     await page.getByLabel("Titel*").fill(TITLE);
-    await selectOption(page, "posting-team", TEAM);
+    await page.locator("#posting-team").click();
+    await expect(page.getByRole("option", { name: TEAM })).toBeVisible();
+    await expect(page.getByRole("option", { name: OTHER_TEAM })).toHaveCount(0);
+    await page.getByRole("option", { name: TEAM }).click();
     await page.getByRole("button", { name: "Entwurf erstellen" }).click();
 
     await expect(page).toHaveURL(/\/recruiting\/[^/]+$/);


### PR DESCRIPTION
## summary

- Ask for the department first when creating a job posting and only show teams from that department.
- Reset stale team selections on department changes and cover the dependent selection flow in Playwright.

## validation

- `pnpm exec prettier --check app/components/Dialogs/CreateJobPostingDialog.tsx app/components/Selectors/SelectDepartment.tsx e2e/recruiting.spec.ts`
- `pnpm exec biome lint app/components/Dialogs/CreateJobPostingDialog.tsx app/components/Selectors/SelectDepartment.tsx e2e/recruiting.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm exec playwright test e2e/recruiting.spec.ts`