### PR TITLE
fix(reimbursements): simplify actions and sync creator names

### DIFF
--- a/app/(protected)/reimbursements/PendingLinksTable.tsx
+++ b/app/(protected)/reimbursements/PendingLinksTable.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import {
-  Car,
-  Check,
-  Copy,
-  Loader2,
-  Receipt,
-  Trash2,
-  Users,
-} from "lucide-react";
+import { Check, Copy, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { linkUrl } from "@/components/Reimbursements/shareModal/constants";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -33,23 +31,14 @@ type Props = {
   links: PendingLink[];
 };
 
-function linkDetails(link: PendingLink) {
+function linkLabel(link: PendingLink) {
   if (link.linkType === "allowance") {
-    return {
-      icon: <Users className="size-4 text-purple-500" />,
-      label: "Ehrenamtspauschale",
-    };
+    return "Ehrenamtspauschale";
   }
   if (link.type === "travel") {
-    return {
-      icon: <Car className="size-4 text-blue-500" />,
-      label: "Reisekostenerstattung",
-    };
+    return "Reisekostenerstattung";
   }
-  return {
-    icon: <Receipt className="size-4 text-green-500" />,
-    label: "Auslagenerstattung",
-  };
+  return "Auslagenerstattung";
 }
 
 export function PendingLinksTable({ links }: Props) {
@@ -102,21 +91,15 @@ export function PendingLinksTable({ links }: Props) {
             <TableHead>Projekt</TableHead>
             <TableHead>Erstellt von</TableHead>
             <TableHead>Erstellt</TableHead>
-            <TableHead className="w-24 text-right">Aktionen</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {links.map((link) => {
-            const details = linkDetails(link);
+            const label = linkLabel(link);
             const isDeleting = deletingId === link._id;
             return (
               <TableRow key={`${link.linkType}:${link._id}`}>
-                <TableCell>
-                  <div className="flex items-center gap-2 font-medium">
-                    {details.icon}
-                    {details.label}
-                  </div>
-                </TableCell>
+                <TableCell className="font-medium">{label}</TableCell>
                 <TableCell className="max-w-56 truncate">
                   {link.projectName}
                 </TableCell>
@@ -124,38 +107,44 @@ export function PendingLinksTable({ links }: Props) {
                   {link.creatorName}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
-                  {formatDate(link._creationTime)}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex justify-end gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleCopy(link)}
-                      aria-label={`${details.label}-Link kopieren`}
-                      title="Link kopieren"
-                    >
-                      {copiedId === link._id ? (
-                        <Check className="text-green-500" />
-                      ) : (
-                        <Copy />
-                      )}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="hover:bg-destructive/10 hover:text-destructive"
-                      onClick={() => handleDelete(link)}
-                      disabled={isDeleting}
-                      aria-label={`${details.label}-Link löschen`}
-                      title="Link löschen"
-                    >
-                      {isDeleting ? (
-                        <Loader2 className="animate-spin" />
-                      ) : (
-                        <Trash2 />
-                      )}
-                    </Button>
+                  <div className="flex items-center justify-between gap-3">
+                    {formatDate(link._creationTime)}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={`Aktionen für ${label} anzeigen`}
+                          title="Aktionen anzeigen"
+                        >
+                          <MoreVertical />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onSelect={() => void handleCopy(link)}
+                        >
+                          {copiedId === link._id ? (
+                            <Check className="text-green-500" />
+                          ) : (
+                            <Copy />
+                          )}
+                          Link kopieren
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          variant="destructive"
+                          disabled={isDeleting}
+                          onSelect={() => void handleDelete(link)}
+                        >
+                          {isDeleting ? (
+                            <Loader2 className="animate-spin" />
+                          ) : (
+                            <Trash2 />
+                          )}
+                          Link löschen
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 </TableCell>
               </TableRow>

--- a/app/(protected)/reimbursements/ReimbursementTable.module.css
+++ b/app/(protected)/reimbursements/ReimbursementTable.module.css
@@ -39,7 +39,7 @@
 }
 
 .tableShell :global([data-reimbursement-column="status"]) {
-  min-width: 7.5rem;
+  min-width: 11rem;
 }
 
 .tableShell :global([data-reimbursement-mobile-metadata]) {
@@ -116,7 +116,7 @@
   }
 
   .tableShell :global([data-reimbursement-column="status"]) {
-    min-width: 10rem;
+    min-width: 13rem;
   }
 }
 

--- a/app/(protected)/reimbursements/ReimbursementTable.tsx
+++ b/app/(protected)/reimbursements/ReimbursementTable.tsx
@@ -105,11 +105,10 @@ export function ReimbursementTable({
             <TableHead data-reimbursement-column="project">Projekt</TableHead>
             <TableHead data-reimbursement-column="created">Erstellt</TableHead>
             <TableHead className="text-right">Betrag</TableHead>
-            <TableHead>Status</TableHead>
             <TableHead data-reimbursement-column="reviewed-by">
               Bearbeitet von
             </TableHead>
-            <TableHead className="w-12 text-right" />
+            <TableHead>Status</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/app/components/Tables/Reimbursements/ReimbursementRow.tsx
+++ b/app/components/Tables/Reimbursements/ReimbursementRow.tsx
@@ -2,7 +2,7 @@ import {
   Check,
   ExternalLink,
   MessageSquareWarning,
-  MoreHorizontal,
+  MoreVertical,
   Pencil,
   Trash2,
   X,
@@ -118,11 +118,6 @@ export function ReimbursementRow({
       <TableCell className="text-right font-medium">
         {formatCurrency(item.amount)}
       </TableCell>
-      <TableCell data-reimbursement-column="status">
-        <Badge variant={display.variant} className={display.className}>
-          {display.label}
-        </Badge>
-      </TableCell>
       <TableCell
         className="max-w-48 truncate text-muted-foreground"
         data-reimbursement-column="reviewed-by"
@@ -130,68 +125,73 @@ export function ReimbursementRow({
         {item.reviewedByName ?? "–"}
       </TableCell>
       <TableCell
-        className="w-12 text-right"
+        data-reimbursement-column="status"
         onClick={(e) => e.stopPropagation()}
       >
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className={styles.menuTrigger}
-              aria-label="Aktionen anzeigen"
-              title="Aktionen anzeigen"
-            >
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent sideOffset={0} className={styles.menuContent}>
-            {showReviewActions ? (
-              <>
-                <DropdownMenuItem
-                  className={styles.menuItem}
-                  onSelect={onApprove}
-                >
-                  <Check className="text-current" />
-                  Genehmigen
+        <div className="flex items-center justify-between gap-3">
+          <Badge variant={display.variant} className={display.className}>
+            {display.label}
+          </Badge>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={styles.menuTrigger}
+                aria-label="Aktionen anzeigen"
+                title="Aktionen anzeigen"
+              >
+                <MoreVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent sideOffset={0} className={styles.menuContent}>
+              {showReviewActions ? (
+                <>
+                  <DropdownMenuItem
+                    className={styles.menuItem}
+                    onSelect={onApprove}
+                  >
+                    <Check className="text-current" />
+                    Genehmigen
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className={styles.menuItem}
+                    onSelect={onRequestChanges}
+                  >
+                    <MessageSquareWarning className="text-current" />
+                    Änderungen anfordern
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
+                    onSelect={onReject}
+                  >
+                    <X className="text-current" />
+                    Ablehnen
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+              {showEditAction ? (
+                <DropdownMenuItem className={styles.menuItem} onSelect={onEdit}>
+                  <Pencil className="text-current" />
+                  Bearbeiten
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  className={styles.menuItem}
-                  onSelect={onRequestChanges}
-                >
-                  <MessageSquareWarning className="text-current" />
-                  Änderungen anfordern
-                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuItem className={styles.menuItem} onSelect={onOpen}>
+                <ExternalLink className="text-current" />
+                Öffnen
+              </DropdownMenuItem>
+              {canManageReimbursements ? (
                 <DropdownMenuItem
                   className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
-                  onSelect={onReject}
+                  onSelect={onDelete}
                 >
-                  <X className="text-current" />
-                  Ablehnen
+                  <Trash2 className="text-current" />
+                  Löschen
                 </DropdownMenuItem>
-              </>
-            ) : null}
-            {showEditAction ? (
-              <DropdownMenuItem className={styles.menuItem} onSelect={onEdit}>
-                <Pencil className="text-current" />
-                Bearbeiten
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuItem className={styles.menuItem} onSelect={onOpen}>
-              <ExternalLink className="text-current" />
-              Öffnen
-            </DropdownMenuItem>
-            {canManageReimbursements ? (
-              <DropdownMenuItem
-                className={`${styles.menuItem} ${styles.destructiveMenuItem}`}
-                onSelect={onDelete}
-              >
-                <Trash2 className="text-current" />
-                Löschen
-              </DropdownMenuItem>
-            ) : null}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/app/lib/auth/provisioning.ts
+++ b/app/lib/auth/provisioning.ts
@@ -30,6 +30,26 @@ export async function ensureAppUser(profile: SignInProfile): Promise<User> {
       registeredAt: now,
     };
     await usersCol.insertOne(user);
+  } else {
+    const profileUpdates = {
+      ...(profile.name && profile.name !== user.name
+        ? { name: profile.name }
+        : {}),
+      ...(profile.image && profile.image !== user.image
+        ? { image: profile.image }
+        : {}),
+      ...(profile.firstName && profile.firstName !== user.firstName
+        ? { firstName: profile.firstName }
+        : {}),
+      ...(profile.lastName && profile.lastName !== user.lastName
+        ? { lastName: profile.lastName }
+        : {}),
+    };
+
+    if (Object.keys(profileUpdates).length > 0) {
+      await usersCol.updateOne({ _id: user._id }, { $set: profileUpdates });
+      user = { ...user, ...profileUpdates };
+    }
   }
 
   if (!user.organizationId) {

--- a/app/lib/db/foundation.test.ts
+++ b/app/lib/db/foundation.test.ts
@@ -45,6 +45,26 @@ test("ensureAppUser is idempotent for the same email", async () => {
   expect(await db.collection("users").countDocuments()).toBe(1);
 });
 
+test("ensureAppUser updates an existing user from the current login profile", async () => {
+  const first = await ensureAppUser({
+    email: "alice@youngfounders.network",
+    name: "Outdated Name",
+  });
+  const second = await ensureAppUser({
+    email: "alice@youngfounders.network",
+    name: "Alice Example",
+    firstName: "Alice",
+    lastName: "Example",
+  });
+
+  expect(second).toMatchObject({
+    _id: first._id,
+    name: "Alice Example",
+    firstName: "Alice",
+    lastName: "Example",
+  });
+});
+
 test("ensureAppUser leaves organizationId unset when no org matches the domain", async () => {
   const user = await ensureAppUser({ email: "bob@newverein.de", name: "Bob" });
 


### PR DESCRIPTION
## summary

- Remove reimbursement type icons and dedicated action columns, grouping row actions in vertical three-dot menus.
- Sync persisted app-user profile fields from the current login so creator names reflect the signed-in Google account.

## validation

- `pnpm exec biome lint <changed TS/TSX files>`
- `pnpm vitest run app/lib/db/foundation.test.ts app/lib/auth/config.test.ts`
- `pnpm exec playwright test e2e/reimbursements.spec.ts`
- `pnpm build`
- `pnpm lint` *(fails on the pre-existing Biome CSS Modules `:global` parser configuration)*