### PR TITLE
fix(reimbursements): restore repeated travel cost actions

### DIFF
--- a/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx
@@ -33,9 +33,6 @@ export function TravelCostsSection(props: Props) {
       <CostTypeSelector
         costTypes={COST_TYPES}
         labels={props.costLabels}
-        isSelected={(costType) =>
-          props.travelReceipts.some((receipt) => receipt.costType === costType)
-        }
         onSelect={props.onAddTravelReceipt}
         getAccessibleLabel={(costType) =>
           `${props.costLabels[costType]} hinzufügen`

--- a/app/components/Reimbursements/CostTypeSelector.tsx
+++ b/app/components/Reimbursements/CostTypeSelector.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { CostType } from "@/lib/travel-costs";
 
 type Props = {
   costTypes: readonly CostType[];
   labels: Record<CostType, string>;
-  isSelected: (costType: CostType) => boolean;
   onSelect: (costType: CostType) => void;
   getAccessibleLabel?: (costType: CostType) => string;
 };
@@ -15,28 +14,23 @@ type Props = {
 export function CostTypeSelector({
   costTypes,
   labels,
-  isSelected,
   onSelect,
   getAccessibleLabel,
 }: Props) {
   return (
     <fieldset className="flex flex-wrap gap-2" aria-label="Kostenarten">
-      {costTypes.map((costType) => {
-        const selected = isSelected(costType);
-
-        return (
-          <Button
-            key={costType}
-            type="button"
-            variant={selected ? "primary" : "outline"}
-            aria-label={getAccessibleLabel?.(costType)}
-            onClick={() => onSelect(costType)}
-          >
-            {selected ? <Check className="size-4" aria-hidden="true" /> : null}
-            {labels[costType]}
-          </Button>
-        );
-      })}
+      {costTypes.map((costType) => (
+        <Button
+          key={costType}
+          type="button"
+          variant="outline"
+          aria-label={getAccessibleLabel?.(costType)}
+          onClick={() => onSelect(costType)}
+        >
+          <Plus className="size-4" aria-hidden="true" />
+          {labels[costType]}
+        </Button>
+      ))}
     </fieldset>
   );
 }

--- a/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptsSection.tsx
@@ -55,9 +55,6 @@ export function ReceiptsSection({
         <CostTypeSelector
           costTypes={COST_TYPES}
           labels={LABELS}
-          isSelected={(type) =>
-            receipts.some((receipt) => receipt.costType === type)
-          }
           onSelect={addReceipt}
           getAccessibleLabel={(type) => `${LABELS[type]} hinzufügen`}
         />


### PR DESCRIPTION
## summary

- keep travel cost buttons visibly additive after the first item
- restore the repeated-cost affordance in both member and public forms

## validation

- `pnpm exec biome lint app/components/Reimbursements/CostTypeSelector.tsx app/components/Reimbursements/travelForm/ReceiptsSection.tsx app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx`
- `pnpm exec prettier --check app/components/Reimbursements/CostTypeSelector.tsx app/components/Reimbursements/travelForm/ReceiptsSection.tsx app/(public)/erstattung/[id]/_components/TravelCostsSection.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm test app/lib/travelReceiptForm.test.ts`
- `pnpm exec playwright test e2e/reimbursements.spec.ts --grep "travel reimbursement can be submitted and declined"`