### PR TITLE
feat(reimbursements): add onboarding-free invite link

### DIFF
--- a/app/(public)/invite/[token]/page.tsx
+++ b/app/(public)/invite/[token]/page.tsx
@@ -1,0 +1,87 @@
+import { CircleAlert } from "lucide-react";
+import Image from "next/image";
+import { redirect } from "next/navigation";
+import { LoginForm } from "@/components/Auth/LoginForm";
+import { TestAuthForm } from "@/components/Auth/TestAuthForm";
+import { auth } from "@/lib/auth";
+import { isTestMode } from "@/lib/auth/environment";
+import { isValidReimbursementInvite } from "@/lib/server/reimbursementInvites/data";
+import { redeemReimbursementInvite } from "@/lib/server/reimbursementInvites/redemption";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+function InviteShell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-muted/30 p-6">
+      <div className="w-full max-w-lg space-y-6">
+        <div className="flex items-center justify-center gap-3">
+          <Image src="/AppIcon.png" alt="" width={40} height={40} priority />
+          <span className="text-xl font-bold">YBase</span>
+        </div>
+        {children}
+      </div>
+    </main>
+  );
+}
+
+function InviteError({ message }: { message: string }) {
+  return (
+    <InviteShell>
+      <Card>
+        <CardHeader className="text-center">
+          <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <CircleAlert aria-hidden="true" className="size-6" />
+          </div>
+          <CardTitle>Einladung nicht verfügbar</CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardHeader>
+      </Card>
+    </InviteShell>
+  );
+}
+
+export default async function ReimbursementInvitePage({ params }: Props) {
+  const [{ token }, session] = await Promise.all([params, auth()]);
+
+  if (session?.user) {
+    try {
+      await redeemReimbursementInvite(token);
+    } catch (error) {
+      return (
+        <InviteError
+          message={
+            error instanceof Error
+              ? error.message
+              : "Die Einladung konnte nicht eingelöst werden."
+          }
+        />
+      );
+    }
+    redirect("/reimbursements/new");
+  }
+
+  if (!(await isValidReimbursementInvite(token))) {
+    return <InviteError message="Dieser Einladungslink ist ungültig." />;
+  }
+
+  const callbackUrl = `/invite/${token}`;
+  const loginForm = isTestMode() ? (
+    <TestAuthForm callbackUrl={callbackUrl} />
+  ) : (
+    <LoginForm callbackUrl={callbackUrl} />
+  );
+
+  return (
+    <div className="flex min-h-svh -mt-24 items-center justify-center p-8">
+      <div className="w-full max-w-sm">{loginForm}</div>
+    </div>
+  );
+}

