### PR TITLE
fix(reimbursements): remove travel date divider

### DIFF
--- a/app/components/Reimbursements/travelForm/TravelDetailsSection.tsx
+++ b/app/components/Reimbursements/travelForm/TravelDetailsSection.tsx
@@ -71,7 +71,7 @@ export function TravelDetailsSection({ travel, update }: Props) {
           </div>
         </fieldset>
 
-        <div className="border-t pt-6">
+        <div className="pt-6">
           <fieldset className="min-w-0">
             <legend className="mb-3 text-base font-medium">Reiseende</legend>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## summary

- remove the horizontal divider between travel start and end fields
- preserve the existing spacing and form structure

## validation

- `pnpm exec biome lint app/components/Reimbursements/travelForm/TravelDetailsSection.tsx`
- `git diff --check`
- tests not run (styling-only change; project guidance skips styling tests)