### PR TITLE
fix(reimbursements): clarify toolbar actions

### DIFF
--- a/app/(protected)/reimbursements/ReimbursementToolbar.tsx
+++ b/app/(protected)/reimbursements/ReimbursementToolbar.tsx
@@ -9,7 +9,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -88,8 +87,8 @@ export function ReimbursementToolbar({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button type="button" variant="outline">
-              <Table2 />
-              Export
+              <Download />
+              Exportieren
               <ChevronDown />
             </Button>
           </DropdownMenuTrigger>
@@ -107,31 +106,16 @@ export function ReimbursementToolbar({
       ) : null}
 
       {canManageReimbursements ? (
-        <ButtonGroup>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button type="button" variant="outline" onClick={onShareClick}>
+            <Share2 />
+            Erstattung anfordern
+          </Button>
           <Button type="button" variant="primary" onClick={onNewClick}>
             <Plus />
             Neue Erstattung
           </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="primary"
-                size="icon"
-                aria-label="Weitere Erstattungsaktionen"
-                title="Weitere Erstattungsaktionen"
-              >
-                <ChevronDown />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={onShareClick}>
-                <Share2 />
-                Erstattung anfordern
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </ButtonGroup>
+        </div>
       ) : (
         <Button type="button" variant="primary" onClick={onNewClick}>
           <Plus />


### PR DESCRIPTION
## summary

- exposes the reimbursement request as a clear secondary action beside the primary create action
- clarifies the payment export trigger with a download icon and action-oriented label

## validation

- pnpm exec prettier --check app/(protected)/reimbursements/ReimbursementToolbar.tsx
- pnpm exec biome lint app/(protected)/reimbursements/ReimbursementToolbar.tsx
- pnpm exec tsc --noEmit
- pnpm test (327 tests)
- pnpm exec playwright test e2e/reimbursements.spec.ts --grep expense reimbursement can be revised and approved (1 test)
- git diff --check
- pnpm build: not run (repo-wide; targeted typecheck and e2e cover this toolbar-only change)