### PR TITLE
fix(recruiting): simplify publish action label

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingForm.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingForm.tsx
@@ -110,7 +110,7 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
               )}
               {posting.tallyFormError
                 ? "Speichern & erneut veröffentlichen"
-                : "Speichern & veröffentlichen"}
+                : "Veröffentlichen"}
             </Button>
           ) : null}
         </div>

--- a/e2e/recruiting.spec.ts
+++ b/e2e/recruiting.spec.ts
@@ -124,9 +124,7 @@ test.describe("Ausschreibungen", () => {
 
     await description.click();
     await page.keyboard.type(" Aktualisiert.");
-    await page
-      .getByRole("button", { name: "Speichern & veröffentlichen" })
-      .click();
+    await page.getByRole("button", { name: "Veröffentlichen" }).click();
     await expect(page.getByText("Ausschreibung veröffentlicht")).toBeVisible();
     await expect(
       page.getByText("Veröffentlicht", { exact: true }),


### PR DESCRIPTION
## summary

- shorten the draft publish action label to “Veröffentlichen”
- update the recruiting end-to-end flow to use the new accessible button name

## validation

- `pnpm exec prettier --check "app/(protected)/recruiting/[id]/JobPostingForm.tsx" e2e/recruiting.spec.ts`
- `pnpm exec biome lint "app/(protected)/recruiting/[id]/JobPostingForm.tsx" e2e/recruiting.spec.ts`
- `pnpm exec playwright test e2e/recruiting.spec.ts`
- `git diff --check`