### PR TITLE
feat(reimbursements): support multiple travel receipts

### DIFF
--- a/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
+++ b/app/(public)/erstattung/[id]/ExternalReimbursementPageUI.tsx
@@ -64,7 +64,8 @@ export default function ExternalReimbursementPageUI(
               organizationName={props.organizationName}
               travelReceipts={props.travelReceipts}
               costLabels={props.costLabels}
-              onToggleCostType={props.onToggleCostType}
+              onAddTravelReceipt={props.onAddTravelReceipt}
+              onRemoveTravelReceipt={props.onRemoveTravelReceipt}
               onUpdateTravelReceipt={props.onUpdateTravelReceipt}
               toNet={props.toNet}
               generateUploadUrl={props.generateUploadUrl}

--- a/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { getTravelReceiptLabel } from "@/lib/travelReceiptForm";
+import { Plus } from "lucide-react";
 import { TravelReceiptCard } from "./TravelReceiptCard";
 import type { CostType, TravelReceipt } from "./types";
 
@@ -8,9 +10,10 @@ type Props = {
   organizationName: string;
   travelReceipts: TravelReceipt[];
   costLabels: Record<CostType, string>;
-  onToggleCostType: (costType: CostType) => void;
+  onAddTravelReceipt: (costType: CostType) => void;
+  onRemoveTravelReceipt: (clientId: string) => void;
   onUpdateTravelReceipt: (
-    costType: CostType,
+    clientId: string,
     updates: Partial<TravelReceipt>,
   ) => void;
   toNet: (gross: number, tax: number) => number;
@@ -23,37 +26,37 @@ type Props = {
 export function TravelCostsSection(props: Props) {
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-medium">Kostenarten</h2>
+      <h2 className="text-lg font-medium">Kostenpositionen hinzufügen</h2>
       <p className="text-sm text-muted-foreground">
-        Wähle alle Kostenarten aus, die du geltend machen möchtest.
+        Wähle eine Kostenart, um eine Position hinzuzufügen.
       </p>
       <div className="flex flex-wrap gap-2">
         {(Object.keys(props.costLabels) as CostType[]).map((costType) => (
           <Button
             key={costType}
             type="button"
-            variant={
-              props.travelReceipts.some(
-                (receipt) => receipt.costType === costType,
-              )
-                ? "default"
-                : "outline"
-            }
-            onClick={() => props.onToggleCostType(costType)}
+            variant="outline"
+            aria-label={`${props.costLabels[costType]} hinzufügen`}
+            onClick={() => props.onAddTravelReceipt(costType)}
           >
+            <Plus className="size-4" />
             {props.costLabels[costType]}
           </Button>
         ))}
       </div>
 
-      {props.travelReceipts.map((receipt) => (
+      {props.travelReceipts.map((receipt, index) => (
         <TravelReceiptCard
-          key={receipt.costType}
+          key={receipt.clientId}
           receipt={receipt}
-          costLabels={props.costLabels}
-          onRemove={() => props.onToggleCostType(receipt.costType)}
+          title={getTravelReceiptLabel(
+            props.travelReceipts,
+            index,
+            props.costLabels,
+          )}
+          onRemove={() => props.onRemoveTravelReceipt(receipt.clientId)}
           onUpdate={(updates) =>
-            props.onUpdateTravelReceipt(receipt.costType, updates)
+            props.onUpdateTravelReceipt(receipt.clientId, updates)
           }
           toNet={props.toNet}
           generateUploadUrl={props.generateUploadUrl}

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -15,11 +15,11 @@ import {
 import { Trash2 } from "lucide-react";
 import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
-import type { CostType, TravelReceipt } from "./types";
+import type { TravelReceipt } from "./types";
 
 type Props = {
   receipt: TravelReceipt;
-  costLabels: Record<CostType, string>;
+  title: string;
   onRemove: () => void;
   onUpdate: (updates: Partial<TravelReceipt>) => void;
   toNet: (gross: number, tax: number) => number;
@@ -35,14 +35,21 @@ export function TravelReceiptCard(props: Props) {
   const isCar = receipt.costType === "car";
 
   return (
-    <div className="@container border rounded-lg p-4 space-y-4">
+    <fieldset className="@container min-w-0 border rounded-lg p-4 space-y-4">
+      <legend className="sr-only">{props.title}</legend>
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {isCar
-            ? `PKW (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
-            : props.costLabels[receipt.costType]}
+            ? `${props.title} (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
+            : props.title}
         </h3>
-        <Button variant="ghost" size="icon" onClick={props.onRemove}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={props.onRemove}
+          aria-label={`${props.title} entfernen`}
+          title={`${props.title} entfernen`}
+        >
           <Trash2 className="size-4" />
         </Button>
       </div>
@@ -169,6 +176,6 @@ export function TravelReceiptCard(props: Props) {
           />
         </div>
       )}
-    </div>
+    </fieldset>
   );
 }

--- a/app/(public)/erstattung/[id]/_components/submitReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/submitReimbursementForm.ts
@@ -2,6 +2,7 @@ import toast from "react-hot-toast";
 import { submitReimbursement } from "@/(public)/_lib/reimbursements";
 import { BIC_REGEX, IBAN_REGEX, normalizeIban } from "@/lib/bank-utils";
 import { getTravelDateRangeError } from "@/lib/travelDates";
+import { withoutClientReceiptId } from "@/lib/travelReceiptForm";
 import type { Receipt, TravelReceipt } from "./types";
 import type { MealAllowance } from "@/lib/db/types";
 
@@ -122,9 +123,9 @@ export async function submitReimbursementForm(params: SubmitParams) {
     params.receipts.filter((receipt) => receipt.fileStorageId),
   );
 
-  const validTravelReceipts = params.travelReceipts.filter(
-    (receipt) => receipt.grossAmount > 0,
-  );
+  const validTravelReceipts = params.travelReceipts
+    .filter((receipt) => receipt.grossAmount > 0)
+    .map(withoutClientReceiptId);
 
   try {
     await submitReimbursement(params.id, {

--- a/app/(public)/erstattung/[id]/_components/types.ts
+++ b/app/(public)/erstattung/[id]/_components/types.ts
@@ -15,6 +15,7 @@ export type Receipt = {
 };
 
 export type TravelReceipt = Receipt & {
+  clientId: string;
   costType: CostType;
   kilometers?: number;
 };
@@ -77,9 +78,10 @@ export type ExternalReimbursementPageUIProps = {
   travelReceipts: TravelReceipt[];
   onAddReceipt: () => void;
   onRemoveReceipt: (index: number) => void;
-  onToggleCostType: (costType: CostType) => void;
+  onAddTravelReceipt: (costType: CostType) => void;
+  onRemoveTravelReceipt: (clientId: string) => void;
   onUpdateTravelReceipt: (
-    costType: CostType,
+    clientId: string,
     updates: Partial<TravelReceipt>,
   ) => void;
 

--- a/app/(public)/erstattung/[id]/_components/useReceipts.ts
+++ b/app/(public)/erstattung/[id]/_components/useReceipts.ts
@@ -2,6 +2,7 @@
 
 import { toNet } from "@/lib/bank-utils";
 import { type CostType, DEFAULT_TAX_RATES } from "@/lib/travel-costs";
+import { createClientReceiptId } from "@/lib/travelReceiptForm";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import type { Receipt, TravelReceipt } from "./types";
@@ -23,8 +24,8 @@ export function useReceipts(startDate: string) {
       return toast.error("Bitte Pflichtfelder ausfüllen");
     }
 
-    setReceipts([
-      ...receipts,
+    setReceipts((current) => [
+      ...current,
       {
         receiptNumber: number || undefined,
         receiptDate: date,
@@ -49,24 +50,14 @@ export function useReceipts(startDate: string) {
   };
 
   const removeReceipt = (index: number) => {
-    setReceipts(receipts.filter((_, idx) => idx !== index));
+    setReceipts((current) => current.filter((_, idx) => idx !== index));
   };
 
-  const toggleCostType = (costType: CostType) => {
-    const exists = travelReceipts.some(
-      (receipt) => receipt.costType === costType,
-    );
-
-    if (exists) {
-      setTravelReceipts(
-        travelReceipts.filter((receipt) => receipt.costType !== costType),
-      );
-      return;
-    }
-
-    setTravelReceipts([
-      ...travelReceipts,
+  const addTravelReceipt = (costType: CostType) => {
+    setTravelReceipts((current) => [
+      ...current,
       {
+        clientId: createClientReceiptId(),
         costType,
         receiptNumber: undefined,
         receiptDate: startDate,
@@ -81,13 +72,19 @@ export function useReceipts(startDate: string) {
     ]);
   };
 
+  const removeTravelReceipt = (clientId: string) => {
+    setTravelReceipts((current) =>
+      current.filter((receipt) => receipt.clientId !== clientId),
+    );
+  };
+
   const updateTravelReceipt = (
-    costType: CostType,
+    clientId: string,
     updates: Partial<TravelReceipt>,
   ) => {
-    setTravelReceipts(
-      travelReceipts.map((receipt) =>
-        receipt.costType === costType ? { ...receipt, ...updates } : receipt,
+    setTravelReceipts((current) =>
+      current.map((receipt) =>
+        receipt.clientId === clientId ? { ...receipt, ...updates } : receipt,
       ),
     );
   };
@@ -113,7 +110,8 @@ export function useReceipts(startDate: string) {
     setFile,
     addReceipt,
     removeReceipt,
-    toggleCostType,
+    addTravelReceipt,
+    removeTravelReceipt,
     updateTravelReceipt,
   };
 }

--- a/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
@@ -9,6 +9,7 @@ import {
   reimbursementUploadUrl,
   validateReimbursementLink,
 } from "@/(public)/_lib/reimbursements";
+import { createClientReceiptId } from "@/lib/travelReceiptForm";
 import {
   submitReimbursementForm,
   validateReimbursement,
@@ -58,9 +59,17 @@ export function useReimbursementForm(id: string) {
             })),
         );
         setTravelReceipts(
-          submission.receipts.filter(
-            (receipt) => receipt.costType,
-          ) as typeof receiptState.travelReceipts,
+          submission.receipts.flatMap((receipt) => {
+            if (!receipt.costType) return [];
+            return [
+              {
+                ...receipt,
+                costType: receipt.costType,
+                receiptNumber: receipt.receiptNumber,
+                clientId: createClientReceiptId(),
+              },
+            ];
+          }),
         );
       }
 

--- a/app/(public)/erstattung/[id]/page.tsx
+++ b/app/(public)/erstattung/[id]/page.tsx
@@ -82,7 +82,8 @@ export default function ExternalReimbursementPage() {
       travelReceipts={form.travelReceipts}
       onAddReceipt={form.addReceipt}
       onRemoveReceipt={form.removeReceipt}
-      onToggleCostType={form.toggleCostType}
+      onAddTravelReceipt={form.addTravelReceipt}
+      onRemoveTravelReceipt={form.removeTravelReceipt}
       onUpdateTravelReceipt={form.updateTravelReceipt}
       totalGross={form.totalGross}
       accountHolder={form.accountHolder}

--- a/app/components/Reimbursements/TravelReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/TravelReimbursementFormUI.tsx
@@ -55,8 +55,8 @@ export function TravelReimbursementFormUI({
         {form.hasBasicInfo && (
           <ReceiptsSection
             receipts={form.receipts}
-            hasReceipt={form.hasReceipt}
-            toggleType={form.toggleType}
+            addReceipt={form.addReceipt}
+            removeReceipt={form.removeReceipt}
             updateReceipt={form.updateReceipt}
             travel={form.travel}
             update={form.update}

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -13,11 +13,7 @@ import {
 } from "@/components/ui/select";
 import { toNet } from "@/lib/bank-utils";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
-import {
-  CAR_ALLOWANCE_RATE_EUR_PER_KM,
-  COST_LABELS as LABELS,
-  type CostType,
-} from "@/lib/travel-costs";
+import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
 import { Trash2 } from "lucide-react";
 import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { PLACEHOLDERS } from "./constants";
@@ -25,31 +21,34 @@ import type { Receipt } from "./types";
 
 interface Props {
   receipt: Receipt;
-  toggleType: (type: CostType) => void;
-  updateReceipt: (type: CostType, updates: Partial<Receipt>) => void;
+  title: string;
+  onRemove: () => void;
+  onUpdate: (updates: Partial<Receipt>) => void;
   organizationName: string;
 }
 
 export function ReceiptCard({
   receipt,
-  toggleType,
-  updateReceipt,
+  title,
+  onRemove,
+  onUpdate,
   organizationName,
 }: Props) {
   return (
-    <div className="@container border rounded-lg p-4 space-y-4">
+    <fieldset className="@container min-w-0 border rounded-lg p-4 space-y-4">
+      <legend className="sr-only">{title}</legend>
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {receipt.costType === "car"
-            ? `PKW (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
-            : LABELS[receipt.costType]}
+            ? `${title} (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
+            : title}
         </h3>
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => toggleType(receipt.costType)}
-          aria-label="Position entfernen"
-          title="Position entfernen"
+          onClick={onRemove}
+          aria-label={`${title} entfernen`}
+          title={`${title} entfernen`}
         >
           <Trash2 className="size-4" />
         </Button>
@@ -63,7 +62,7 @@ export function ReceiptCard({
               <Input
                 value={receipt.companyName}
                 onChange={(e) =>
-                  updateReceipt(receipt.costType, {
+                  onUpdate({
                     companyName: e.target.value,
                   })
                 }
@@ -75,7 +74,7 @@ export function ReceiptCard({
               <Input
                 value={receipt.receiptNumber ?? ""}
                 onChange={(e) =>
-                  updateReceipt(receipt.costType, {
+                  onUpdate({
                     receiptNumber: e.target.value || undefined,
                   })
                 }
@@ -99,7 +98,7 @@ export function ReceiptCard({
                   );
                   const amount =
                     Math.round(km * CAR_ALLOWANCE_RATE_EUR_PER_KM * 100) / 100;
-                  updateReceipt(receipt.costType, {
+                  onUpdate({
                     kilometers: km,
                     grossAmount: amount,
                     netAmount: amount,
@@ -128,7 +127,7 @@ export function ReceiptCard({
                 value={receipt.grossAmount || ""}
                 onChange={(e) => {
                   const gross = Math.max(0, parseFloat(e.target.value) || 0);
-                  updateReceipt(receipt.costType, {
+                  onUpdate({
                     grossAmount: gross,
                     netAmount: toNet(gross, receipt.taxRate),
                   });
@@ -142,7 +141,7 @@ export function ReceiptCard({
                 value={String(receipt.taxRate)}
                 onValueChange={(value) => {
                   const tax = parseInt(value, 10);
-                  updateReceipt(receipt.costType, {
+                  onUpdate({
                     taxRate: tax,
                     netAmount: toNet(receipt.grossAmount, tax),
                   });
@@ -168,13 +167,11 @@ export function ReceiptCard({
             <Label>Beleg *</Label>
             <InvoiceOrganizationHint organizationName={organizationName} />
             <ReceiptUpload
-              onUploadComplete={(id) =>
-                updateReceipt(receipt.costType, { fileStorageId: id })
-              }
+              onUploadComplete={(id) => onUpdate({ fileStorageId: id })}
               storageId={receipt.fileStorageId || undefined}
             />
           </div>
         )}
-    </div>
+    </fieldset>
   );
 }

--- a/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
@@ -7,15 +7,17 @@ import {
   type CostType,
   COST_LABELS as LABELS,
 } from "@/lib/travel-costs";
-import { MealAllowanceSection } from "./MealAllowanceSection";
+import { getTravelReceiptLabel } from "@/lib/travelReceiptForm";
+import { Plus } from "lucide-react";
 import { ReceiptCard } from "./ReceiptCard";
+import { MealAllowanceSection } from "./MealAllowanceSection";
 import type { Receipt, Travel } from "./types";
 
 interface Props {
   receipts: Receipt[];
-  hasReceipt: (type: CostType) => boolean;
-  toggleType: (type: CostType) => void;
-  updateReceipt: (type: CostType, updates: Partial<Receipt>) => void;
+  addReceipt: (type: CostType) => void;
+  removeReceipt: (clientId: string) => void;
+  updateReceipt: (clientId: string, updates: Partial<Receipt>) => void;
   travel: Travel;
   update: (field: Partial<Travel>) => void;
   showMealAllowance: boolean;
@@ -29,8 +31,8 @@ interface Props {
 
 export function ReceiptsSection({
   receipts,
-  hasReceipt,
-  toggleType,
+  addReceipt,
+  removeReceipt,
   updateReceipt,
   travel,
   update,
@@ -45,31 +47,35 @@ export function ReceiptsSection({
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-lg font-medium mb-3">Kostenarten auswählen</h2>
+        <h2 className="text-lg font-medium mb-3">
+          Kostenpositionen hinzufügen
+        </h2>
         <p className="text-sm text-muted-foreground mb-2">
-          Wähle alle Kostenarten aus, die du geltend machen möchtest.
+          Wähle eine Kostenart, um eine Position hinzuzufügen.
         </p>
         <div className="flex flex-wrap gap-2">
           {COST_TYPES.map((type) => (
             <Button
               key={type}
               type="button"
-              variant={hasReceipt(type) ? "primary" : "outline"}
-              aria-pressed={hasReceipt(type)}
-              onClick={() => toggleType(type)}
+              variant="outline"
+              aria-label={`${LABELS[type]} hinzufügen`}
+              onClick={() => addReceipt(type)}
             >
+              <Plus className="size-4" />
               {LABELS[type]}
             </Button>
           ))}
         </div>
       </div>
 
-      {receipts.map((receipt) => (
+      {receipts.map((receipt, index) => (
         <ReceiptCard
-          key={receipt.costType}
+          key={receipt.clientId}
           receipt={receipt}
-          toggleType={toggleType}
-          updateReceipt={updateReceipt}
+          title={getTravelReceiptLabel(receipts, index, LABELS)}
+          onRemove={() => removeReceipt(receipt.clientId)}
+          onUpdate={(updates) => updateReceipt(receipt.clientId, updates)}
           organizationName={organizationName}
         />
       ))}

--- a/app/components/Reimbursements/travelForm/SummarySection.tsx
+++ b/app/components/Reimbursements/travelForm/SummarySection.tsx
@@ -7,6 +7,7 @@ import {
   CAR_ALLOWANCE_RATE_EUR_PER_KM,
   COST_LABELS as LABELS,
 } from "@/lib/travel-costs";
+import { getTravelReceiptLabel } from "@/lib/travelReceiptForm";
 import { Loader2 } from "lucide-react";
 import type { Receipt } from "./types";
 
@@ -47,27 +48,32 @@ export function SummarySection({
       ) : (
         <>
           <div className="space-y-2">
-            {items.map((receipt) => (
-              <div
-                key={receipt.costType}
-                className="flex items-start justify-between gap-2 border bg-muted px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <div className="font-semibold truncate">
-                    {LABELS[receipt.costType]}
-                  </div>
-                  {receipt.costType === "car" && (
-                    <div className="text-sm text-muted-foreground">
-                      {receipt.kilometers} km ×{" "}
-                      {formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}
+            {items.map((receipt) => {
+              const receiptIndex = receipts.findIndex(
+                (item) => item.clientId === receipt.clientId,
+              );
+              return (
+                <div
+                  key={receipt.clientId}
+                  className="flex items-start justify-between gap-2 border bg-muted px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="font-semibold truncate">
+                      {getTravelReceiptLabel(receipts, receiptIndex, LABELS)}
                     </div>
-                  )}
+                    {receipt.costType === "car" && (
+                      <div className="text-sm text-muted-foreground">
+                        {receipt.kilometers} km ×{" "}
+                        {formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}
+                      </div>
+                    )}
+                  </div>
+                  <span className="font-semibold whitespace-nowrap">
+                    {formatCurrency(receipt.grossAmount)}
+                  </span>
                 </div>
-                <span className="font-semibold whitespace-nowrap">
-                  {formatCurrency(receipt.grossAmount)}
-                </span>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="space-y-2">

--- a/app/components/Reimbursements/travelForm/types.ts
+++ b/app/components/Reimbursements/travelForm/types.ts
@@ -6,7 +6,7 @@ export type BankDetails = { iban: string; bic: string; accountHolder: string };
 export type Receipt = Omit<
   ReceiptDoc,
   "_id" | "_creationTime" | "reimbursementId"
-> & { costType: CostType };
+> & { clientId: string; costType: CostType };
 
 export type Travel = {
   destination: string;

--- a/app/components/Reimbursements/travelForm/useTravelForm.ts
+++ b/app/components/Reimbursements/travelForm/useTravelForm.ts
@@ -12,6 +12,10 @@ import {
   getMealAllowanceTotal,
   OVERNIGHT_ALLOWANCE_EUR,
 } from "@/lib/travel-costs";
+import {
+  createClientReceiptId,
+  withoutClientReceiptId,
+} from "@/lib/travelReceiptForm";
 import { getTravelDateRangeError } from "@/lib/travelDates";
 import type { BankDetails, Receipt } from "./types";
 
@@ -41,18 +45,11 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
   const update = (field: Partial<typeof travel>) =>
     setTravel((prev) => ({ ...prev, ...field }));
 
-  const hasReceipt = (type: CostType) =>
-    receipts.some((receipt) => receipt.costType === type);
-
-  const toggleType = (type: CostType) => {
-    if (hasReceipt(type)) {
-      return setReceipts(
-        receipts.filter((receipt) => receipt.costType !== type),
-      );
-    }
-    setReceipts([
-      ...receipts,
+  const addReceipt = (type: CostType) => {
+    setReceipts((current) => [
+      ...current,
       {
+        clientId: createClientReceiptId(),
         costType: type,
         receiptNumber: undefined,
         receiptDate: travel.startDate,
@@ -67,10 +64,15 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
     ]);
   };
 
-  const updateReceipt = (type: CostType, updates: Partial<Receipt>) =>
-    setReceipts(
-      receipts.map((receipt) =>
-        receipt.costType === type ? { ...receipt, ...updates } : receipt,
+  const removeReceipt = (clientId: string) =>
+    setReceipts((current) =>
+      current.filter((receipt) => receipt.clientId !== clientId),
+    );
+
+  const updateReceipt = (clientId: string, updates: Partial<Receipt>) =>
+    setReceipts((current) =>
+      current.map((receipt) =>
+        receipt.clientId === clientId ? { ...receipt, ...updates } : receipt,
       ),
     );
 
@@ -145,7 +147,7 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
           travel.overnightAllowanceNights > 0
             ? travel.overnightAllowanceRate
             : undefined,
-        receipts,
+        receipts: receipts.map(withoutClientReceiptId),
       });
       toast.success("Reisekostenerstattung eingereicht");
       router.push("/reimbursements");
@@ -169,8 +171,8 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
     receipts,
     travel,
     update,
-    hasReceipt,
-    toggleType,
+    addReceipt,
+    removeReceipt,
     updateReceipt,
     hasBasicInfo,
     mealTotal,

--- a/app/lib/travelReceiptForm.test.ts
+++ b/app/lib/travelReceiptForm.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  getTravelReceiptLabel,
+  withoutClientReceiptId,
+} from "./travelReceiptForm";
+
+const labels = {
+  car: "PKW",
+  train: "Bahn",
+  flight: "Flug",
+  taxi: "Taxi",
+  bus: "Bus",
+  accommodation: "Unterkunft",
+  incidental: "Reise-Nebenkosten",
+} as const;
+
+describe("travel receipt form helpers", () => {
+  test("numbers repeated cost types independently", () => {
+    const receipts = [
+      { clientId: "train-1", costType: "train" as const },
+      { clientId: "taxi-1", costType: "taxi" as const },
+      { clientId: "train-2", costType: "train" as const },
+    ];
+
+    expect(getTravelReceiptLabel(receipts, 0, labels)).toBe("Bahn 1");
+    expect(getTravelReceiptLabel(receipts, 1, labels)).toBe("Taxi");
+    expect(getTravelReceiptLabel(receipts, 2, labels)).toBe("Bahn 2");
+  });
+
+  test("removes the form-only id without mutating the receipt", () => {
+    const receipt = {
+      clientId: "train-1",
+      costType: "train" as const,
+      grossAmount: 49.9,
+    };
+
+    expect(withoutClientReceiptId(receipt)).toEqual({
+      costType: "train",
+      grossAmount: 49.9,
+    });
+    expect(receipt.clientId).toBe("train-1");
+  });
+});

--- a/app/lib/travelReceiptForm.ts
+++ b/app/lib/travelReceiptForm.ts
@@ -1,0 +1,36 @@
+import type { CostType } from "./travel-costs";
+
+export type ClientTravelReceipt = {
+  clientId: string;
+  costType: CostType;
+};
+
+export function createClientReceiptId(): string {
+  return crypto.randomUUID();
+}
+
+export function withoutClientReceiptId<T extends { clientId: string }>({
+  clientId: _clientId,
+  ...receipt
+}: T): Omit<T, "clientId"> {
+  return receipt;
+}
+
+export function getTravelReceiptLabel(
+  receipts: readonly ClientTravelReceipt[],
+  index: number,
+  labels: Record<CostType, string>,
+): string {
+  const receipt = receipts[index];
+  const label = labels[receipt.costType];
+  const sameTypeCount = receipts.filter(
+    (item) => item.costType === receipt.costType,
+  ).length;
+
+  if (sameTypeCount === 1) return label;
+
+  const position = receipts
+    .slice(0, index + 1)
+    .filter((item) => item.costType === receipt.costType).length;
+  return `${label} ${position}`;
+}

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -270,29 +270,55 @@ test.describe("critical reimbursement journeys", () => {
     await page.getByRole("combobox", { name: "Projekt suchen..." }).click();
     await page.getByRole("button", { name: "Allgemein" }).click();
 
-    const destination = page.getByRole("textbox", {
-      name: "z.B. München, Berlin",
-    });
-    const purpose = page.getByRole("textbox", {
-      name: "z.B. Kundentermin, Konferenz",
-    });
+    const destination = page.getByLabel("Reiseziel *");
+    const purpose = page.getByLabel("Reisezweck *");
     await destination.fill("Berlin");
     await purpose.fill("Event");
-    await page
-      .getByRole("textbox", { name: "TT.MM.JJJJ" })
-      .first()
-      .fill("15.05.2026");
-    await page
-      .getByRole("textbox", { name: "TT.MM.JJJJ" })
-      .nth(1)
-      .fill("20.05.2026");
-    await page.locator('input[type="time"]').first().fill("08:00");
-    await page.locator('input[type="time"]').nth(1).fill("18:00");
-    await page.getByRole("textbox", { name: "TT.MM.JJJJ" }).nth(1).blur();
+    const travelStart = page.getByRole("group", { name: "Reisebeginn" });
+    const travelEnd = page.getByRole("group", { name: "Reiseende" });
+    await travelStart.getByLabel("Datum *").fill("15.05.2026");
+    await travelEnd.getByLabel("Datum *").fill("20.05.2026");
+    await travelStart.getByLabel("Uhrzeit *").fill("08:00");
+    await travelEnd.getByLabel("Uhrzeit *").fill("18:00");
+    await travelEnd.getByLabel("Datum *").blur();
 
-    await page.getByRole("button", { name: "PKW" }).click();
+    await page.getByRole("button", { name: "Bahn hinzufügen" }).click();
+    await page.getByRole("button", { name: "Bahn hinzufügen" }).click();
 
-    await page.getByRole("spinbutton").first().fill("500");
+    const firstTrainReceipt = page.getByRole("group", { name: "Bahn 1" });
+    const secondTrainReceipt = page.getByRole("group", { name: "Bahn 2" });
+    await expect(firstTrainReceipt).toBeVisible();
+    await expect(secondTrainReceipt).toBeVisible();
+
+    await firstTrainReceipt
+      .getByPlaceholder("Deutsche Bahn, Flix, etc.")
+      .fill("Deutsche Bahn Hinfahrt");
+    await firstTrainReceipt
+      .getByPlaceholder("z.B. RE-2026-001 (optional)")
+      .fill("DB-001");
+    await firstTrainReceipt.getByRole("spinbutton").fill("40");
+    await firstTrainReceipt
+      .locator('input[type="file"]')
+      .setInputFiles(IMAGE_FILE);
+    await expect(
+      firstTrainReceipt.getByRole("img", { name: "Beleg" }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+
+    await secondTrainReceipt
+      .getByPlaceholder("Deutsche Bahn, Flix, etc.")
+      .fill("Deutsche Bahn Rückfahrt");
+    await secondTrainReceipt
+      .getByPlaceholder("z.B. RE-2026-001 (optional)")
+      .fill("DB-002");
+    await secondTrainReceipt.getByRole("spinbutton").fill("60");
+    await secondTrainReceipt
+      .locator('input[type="file"]')
+      .setInputFiles(IMAGE_FILE);
+    await expect(
+      secondTrainReceipt.getByRole("img", { name: "Beleg" }),
+    ).toBeVisible({ timeout: 10000 });
 
     await page
       .getByRole("checkbox", {
@@ -301,8 +327,7 @@ test.describe("critical reimbursement journeys", () => {
       .check();
     await page.locator("#fullDay-days").fill("1");
 
-    await expect(page.getByText("PKW500 km × 0,30 €")).toBeVisible();
-    await expect(page.getByText("Brutto gesamt178,00 €")).toBeVisible();
+    await expect(page.getByText("Brutto gesamt128,00 €")).toBeVisible();
 
     await saveBankDetails(page);
     await addSignature(page);


### PR DESCRIPTION
## summary

- allow internal and public travel forms to add, edit, and remove repeated cost types independently
- keep stable form-only receipt ids out of submitted data and label repeated positions clearly

## validation

- `{ git diff --name-only -z; git ls-files --others --exclude-standard -z; } | xargs -0 pnpm exec prettier --check`
- `{ git diff --name-only -z; git ls-files --others --exclude-standard -z; } | xargs -0 pnpm exec biome lint`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec vitest run app/lib/travelReceiptForm.test.ts app/lib/fileHandlers/travelReimbursementPdf/data.test.ts`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "travel reimbursement can be submitted and declined"`