### PR TITLE
fix(reimbursements): hide unsubmitted shared requests

### DIFF
--- a/app/lib/server/reimbursements/data.ts
+++ b/app/lib/server/reimbursements/data.ts
@@ -109,9 +109,11 @@ export async function getAllReimbursements(): Promise<
     USER_PERMISSIONS.finance,
   );
 
-  const scope = canManageReimbursements
-    ? { organizationId: user.organizationId }
-    : { organizationId: user.organizationId, createdBy: user._id };
+  const scope = {
+    organizationId: user.organizationId,
+    ...(canManageReimbursements ? {} : { createdBy: user._id }),
+    $or: [{ isSharedLink: { $ne: true } }, { submittedAt: { $exists: true } }],
+  };
 
   const list = await (await reimbursements())
     .find(scope)

--- a/app/lib/server/reimbursements/public.ts
+++ b/app/lib/server/reimbursements/public.ts
@@ -12,7 +12,7 @@ export async function requireOpenSharedReimbursement(id: string) {
   const doc = await (await reimbursements()).findOne({ _id: id });
   if (
     !doc?.isSharedLink ||
-    (doc.amount !== 0 && doc.status !== "changes_requested")
+    (doc.submittedAt !== undefined && doc.status !== "changes_requested")
   ) {
     throw new Error("Invalid link");
   }
@@ -26,7 +26,7 @@ export async function getPublicReimbursement(id: string) {
     return { valid: false as const, error: "Kein geteilter Link" };
   }
   const isEditing = doc.status === "changes_requested";
-  if (doc.amount > 0 && !isEditing) {
+  if (doc.submittedAt !== undefined && !isEditing) {
     return { valid: false as const, error: "Bereits eingereicht" };
   }
 
@@ -80,7 +80,7 @@ export async function createPublicReimbursementUpload(
       _id: id,
       isSharedLink: true,
       $or: [
-        { submitterName: { $exists: false } },
+        { submittedAt: { $exists: false } },
         { status: "changes_requested" },
       ],
     },

--- a/app/lib/server/reimbursements/publicSubmission.ts
+++ b/app/lib/server/reimbursements/publicSubmission.ts
@@ -16,7 +16,7 @@ export async function submitPublicReimbursement(
   const collection = await reimbursements();
   const existing = await requireOpenSharedReimbursement(id);
   const isResubmission = existing.status === "changes_requested";
-  if (existing.submitterName && !isResubmission) {
+  if (existing.submittedAt !== undefined && !isResubmission) {
     throw new Error("Already submitted");
   }
 
@@ -52,7 +52,7 @@ export async function submitPublicReimbursement(
       _id: id,
       isSharedLink: true,
       $or: [
-        { submitterName: { $exists: false } },
+        { submittedAt: { $exists: false } },
         { status: "changes_requested" },
       ],
     },

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -60,7 +60,7 @@ import { getReimbursementPdfData } from "./files";
 import { getPublicReimbursementFileUrl } from "./public";
 import { submitPublicReimbursement } from "./publicSubmission";
 import { approve, decline, requestChanges } from "./review";
-import { createReimbursementLink } from "./sharing";
+import { createReimbursementLink, getPendingSharedLinks } from "./sharing";
 
 let orgA: string;
 let orgB: string;
@@ -242,6 +242,32 @@ test("creating an emailed submission request sends the request template", async 
   const stored = await (await reimbursements()).findOne({ _id: id });
   expect(stored?.invitedEmail).toBe("erika@example.com");
   expect(sendSubmissionRequestedEmail).toHaveBeenCalledWith(id);
+});
+
+test("unsubmitted shared links stay out of the reimbursement list", async () => {
+  const openLinkId = await createReimbursementLink({
+    projectId: projectA,
+    type: "expense",
+  });
+  const submittedZeroAmountLinkId = await createReimbursementLink({
+    projectId: projectA,
+    type: "expense",
+  });
+  await (
+    await reimbursements()
+  ).updateOne(
+    { _id: submittedZeroAmountLinkId },
+    { $set: { submittedAt: Date.now(), submitterName: "Erika" } },
+  );
+
+  const list = await getAllReimbursements();
+  const pendingLinks = await getPendingSharedLinks();
+
+  expect(list.map((item) => item._id)).toEqual([submittedZeroAmountLinkId]);
+  expect(list.some((item) => item._id === openLinkId)).toBe(false);
+  expect(pendingLinks.reimbursementLinks.map((item) => item._id)).toEqual([
+    openLinkId,
+  ]);
 });
 
 test("getFileInfo returns signed download metadata", async () => {

--- a/app/lib/server/reimbursements/sharing.ts
+++ b/app/lib/server/reimbursements/sharing.ts
@@ -44,7 +44,8 @@ export async function deleteSharedReimbursementLink(input: {
 
   if (!doc) throw new Error("Not found");
   if (!doc.isSharedLink) throw new Error("Not a shared link");
-  if (doc.amount > 0) throw new Error("Cannot delete submitted reimbursement");
+  if (doc.submittedAt !== undefined)
+    throw new Error("Cannot delete submitted reimbursement");
   if (doc.organizationId !== user.organizationId)
     throw new Error("Unauthorized");
 

--- a/app/lib/server/reimbursements/sharingHelpers.ts
+++ b/app/lib/server/reimbursements/sharingHelpers.ts
@@ -75,8 +75,14 @@ export async function loadPendingSharedLinks(organizationId: string): Promise<{
   reimbursementLinks: PendingReimbursementLink[];
   allowanceLinks: PendingAllowanceLink[];
 }> {
-  const pendingReimbursements = await (await reimbursements())
-    .find({ organizationId, isSharedLink: true, amount: 0 })
+  const pendingReimbursements = await (
+    await reimbursements()
+  )
+    .find({
+      organizationId,
+      isSharedLink: true,
+      submittedAt: { $exists: false },
+    })
     .toArray();
 
   const allAllowances = await (await volunteerAllowance())


### PR DESCRIPTION
## summary

- keep unsubmitted shared reimbursement requests out of dashboards and reimbursement lists
- use `submittedAt` as the lifecycle marker so legitimate zero-amount submissions remain supported

## validation

- `pnpm exec prettier --check <changed files>` and `pnpm biome lint <changed files>`
- `pnpm exec tsc --noEmit`, `pnpm lint:lines`, and `pnpm build`
- `pnpm test` (333 passed) and `pnpm exec playwright test e2e/reimbursements.spec.ts --reporter=list` (3 passed)
- `pnpm lint` is blocked by the existing CSS Modules `:global` parser configuration on `origin/main`
