### PR TITLE
fix(reimbursements): preserve invite through login

### DIFF
--- a/app/proxy.test.ts
+++ b/app/proxy.test.ts
@@ -1,0 +1,15 @@
+import { expect, test, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: (handler: unknown) => handler,
+}));
+
+import { isPublicPath } from "../proxy";
+
+test("allows reimbursement invite links before authentication", () => {
+  expect(isPublicPath("/invite/reimbursement-token")).toBe(true);
+});
+
+test("does not treat similarly named routes as public", () => {
+  expect(isPublicPath("/invited-users")).toBe(false);
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 
 const PUBLIC_PREFIXES = [
   "/login",
+  "/invite",
   "/erstattung",
   "/ehrenamtspauschale",
   "/sign",
@@ -10,12 +11,15 @@ const PUBLIC_PREFIXES = [
   "/datenschutz",
 ];
 
-export default auth((req) => {
-  const { pathname } = req.nextUrl;
-  const isPublic = PUBLIC_PREFIXES.some(
+export function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
-  if (!req.auth && !isPublic) {
+}
+
+export default auth((req) => {
+  const { pathname } = req.nextUrl;
+  if (!req.auth && !isPublicPath(pathname)) {
     return Response.redirect(new URL("/login", req.nextUrl));
   }
 });


### PR DESCRIPTION
## summary

- keep reimbursement invite routes reachable before authentication so the callback survives Google login
- cover invite path matching without exposing similarly named protected routes

## validation

- `pnpm vitest run app/proxy.test.ts app/lib/server/reimbursementInvites/reimbursementInvites.test.ts`
- `pnpm exec biome lint proxy.ts app/proxy.test.ts`
- `pnpm build`
- `pnpm lint` (fails on pre-existing CSS Modules parser errors in `ReimbursementTable.module.css`)