--- a/app/components/Auth/LoginForm.tsx
+++ b/app/components/Auth/LoginForm.tsx
@@ -7,12 +7,16 @@ import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
-export function LoginForm() {
+export function LoginForm({
+  callbackUrl = "/dashboard",
+}: {
+  callbackUrl?: string;
+}) {
   const [isSigningIn, setIsSigningIn] = useState(false);
 
   function handleSignIn() {
     setIsSigningIn(true);
-    void signIn("google", { callbackUrl: "/dashboard" });
+    void signIn("google", { callbackUrl });
   }
 
   return (

--- a/app/components/Auth/TestAuthForm.tsx
+++ b/app/components/Auth/TestAuthForm.tsx
@@ -7,7 +7,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-export function TestAuthForm() {
+export function TestAuthForm({
+  callbackUrl = "/dashboard",
+}: {
+  callbackUrl?: string;
+}) {
   const router = useRouter();
   const [email, setEmail] = useState("user@test.com");
   const [name, setName] = useState("Test User");
@@ -24,7 +28,7 @@ export function TestAuthForm() {
       setStatus(`Error: ${result.error}`);
       return;
     }
-    router.push("/dashboard");
+    router.push(callbackUrl);
   }
 
   return (

--- a/app/lib/db/collections.ts
+++ b/app/lib/db/collections.ts
@@ -9,6 +9,7 @@ import type {
   Project,
   Receipt,
   Reimbursement,
+  ReimbursementInvite,
   SignatureToken,
   TallyWebhookEvent,
   Team,
@@ -56,6 +57,12 @@ export async function tallyWebhookEvents() {
 
 export async function reimbursements() {
   return (await getDb()).collection<Reimbursement>("reimbursements");
+}
+
+export async function reimbursementInvites() {
+  return (await getDb()).collection<ReimbursementInvite>(
+    "reimbursementInvites",
+  );
 }
 
 export async function travelDetails() {

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -81,6 +81,10 @@ export async function ensureIndexes(): Promise<void> {
     ]);
 
   await db
+    .collection("reimbursementInvites")
+    .createIndex({ tokenHash: 1 }, { unique: true });
+
+  await db
     .collection("travelDetails")
     .createIndexes([{ key: { reimbursementId: 1 } }]);
 

--- a/app/lib/db/reimbursementInvite.ts
+++ b/app/lib/db/reimbursementInvite.ts
@@ -1,0 +1,6 @@
+export interface ReimbursementInvite {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  tokenHash: string;
+}

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -21,4 +21,5 @@ export type {
   User,
   UserRole,
 } from "./user";
+export type { ReimbursementInvite } from "./reimbursementInvite";
 export type { VolunteerAllowance } from "./volunteerAllowance";

--- a/app/lib/server/reimbursementInvites/data.ts
+++ b/app/lib/server/reimbursementInvites/data.ts
@@ -1,0 +1,19 @@
+import { reimbursementInvites } from "../../db/collections";
+import {
+  hashReimbursementInviteToken,
+  isReimbursementInviteToken,
+} from "./token";
+
+export async function isValidReimbursementInvite(
+  token: string,
+): Promise<boolean> {
+  if (!isReimbursementInviteToken(token)) return false;
+
+  const invite = await (
+    await reimbursementInvites()
+  ).findOne(
+    { tokenHash: hashReimbursementInviteToken(token) },
+    { projection: { _id: 1 } },
+  );
+  return Boolean(invite);
+}

--- a/app/lib/server/reimbursementInvites/redemption.ts
+++ b/app/lib/server/reimbursementInvites/redemption.ts
@@ -1,0 +1,76 @@
+import { requireAuthenticatedUser } from "../../auth/session";
+import {
+  organizations,
+  reimbursementInvites,
+  users,
+} from "../../db/collections";
+import { addLog } from "../logs";
+import {
+  hashReimbursementInviteToken,
+  isReimbursementInviteToken,
+} from "./token";
+
+export async function redeemReimbursementInvite(token: string): Promise<void> {
+  const user = await requireAuthenticatedUser();
+  if (!isReimbursementInviteToken(token)) throw new Error("Ungültiger Link");
+
+  const invite = await (
+    await reimbursementInvites()
+  ).findOne({
+    tokenHash: hashReimbursementInviteToken(token),
+  });
+  if (!invite) throw new Error("Dieser Einladungslink ist ungültig");
+  if (user.organizationId && user.organizationId !== invite.organizationId) {
+    throw new Error("Dein Konto gehört bereits zu einer anderen Organisation");
+  }
+  if (user.memberStatus === "offboarded") {
+    throw new Error("Dein Konto wurde deaktiviert");
+  }
+
+  const organization = await (
+    await organizations()
+  ).findOne({ _id: invite.organizationId });
+  if (!organization) throw new Error("Organisation nicht gefunden");
+  const email = user.email?.trim().toLowerCase();
+  if (!email?.endsWith(`@${organization.domain.toLowerCase()}`)) {
+    throw new Error(
+      `Bitte melde dich mit einem @${organization.domain}-Konto an`,
+    );
+  }
+  if (user.memberStatus === "active") return;
+
+  const now = Date.now();
+  const granted = await (
+    await users()
+  ).updateOne(
+    {
+      _id: user._id,
+      memberStatus: { $ne: "offboarded" },
+      $or: [
+        { organizationId: invite.organizationId },
+        { organizationId: { $exists: false } },
+      ],
+    },
+    {
+      $set: {
+        organizationId: invite.organizationId,
+        role: "member",
+        memberStatus: "active",
+        teamOnboardingStatus: "completed",
+        onboardedAt: now,
+        teamOnboardedAt: now,
+      },
+    },
+  );
+  if (granted.matchedCount !== 1) {
+    throw new Error("Dieser Zugang kann für dein Konto nicht aktiviert werden");
+  }
+
+  await addLog(
+    invite.organizationId,
+    user._id,
+    "reimbursementInvite.redeem",
+    invite._id,
+    email,
+  );
+}

--- a/app/lib/server/reimbursementInvites/reimbursementInvites.test.ts
+++ b/app/lib/server/reimbursementInvites/reimbursementInvites.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../auth/session", () => ({
+  requireAuthenticatedUser: vi.fn(),
+}));
+
+import { requireAuthenticatedUser } from "../../auth/session";
+import { reimbursementInvites, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import { createTestActor, insertTestOrganization } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { isValidReimbursementInvite } from "./data";
+import { redeemReimbursementInvite } from "./redemption";
+import { createReimbursementInviteToken } from "./token";
+
+setupTestDatabase();
+
+let organizationId: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  organizationId = newId();
+  await insertTestOrganization({
+    _id: organizationId,
+    name: "Young Founders",
+    domain: "youngfounders.network",
+  });
+});
+
+async function insertInvite(): Promise<string> {
+  const { token, tokenHash } = createReimbursementInviteToken();
+  await (
+    await reimbursementInvites()
+  ).insertOne({
+    _id: newId(),
+    _creationTime: Date.now(),
+    organizationId,
+    tokenHash,
+  });
+  return token;
+}
+
+function onboardingMember(email: string) {
+  return createTestActor({
+    _id: newId(),
+    email,
+    organizationId,
+    role: "member",
+    memberStatus: "onboarding",
+    teamOnboardingStatus: "not_started",
+  });
+}
+
+test("redeems a prepared link as a normal active member", async () => {
+  const token = await insertInvite();
+  const member = onboardingMember("member@youngfounders.network");
+  await (await users()).insertOne(member);
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+
+  await redeemReimbursementInvite(token);
+
+  const updated = await (await users()).findOne({ _id: member._id });
+  expect(updated).toMatchObject({
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+    role: "member",
+  });
+  expect(updated?.onboardedAt).toBeTypeOf("number");
+});
+
+test("the same link activates multiple members", async () => {
+  const token = await insertInvite();
+  const first = onboardingMember("first@youngfounders.network");
+  const second = onboardingMember("second@youngfounders.network");
+  await (await users()).insertMany([first, second]);
+
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(first);
+  await redeemReimbursementInvite(token);
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(second);
+  await redeemReimbursementInvite(token);
+
+  expect(await (await users()).countDocuments({ memberStatus: "active" })).toBe(
+    2,
+  );
+});
+
+test("already active members can follow the link", async () => {
+  const token = await insertInvite();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(
+    createTestActor({
+      email: "active@youngfounders.network",
+      organizationId,
+      role: "member",
+      memberStatus: "active",
+    }),
+  );
+
+  await expect(redeemReimbursementInvite(token)).resolves.toBeUndefined();
+});
+
+test("rejects accounts outside the organization domain", async () => {
+  const token = await insertInvite();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(
+    onboardingMember("member@example.org"),
+  );
+
+  await expect(redeemReimbursementInvite(token)).rejects.toThrow(
+    "@youngfounders.network-Konto",
+  );
+});
+
+test("rejects unknown tokens", async () => {
+  const { token } = createReimbursementInviteToken();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(
+    onboardingMember("member@youngfounders.network"),
+  );
+
+  await expect(isValidReimbursementInvite(token)).resolves.toBe(false);
+  await expect(redeemReimbursementInvite(token)).rejects.toThrow("ungültig");
+});

--- a/app/lib/server/reimbursementInvites/token.ts
+++ b/app/lib/server/reimbursementInvites/token.ts
@@ -1,0 +1,20 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const TOKEN_BYTES = 32;
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+export function hashReimbursementInviteToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function isReimbursementInviteToken(token: string): boolean {
+  return TOKEN_PATTERN.test(token);
+}
+
+export function createReimbursementInviteToken(): {
+  token: string;
+  tokenHash: string;
+} {
+  const token = randomBytes(TOKEN_BYTES).toString("base64url");
+  return { token, tokenHash: hashReimbursementInviteToken(token) };
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -14,6 +14,7 @@ erDiagram
     organizations ||--o{ applications : has
     jobPostings ||--o{ applications : receives
     organizations ||--o| jobFeedTokens : authenticates
+    organizations ||--o{ reimbursementInvites : grants
     reimbursements ||--o{ receipts : has
     reimbursements ||--o| travelDetails : has
 
@@ -31,6 +32,12 @@ erDiagram
         string tokenHash
         number rotatedAt
         string rotatedBy
+    }
+
+    reimbursementInvites {
+        string _id
+        string organizationId
+        string tokenHash
     }
 
     users {


### PR DESCRIPTION
## Summary
- add reusable, hashed reimbursement invite links that activate authenticated organization members without onboarding and redirect them to a new reimbursement
- always grant the standard `member` role, expose only reimbursements in member navigation, and redirect member dashboard requests
- reuse the existing login UI and reject invalid, cross-organization, offboarded, or wrong-domain accounts
- document the collection and cover normal activation, multi-user reuse, active users, domain checks, and invalid tokens

## Validation
- `pnpm test` (332 tests)
- `pnpm exec vitest run app/lib/server/reimbursementInvites/reimbursementInvites.test.ts app/lib/auth/roles.test.ts` (65 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec biome lint <changed source files>`
- `pnpm build`