### PR TITLE
fix(reimbursements): accept mobile signature handoffs

### DIFF
--- a/app/lib/server/reimbursements/creation.ts
+++ b/app/lib/server/reimbursements/creation.ts
@@ -7,7 +7,7 @@ import { newId } from "../../db/ids";
 import type { Receipt, Reimbursement } from "../../db/types";
 import { addLog } from "../logs";
 import { requireActiveOrganizationProject } from "../projects/access";
-import { claimPendingUploads } from "../uploads/ownership";
+import { claimUploadsForSubmission } from "../uploads/ownership";
 import { sendSubmissionReceivedEmail } from "./email";
 import {
   createReimbursementSchema,
@@ -112,15 +112,12 @@ async function claimSubmissionUploads(
   signatureStorageId: string,
   receiptList: ReceiptInsert[],
 ): Promise<void> {
-  await claimPendingUploads(
-    [
-      signatureStorageId,
-      ...receiptList.flatMap((receipt) =>
-        receipt.fileStorageId ? [receipt.fileStorageId] : [],
-      ),
-    ],
+  await claimUploadsForSubmission(
+    receiptList.flatMap((receipt) =>
+      receipt.fileStorageId ? [receipt.fileStorageId] : [],
+    ),
+    signatureStorageId,
     { organizationId: user.organizationId, userId: user._id },
-    ["user", "signatureToken"],
     { type: "reimbursement", id: reimbursementId },
   );
 }

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -30,6 +30,7 @@ import {
   reimbursements,
   signatureTokens,
   travelDetails,
+  uploadOwnerships,
   users,
 } from "../../db/collections";
 import { newId } from "../../db/ids";
@@ -45,7 +46,10 @@ import {
 } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { submitPublicSignature } from "../signatures/public";
-import { registerPendingUpload } from "../uploads/ownership";
+import {
+  claimPendingUploads,
+  registerPendingUpload,
+} from "../uploads/ownership";
 import { createReimbursement, createTravelReimbursement } from "./creation";
 import { getAllReimbursements, getFileInfo, getReimbursement } from "./data";
 import { deleteReimbursement } from "./deletion";
@@ -151,6 +155,29 @@ function reimbursementInput() {
   };
 }
 
+async function completeMobileSignature(storageKey: string): Promise<void> {
+  const tokenId = newId();
+  const token = crypto.randomUUID();
+  await (
+    await signatureTokens()
+  ).insertOne({
+    _id: tokenId,
+    _creationTime: Date.now(),
+    token,
+    organizationId: orgA,
+    createdBy: userA,
+    expiresAt: Date.now() + 60_000,
+    pendingSignatureStorageId: storageKey,
+  });
+  await registerPendingUpload(storageKey, {
+    organizationId: orgA,
+    userId: userA,
+    contextType: "signatureToken",
+    contextId: tokenId,
+  });
+  await submitPublicSignature(token);
+}
+
 test("createReimbursement writes the reimbursement and receipts scoped to the org", async () => {
   const id = await createReimbursement(reimbursementInput());
 
@@ -164,6 +191,80 @@ test("createReimbursement writes the reimbursement and receipts scoped to the or
   expect(receiptList).toHaveLength(1);
   expect(receiptList[0]?.fileStorageId).toBe("receipt-key");
   expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(id);
+});
+
+test("travel creation transfers a mobile signature with repeated receipt types", async () => {
+  await completeMobileSignature("mobile-signature-key");
+  await registerPendingUpload("second-receipt-key", {
+    organizationId: orgA,
+    userId: userA,
+    contextType: "user",
+    contextId: userA,
+  });
+
+  const id = await createTravelReimbursement({
+    ...reimbursementInput(),
+    signatureStorageId: "mobile-signature-key",
+    startDate: "2026-05-15",
+    startTime: "08:00",
+    endDate: "2026-05-20",
+    endTime: "18:00",
+    destination: "Berlin",
+    purpose: "Event",
+    isInternational: false,
+    receipts: [
+      {
+        ...reimbursementInput().receipts[0],
+        costType: "train",
+      },
+      {
+        ...reimbursementInput().receipts[0],
+        fileStorageId: "second-receipt-key",
+        costType: "train",
+      },
+    ],
+  });
+
+  expect(await (await receipts()).countDocuments({ reimbursementId: id })).toBe(
+    2,
+  );
+  expect(
+    await (await uploadOwnerships()).findOne({ _id: "mobile-signature-key" }),
+  ).toMatchObject({
+    claimedByType: "reimbursement",
+    claimedById: id,
+  });
+
+  await expect(
+    createReimbursement({
+      ...reimbursementInput(),
+      signatureStorageId: "mobile-signature-key",
+      receipts: [],
+    }),
+  ).rejects.toThrow("Upload does not belong to the current user");
+});
+
+test("creation rejects a mobile signature claimed by a different token", async () => {
+  await registerPendingUpload("mismatched-mobile-signature", {
+    organizationId: orgA,
+    userId: userA,
+    contextType: "signatureToken",
+    contextId: "original-token-id",
+  });
+  await claimPendingUploads(
+    ["mismatched-mobile-signature"],
+    { organizationId: orgA, userId: userA },
+    ["signatureToken"],
+    { type: "signatureToken", id: "different-token-id" },
+  );
+
+  await expect(
+    createReimbursement({
+      ...reimbursementInput(),
+      signatureStorageId: "mismatched-mobile-signature",
+      receipts: [],
+    }),
+  ).rejects.toThrow("Upload does not belong to the current user");
 });
 
 test("travel PDF data includes travel details and the project name", async () => {
@@ -431,6 +532,9 @@ test("creation rejects a signature upload owned by another user", async () => {
     }),
   ).rejects.toThrow("Upload does not belong to the current user");
   expect(await (await reimbursements()).findOne({ amount: 50 })).toBeNull();
+  expect(
+    await (await uploadOwnerships()).findOne({ _id: "receipt-key" }),
+  ).not.toHaveProperty("claimedAt");
 });
 
 test("public links reject raw keys owned by another link", async () => {

--- a/app/lib/server/uploads/ownership.ts
+++ b/app/lib/server/uploads/ownership.ts
@@ -13,6 +13,8 @@ type UploadClaim = {
   id: string;
 };
 
+type UploadIdentity = Pick<UploadOwner, "organizationId" | "userId">;
+
 export async function registerPendingUpload(
   storageKey: string,
   owner: UploadOwner,
@@ -31,7 +33,7 @@ export async function registerPendingUpload(
 
 export async function claimPendingUploads(
   storageKeys: string[],
-  owner: Pick<UploadOwner, "organizationId" | "userId">,
+  owner: UploadIdentity,
   allowedContexts: UploadContextType[],
   claim: UploadClaim,
   contextId?: string,
@@ -67,24 +69,86 @@ export async function claimPendingUploads(
       claimedKeys.push(storageKey);
     }
   } catch (error) {
-    if (claimedKeys.length > 0) {
-      await (
-        await uploadOwnerships()
-      ).updateMany(
+    await releaseUploadsClaimedBy(claimedKeys, claim);
+    throw error;
+  }
+}
+
+async function releaseUploadsClaimedBy(
+  storageKeys: string[],
+  claim: UploadClaim,
+): Promise<void> {
+  if (storageKeys.length === 0) return;
+
+  await (
+    await uploadOwnerships()
+  ).updateMany(
+    {
+      _id: { $in: storageKeys },
+      claimedByType: claim.type,
+      claimedById: claim.id,
+    },
+    {
+      $unset: {
+        claimedByType: "",
+        claimedById: "",
+        claimedAt: "",
+      },
+    },
+  );
+}
+
+async function claimSubmissionSignature(
+  storageKey: string,
+  owner: UploadIdentity,
+  claim: UploadClaim,
+): Promise<void> {
+  const result = await (
+    await uploadOwnerships()
+  ).updateOne(
+    {
+      _id: storageKey,
+      organizationId: owner.organizationId,
+      userId: owner.userId,
+      $or: [
         {
-          _id: { $in: claimedKeys },
-          claimedByType: claim.type,
-          claimedById: claim.id,
+          contextType: "user",
+          claimedAt: { $exists: false },
         },
         {
-          $unset: {
-            claimedByType: "",
-            claimedById: "",
-            claimedAt: "",
-          },
+          contextType: "signatureToken",
+          claimedByType: "signatureToken",
+          $expr: { $eq: ["$claimedById", "$contextId"] },
         },
-      );
-    }
+      ],
+    },
+    {
+      $set: {
+        claimedByType: claim.type,
+        claimedById: claim.id,
+        claimedAt: Date.now(),
+      },
+    },
+  );
+
+  if (result.modifiedCount !== 1) {
+    throw new Error("Upload does not belong to the current user");
+  }
+}
+
+export async function claimUploadsForSubmission(
+  receiptStorageKeys: string[],
+  signatureStorageKey: string,
+  owner: UploadIdentity,
+  claim: UploadClaim,
+): Promise<void> {
+  const uniqueReceiptKeys = [...new Set(receiptStorageKeys)];
+  await claimPendingUploads(uniqueReceiptKeys, owner, ["user"], claim);
+
+  try {
+    await claimSubmissionSignature(signatureStorageKey, owner, claim);
+  } catch (error) {
+    await releaseUploadsClaimedBy(uniqueReceiptKeys, claim);
     throw error;
   }
 }

--- a/app/lib/server/volunteerAllowance/actions.ts
+++ b/app/lib/server/volunteerAllowance/actions.ts
@@ -9,7 +9,7 @@ import { deleteObject } from "../../s3/storage";
 import { volunteerAllowanceFields } from "../../volunteerAllowance/schemas";
 import { addLog } from "../logs";
 import { requireActiveOrganizationProject } from "../projects/access";
-import { claimPendingUploads } from "../uploads/ownership";
+import { claimUploadsForSubmission } from "../uploads/ownership";
 import { getSignatureUrl } from "./data";
 import { sendSubmissionReceivedEmail } from "./email";
 
@@ -40,10 +40,10 @@ export async function create(input: {
   await requireActiveOrganizationProject(args.projectId, user.organizationId);
 
   const _id = newId();
-  await claimPendingUploads(
-    [args.signatureStorageId],
+  await claimUploadsForSubmission(
+    [],
+    args.signatureStorageId,
     { organizationId: user.organizationId, userId: user._id },
-    ["user", "signatureToken"],
     { type: "allowance", id: _id },
   );
   await (

--- a/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
+++ b/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
@@ -19,7 +19,12 @@ vi.mock("./email", () => ({
 }));
 
 import { requireRole, requireUser } from "../../auth/session";
-import { users, volunteerAllowance } from "../../db/collections";
+import {
+  signatureTokens,
+  uploadOwnerships,
+  users,
+  volunteerAllowance,
+} from "../../db/collections";
 import { newId } from "../../db/ids";
 import { deleteObject } from "../../s3/storage";
 import {
@@ -28,6 +33,7 @@ import {
   insertTestProject,
 } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { submitPublicSignature } from "../signatures/public";
 import { registerPendingUpload } from "../uploads/ownership";
 import { create, remove } from "./actions";
 import { getAll, getSignatureUrl } from "./data";
@@ -210,6 +216,44 @@ test("create persists the allowance as pending", async () => {
   expect(doc?.status).toBe("pending");
   expect(doc?.organizationId).toBe(orgA);
   expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(id);
+});
+
+test("create transfers a completed mobile signature to the allowance", async () => {
+  const projectA = await insertProject();
+  const tokenId = newId();
+  const token = crypto.randomUUID();
+  await (
+    await signatureTokens()
+  ).insertOne({
+    _id: tokenId,
+    _creationTime: Date.now(),
+    token,
+    organizationId: orgA,
+    createdBy: userA,
+    expiresAt: Date.now() + 60_000,
+    pendingSignatureStorageId: "mobile-allowance-signature",
+  });
+  await registerPendingUpload("mobile-allowance-signature", {
+    organizationId: orgA,
+    userId: userA,
+    contextType: "signatureToken",
+    contextId: tokenId,
+  });
+  await submitPublicSignature(token);
+
+  const id = await create({
+    ...newAllowanceInput(projectA),
+    signatureStorageId: "mobile-allowance-signature",
+  });
+
+  expect(
+    await (
+      await uploadOwnerships()
+    ).findOne({ _id: "mobile-allowance-signature" }),
+  ).toMatchObject({
+    claimedByType: "allowance",
+    claimedById: id,
+  });
 });
 
 test("creating an emailed allowance request sends the request template", async () => {


### PR DESCRIPTION
## summary

- transfer completed mobile signature handoffs exactly once into reimbursements and volunteer allowances
- preserve owner and token validation, reject signature replay, and roll back receipt claims when submission fails

## validation

- `pnpm vitest run app/lib/server/reimbursements/reimbursements.test.ts app/lib/server/volunteerAllowance/volunteerAllowance.test.ts`
- `pnpm test`
- `pnpm exec biome lint <changed files>`
- `pnpm lint` (passed with three existing warnings)
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec prettier --check <changed files>`
- `pnpm build`
- not run: Playwright E2E (server-domain regression is covered by MongoDB integration tests)