### PR TITLE
feat(recruiting): streamline draft publishing actions

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingForm.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingForm.tsx
@@ -8,7 +8,7 @@ import {
   type JobPostingFormValues,
   toJobPostingForm,
 } from "@/lib/jobPostings/form";
-import { Loader2, Save } from "lucide-react";
+import { Loader2, Save, Send } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { JobPostingApplications } from "./JobPostingApplications";
@@ -18,26 +18,58 @@ import { JobPostingStatusActions } from "./JobPostingStatusActions";
 import { JobPostingTallySection } from "./JobPostingTallySection";
 
 export function JobPostingForm({ posting }: { posting: JobPosting }) {
-  const { update } = useJobPostingMutations();
+  const { update, generateForm } = useJobPostingMutations();
   const [values, setValues] = useState<JobPostingFormValues>(() =>
     toJobPostingForm(posting),
+  );
+  const [activeAction, setActiveAction] = useState<"save" | "publish" | null>(
+    null,
   );
 
   const patch = (part: Partial<JobPostingFormValues>) =>
     setValues((current) => ({ ...current, ...part }));
 
-  const handleSave = async () => {
+  const hasRequiredFields = () => {
     if (!values.title.trim() || !values.teamId) {
       toast.error("Titel und Team sind erforderlich");
-      return;
+      return false;
     }
+
+    return true;
+  };
+
+  const handleSave = async () => {
+    if (!hasRequiredFields()) return;
+
+    setActiveAction("save");
     try {
       await update.mutateAsync({ jobPostingId: posting._id, ...values });
       toast.success("Ausschreibung gespeichert");
     } catch {
       toast.error("Fehler beim Speichern");
+    } finally {
+      setActiveAction(null);
     }
   };
+
+  const handlePublish = async () => {
+    if (!hasRequiredFields()) return;
+
+    setActiveAction("publish");
+    try {
+      await update.mutateAsync({ jobPostingId: posting._id, ...values });
+      await generateForm.mutateAsync({ jobPostingId: posting._id });
+      toast.success("Ausschreibung veröffentlicht");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Fehler beim Veröffentlichen",
+      );
+    } finally {
+      setActiveAction(null);
+    }
+  };
+
+  const isBusy = activeAction !== null;
 
   return (
     <div className="space-y-6">
@@ -48,15 +80,41 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
       />
 
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <JobPostingStatusActions posting={posting} />
-        <Button onClick={handleSave} disabled={update.isPending}>
-          {update.isPending ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <Save className="size-4" />
-          )}
-          Speichern
-        </Button>
+        {posting.status === "draft" ? null : (
+          <JobPostingStatusActions posting={posting} />
+        )}
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+          <Button
+            variant={posting.status === "draft" ? "outline" : "primary"}
+            onClick={handleSave}
+            disabled={isBusy}
+            aria-busy={activeAction === "save"}
+          >
+            {activeAction === "save" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Save className="size-4" />
+            )}
+            {posting.status === "draft" ? "Entwurf speichern" : "Speichern"}
+          </Button>
+          {posting.status === "draft" ? (
+            <Button
+              variant="primary"
+              onClick={handlePublish}
+              disabled={isBusy}
+              aria-busy={activeAction === "publish"}
+            >
+              {activeAction === "publish" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Send className="size-4" />
+              )}
+              {posting.tallyFormError
+                ? "Speichern & erneut veröffentlichen"
+                : "Speichern & veröffentlichen"}
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       <JobPostingTallySection posting={posting} />

--- a/app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx
@@ -13,10 +13,8 @@ type StatusMutation = {
 };
 
 export function JobPostingStatusActions({ posting }: { posting: JobPosting }) {
-  const { generateForm, close, reopen, archive, retrySync } =
-    useJobPostingMutations();
+  const { close, reopen, archive, retrySync } = useJobPostingMutations();
   const pending =
-    generateForm.isPending ||
     close.isPending ||
     reopen.isPending ||
     archive.isPending ||
@@ -52,17 +50,6 @@ export function JobPostingStatusActions({ posting }: { posting: JobPosting }) {
           className="h-full border-y-0 border-r-0 px-2.5"
         />
       </div>
-      {posting.status === "draft" ? (
-        <Button
-          size="sm"
-          disabled={pending}
-          onClick={() => run(generateForm, "Ausschreibung veröffentlicht")}
-        >
-          {posting.tallyFormError
-            ? "Veröffentlichung erneut versuchen"
-            : "Veröffentlichen"}
-        </Button>
-      ) : null}
       {posting.status === "published" ? (
         <Button
           variant="outline"

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -86,7 +86,7 @@ test.describe("Ausschreibungen", () => {
     const description = page.locator('[aria-label="Beschreibung"]');
     await description.click();
     await page.keyboard.type(DESCRIPTION);
-    await page.getByRole("button", { name: "Speichern" }).click();
+    await page.getByRole("button", { name: "Entwurf speichern" }).click();
     await expect(page.getByText("Ausschreibung gespeichert")).toBeVisible();
 
     await page.reload();
@@ -94,11 +94,20 @@ test.describe("Ausschreibungen", () => {
       DESCRIPTION,
     );
 
-    await page.getByRole("button", { name: "Veröffentlichen" }).click();
+    await description.click();
+    await page.keyboard.type(" Aktualisiert.");
+    await page
+      .getByRole("button", { name: "Speichern & veröffentlichen" })
+      .click();
     await expect(page.getByText("Ausschreibung veröffentlicht")).toBeVisible();
     await expect(
       page.getByText("Veröffentlicht", { exact: true }),
     ).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator('[aria-label="Beschreibung"]')).toContainText(
+      `${DESCRIPTION} Aktualisiert.`,
+    );
 
     await page.getByRole("button", { name: "Schließen" }).click();
     await expect(page.getByText("Ausschreibung geschlossen")).toBeVisible();


### PR DESCRIPTION
## summary

- remove the redundant draft status control and group draft save and publish actions
- save current editor changes before publishing and verify persistence in the recruiting browser flow

## validation

- `pnpm exec prettier --check 'app/(protected)/recruiting/[id]/JobPostingForm.tsx' 'app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx' e2e/recruiting.spec.ts`
- `pnpm exec biome lint 'app/(protected)/recruiting/[id]/JobPostingForm.tsx' 'app/(protected)/recruiting/[id]/JobPostingStatusActions.tsx' e2e/recruiting.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec playwright test e2e/recruiting.spec.ts`
- `pnpm exec biome check ...` *(formatter check conflicts with the repository's Prettier style; the targeted Biome lint passes)*
- `pnpm lint` *(fails on pre-existing CSS Modules parser diagnostics in the unchanged reimbursement table stylesheet)*
- `git diff --check`
