### PR TITLE
fix(reimbursements): preserve draft after saving bank details

### DIFF
--- a/app/components/BankDetailsEditor.tsx
+++ b/app/components/BankDetailsEditor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Loader2, Pencil } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
@@ -23,7 +22,6 @@ interface Props {
 export function BankDetailsEditor({ value, onChange }: Props) {
   const [editing, setEditing] = useState(() => !!getBankDetailsError(value));
   const [isSaving, setIsSaving] = useState(false);
-  const router = useRouter();
 
   const toggle = async () => {
     if (!editing) {
@@ -40,7 +38,6 @@ export function BankDetailsEditor({ value, onChange }: Props) {
       await updateBankDetails(normalized);
       onChange(normalized);
       toast.success("Bankverbindung gespeichert");
-      router.refresh();
       setEditing(false);
     } catch {
       toast.error("Fehler beim Speichern");

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -148,6 +148,10 @@ test.describe("critical reimbursement journeys", () => {
     await expect(page.getByText("Test Firma").first()).toBeVisible();
 
     await saveBankDetails(page);
+    await expect(page.getByText("Test Firma").first()).toBeVisible();
+    await expect(
+      page.getByText("Beschreibung", { exact: true }).first(),
+    ).toBeVisible();
     await addSignature(page);
 
     await page


### PR DESCRIPTION
## summary

- Keep unfinished reimbursement form data intact after users save bank details.
- Remove the unnecessary App Router refresh and add regression coverage for retained receipt data.

## validation

- `pnpm exec biome lint app/components/BankDetailsEditor.tsx e2e/reimbursements.spec.ts`
- `pnpm exec prettier --check app/components/BankDetailsEditor.tsx e2e/reimbursements.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/lib/server/users/users.test.ts app/lib/bank-utils.test.ts`
- `pnpm build`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "expense reimbursement can be revised and approved"`