### PR TITLE
fix(navigation): limit members to reimbursements

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,4 +1,6 @@
+import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import { normalizeUserRole } from "@/lib/auth/roles";
 import type { DashboardEntry } from "@/lib/dashboardStats";
 import { getAllReimbursements } from "@/lib/server/reimbursements/data";
 import { getAll } from "@/lib/server/volunteerAllowance/data";
@@ -12,6 +14,9 @@ const REIMBURSEMENT_LABEL = {
 export default async function DashboardPage() {
   const session = await auth();
   if (!session?.user?.organizationId) return null;
+  if (normalizeUserRole(session.user.role) === "member") {
+    redirect("/reimbursements");
+  }
 
   const [reimbursements, allowances] = await Promise.all([
     getAllReimbursements(),

--- a/app/components/Sidebar/AppSidebar.tsx
+++ b/app/components/Sidebar/AppSidebar.tsx
@@ -31,9 +31,13 @@ import {
 import { MainNav, type NavItem } from "./MainNav";
 import { NavUser } from "./UserNav";
 
-const NAV_ITEMS: NavItem[] = [
-  { name: "Dashboard", url: "/dashboard", icon: LayoutDashboard },
+const MEMBER_NAV_ITEMS: NavItem[] = [
   { name: "Erstattungen", url: "/reimbursements", icon: Coins },
+];
+
+const STAFF_NAV_ITEMS: NavItem[] = [
+  { name: "Dashboard", url: "/dashboard", icon: LayoutDashboard },
+  ...MEMBER_NAV_ITEMS,
 ];
 
 type ProtectedNavItem = NavItem & { permission: UserPermission };
@@ -73,8 +77,9 @@ const ADMINISTRATION_NAV_ITEMS: ProtectedNavItem[] = [
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const role = useCurrentUserRole();
+  const homeUrl = role === "member" ? "/reimbursements" : "/dashboard";
   const mainItems: NavItem[] = [
-    ...NAV_ITEMS,
+    ...(role === "member" ? MEMBER_NAV_ITEMS : STAFF_NAV_ITEMS),
     ...(hasPermission(role, USER_PERMISSIONS.recruiting)
       ? [
           { name: "Ausschreibungen", url: "/recruiting", icon: Megaphone },
@@ -96,7 +101,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
-              <Link href="/dashboard">
+              <Link href={homeUrl}>
                 <Image src="/AppIcon.png" alt="YBase" width={32} height={32} />
                 <div className="grid flex-1 text-left leading-tight">
                   <span className="truncate text-base font-bold">YBase</span>


### PR DESCRIPTION
## Summary
- show standard members only the reimbursements navigation item
- point the YBase logo to reimbursements for members and redirect direct member dashboard requests
- keep elevated navigation unchanged for finance, people & culture, and admin roles

## Validation
- `pnpm exec vitest run app/lib/server/reimbursementInvites/reimbursementInvites.test.ts app/lib/auth/roles.test.ts` (65 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec biome lint <changed source files>`
- `pnpm build`