### PR TITLE
feat(recruiting): add job posting action menu

### DIFF
--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { CreateJobPostingDialog } from "@/components/Dialogs/CreateJobPostingDialog";
+import { DeleteJobPostingDialog } from "@/components/JobPostings/DeleteJobPostingDialog";
+import { JobPostingActionsMenu } from "@/components/JobPostings/JobPostingActionsMenu";
 import { JobPostingStatusBadge } from "@/components/JobPostings/JobPostingStatusBadge";
 import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -12,16 +14,51 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPostingMutations";
 import { useJobPostings } from "@/lib/client/jobPostings/hooks/useJobPostings";
 import { useTeamDirectory } from "@/lib/client/teams/hooks/useTeamDirectory";
-import { Megaphone, Pencil, Plus } from "lucide-react";
+import type { JobPosting } from "@/lib/db/types";
+import { Megaphone, Plus } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import toast from "react-hot-toast";
 
 export function RecruitingClient() {
   const { jobPostings, isLoading } = useJobPostings();
   const { lookup } = useTeamDirectory();
+  const { archive, deletePosting } = useJobPostingMutations();
   const [createOpen, setCreateOpen] = useState(false);
+  const [postingToDelete, setPostingToDelete] = useState<JobPosting | null>(
+    null,
+  );
+
+  const handleArchive = async (posting: JobPosting) => {
+    try {
+      await archive.mutateAsync({ jobPostingId: posting._id });
+      toast.success("Ausschreibung archiviert");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Archivieren fehlgeschlagen",
+      );
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!postingToDelete) return;
+    try {
+      await deletePosting.mutateAsync({
+        jobPostingId: postingToDelete._id,
+      });
+      toast.success("Ausschreibung gelöscht");
+      setPostingToDelete(null);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Ausschreibung konnte nicht gelöscht werden",
+      );
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -71,13 +108,13 @@ export function RecruitingClient() {
                       <TableCell>
                         <JobPostingStatusBadge status={posting.status} />
                       </TableCell>
-                      <TableCell>
-                        <Button variant="ghost" size="sm" asChild>
-                          <Link href={`/recruiting/${posting._id}`}>
-                            <Pencil className="h-4 w-4" />
-                            Bearbeiten
-                          </Link>
-                        </Button>
+                      <TableCell className="text-right">
+                        <JobPostingActionsMenu
+                          posting={posting}
+                          disabled={archive.isPending || deletePosting.isPending}
+                          onArchive={() => void handleArchive(posting)}
+                          onDelete={() => setPostingToDelete(posting)}
+                        />
                       </TableCell>
                     </TableRow>
                   );
@@ -89,6 +126,15 @@ export function RecruitingClient() {
       </section>
 
       <CreateJobPostingDialog open={createOpen} onOpenChange={setCreateOpen} />
+      {postingToDelete ? (
+        <DeleteJobPostingDialog
+          postingTitle={postingToDelete.title}
+          open
+          isDeleting={deletePosting.isPending}
+          onOpenChange={(open) => !open && setPostingToDelete(null)}
+          onConfirm={handleDelete}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/(protected)/recruiting/[id]/JobPostingForm.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PageHeader } from "@/components/Layout/PageHeader";
+import { DeleteJobPostingDialog } from "@/components/JobPostings/DeleteJobPostingDialog";
 import { Button } from "@/components/ui/button";
 import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPostingMutations";
 import type { JobPosting } from "@/lib/db/types";
@@ -8,7 +9,8 @@ import {
   type JobPostingFormValues,
   toJobPostingForm,
 } from "@/lib/jobPostings/form";
-import { Loader2, Save, Send } from "lucide-react";
+import { Loader2, Save, Send, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { JobPostingApplications } from "./JobPostingApplications";
@@ -17,10 +19,12 @@ import { JobPostingContentFields } from "./JobPostingContentFields";
 import { JobPostingStatusActions } from "./JobPostingStatusActions";
 
 export function JobPostingForm({ posting }: { posting: JobPosting }) {
-  const { update, generateForm } = useJobPostingMutations();
+  const router = useRouter();
+  const { update, generateForm, deletePosting } = useJobPostingMutations();
   const [values, setValues] = useState<JobPostingFormValues>(() =>
     toJobPostingForm(posting),
   );
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [activeAction, setActiveAction] = useState<"save" | "publish" | null>(
     null,
   );
@@ -68,7 +72,22 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
     }
   };
 
-  const isBusy = activeAction !== null;
+  const handleDelete = async () => {
+    try {
+      await deletePosting.mutateAsync({ jobPostingId: posting._id });
+      toast.success("Ausschreibung gelöscht");
+      setDeleteDialogOpen(false);
+      router.replace("/recruiting");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Ausschreibung konnte nicht gelöscht werden",
+      );
+    }
+  };
+
+  const isBusy = activeAction !== null || deletePosting.isPending;
 
   return (
     <div className="space-y-6">
@@ -83,6 +102,15 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
           <JobPostingStatusActions posting={posting} />
         )}
         <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => setDeleteDialogOpen(true)}
+            disabled={isBusy}
+          >
+            <Trash2 className="size-4" />
+            Ausschreibung löschen
+          </Button>
           <Button
             variant={posting.status === "draft" ? "outline" : "primary"}
             onClick={handleSave}
@@ -121,6 +149,13 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
       )}
       <JobPostingBasicFields values={values} onChange={patch} />
       <JobPostingContentFields values={values} onChange={patch} />
+      <DeleteJobPostingDialog
+        postingTitle={posting.title}
+        open={deleteDialogOpen}
+        isDeleting={deletePosting.isPending}
+        onOpenChange={setDeleteDialogOpen}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/app/(protected)/settings/logs/page.tsx
+++ b/app/(protected)/settings/logs/page.tsx
@@ -41,6 +41,7 @@ const ACTION_LABELS: Record<string, string> = {
   "jobPosting.close": "Ausschreibung geschlossen",
   "jobPosting.reopen": "Ausschreibung wieder geöffnet",
   "jobPosting.archive": "Ausschreibung archiviert",
+  "jobPosting.delete": "Ausschreibung gelöscht",
   "jobPosting.tally.publish": "Bewerbungsformular veröffentlicht",
   "jobPosting.tally.error": "Tally-Synchronisierung fehlgeschlagen",
   "jobFeedToken.rotate": "Job-Feed-Token rotiert",

--- a/app/api/test/tally/[...path]/route.ts
+++ b/app/api/test/tally/[...path]/route.ts
@@ -49,3 +49,9 @@ export async function PATCH() {
   if (denied) return denied;
   return new Response(null, { status: 204 });
 }
+
+export async function DELETE() {
+  const denied = forbidden();
+  if (denied) return denied;
+  return new Response(null, { status: 204 });
+}

--- a/app/components/JobPostings/DeleteJobPostingDialog.tsx
+++ b/app/components/JobPostings/DeleteJobPostingDialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+
+export function DeleteJobPostingDialog({
+  postingTitle,
+  open,
+  isDeleting,
+  onOpenChange,
+  onConfirm,
+}: {
+  postingTitle: string;
+  open: boolean;
+  isDeleting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => !isDeleting && onOpenChange(nextOpen)}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Ausschreibung löschen?</AlertDialogTitle>
+          <AlertDialogDescription>
+            „{postingTitle}“ wird zusammen mit dem Tally-Formular, allen
+            Bewerbungen und Dateien dauerhaft gelöscht. Das lässt sich nicht
+            rückgängig machen.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            disabled={isDeleting}
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+          >
+            {isDeleting ? <Loader2 className="size-4 animate-spin" /> : null}
+            Endgültig löschen
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/components/JobPostings/JobPostingActionsMenu.tsx
+++ b/app/components/JobPostings/JobPostingActionsMenu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Archive, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { verticalActionMenuClassNames as menu } from "@/components/ui/vertical-action-menu";
+import type { JobPosting } from "@/lib/db/types";
+
+export function JobPostingActionsMenu({
+  posting,
+  disabled,
+  onArchive,
+  onDelete,
+}: {
+  posting: JobPosting;
+  disabled: boolean;
+  onArchive: () => void;
+  onDelete: () => void;
+}) {
+  const canArchive = posting.status !== "archived";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className={menu.trigger}
+          disabled={disabled}
+          aria-label={`Aktionen für ${posting.title} anzeigen`}
+          title="Aktionen anzeigen"
+        >
+          <MoreVertical />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={0} className={menu.content}>
+        <DropdownMenuItem className={menu.item} asChild>
+          <Link href={`/recruiting/${posting._id}`}>
+            <Pencil className="text-current" />
+            Bearbeiten
+          </Link>
+        </DropdownMenuItem>
+        {canArchive ? (
+          <DropdownMenuItem className={menu.item} onSelect={onArchive}>
+            <Archive className="text-current" />
+            Archivieren
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem
+          className={`${menu.item} ${menu.destructiveItem}`}
+          onSelect={onDelete}
+        >
+          <Trash2 className="text-current" />
+          Löschen
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/lib/client/jobPostings/hooks/useJobPostingMutations.ts
+++ b/app/lib/client/jobPostings/hooks/useJobPostingMutations.ts
@@ -8,6 +8,7 @@ import {
   reopenJobPosting,
   retryTallySync,
 } from "@/lib/server/jobPostings/lifecycle";
+import { deleteJobPosting } from "@/lib/server/jobPostings/deletion";
 import { generateTallyForm } from "@/lib/server/jobPostings/tallyForm";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -44,6 +45,10 @@ export function useJobPostingMutations() {
     retrySync: useMutation({
       mutationFn: retryTallySync,
       onSettled: invalidate,
+    }),
+    deletePosting: useMutation({
+      mutationFn: deleteJobPosting,
+      onSuccess: invalidate,
     }),
   };
 }

--- a/app/lib/server/jobPostings/access.ts
+++ b/app/lib/server/jobPostings/access.ts
@@ -5,8 +5,13 @@ export async function requireOwnedJobPosting(
   jobPostingId: string,
   organizationId: string,
 ): Promise<JobPosting> {
-  const posting = await (await jobPostings()).findOne({ _id: jobPostingId });
-  if (!posting || posting.organizationId !== organizationId) {
+  const posting = await (
+    await jobPostings()
+  ).findOne({
+    _id: jobPostingId,
+    organizationId,
+  });
+  if (!posting) {
     throw new Error("Access denied");
   }
   return posting;

--- a/app/lib/server/jobPostings/deletion.test.ts
+++ b/app/lib/server/jobPostings/deletion.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createConfiguredTallyClient: vi.fn(),
+  deleteForm: vi.fn(),
+  deleteObject: vi.fn(),
+  deleteWebhook: vi.fn(),
+}));
+
+vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
+vi.mock("../../s3/storage", () => ({
+  deleteObject: mocks.deleteObject,
+}));
+vi.mock("../tally/client", () => ({
+  createConfiguredTallyClient: mocks.createConfiguredTallyClient,
+}));
+
+import { requirePermission } from "../../auth/session";
+import {
+  applications,
+  jobPostings,
+  logs,
+  tallyWebhookEvents,
+} from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Application, JobPosting } from "../../db/types";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { deleteJobPosting } from "./deletion";
+
+let organizationId: string;
+let actorId: string;
+
+setupTestDatabase();
+
+async function insertPosting(
+  overrides: Partial<JobPosting> = {},
+): Promise<JobPosting> {
+  const posting: JobPosting = {
+    _id: newId(),
+    _creationTime: Date.now(),
+    organizationId,
+    teamId: newId(),
+    status: "published",
+    title: "Tech Lead",
+    createdBy: actorId,
+    ...overrides,
+  };
+  await (await jobPostings()).insertOne(posting);
+  return posting;
+}
+
+function application(jobPostingId: string): Application {
+  const id = newId();
+  return {
+    _id: id,
+    _creationTime: Date.now(),
+    organizationId,
+    jobPostingId,
+    status: "received",
+    applicantEmail: "alex@example.com",
+    applicantEmailNormalized: "alex@example.com",
+    fields: [],
+    files: [
+      {
+        _id: newId(),
+        fieldKey: "cv",
+        fieldLabel: "Lebenslauf",
+        sourceUrl: "https://example.com/cv.pdf",
+        fileName: "cv.pdf",
+        mimeType: "application/pdf",
+        size: 123,
+        status: "imported",
+        attempts: 1,
+        storageKey: "applications/cv.pdf",
+        updatedAt: Date.now(),
+      },
+    ],
+    tallyEventId: `event-${id}`,
+    tallySubmissionId: `submission-${id}`,
+    tallyResponseId: `response-${id}`,
+    tallyFormId: "form-1",
+    submittedAt: Date.now(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  organizationId = newId();
+  actorId = newId();
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({
+      _id: actorId,
+      organizationId,
+      role: "people_culture",
+    }),
+  );
+  mocks.createConfiguredTallyClient.mockReturnValue({
+    deleteForm: mocks.deleteForm,
+    deleteWebhook: mocks.deleteWebhook,
+  });
+  mocks.deleteForm.mockResolvedValue(undefined);
+  mocks.deleteObject.mockResolvedValue(undefined);
+  mocks.deleteWebhook.mockResolvedValue(undefined);
+});
+
+test("deletes the posting, Tally sync, applications, and files", async () => {
+  const posting = await insertPosting({
+    tallyFormId: "form-1",
+    tallyWebhookId: "webhook-1",
+  });
+  const record = application(posting._id);
+  await (await applications()).insertOne(record);
+  const foreignEventId = newId();
+  await (
+    await tallyWebhookEvents()
+  ).insertOne({
+    _id: record.tallyEventId,
+    _creationTime: Date.now(),
+    eventType: "FORM_RESPONSE",
+    submissionId: record.tallySubmissionId,
+    status: "processed",
+    jobPostingId: posting._id,
+    applicationId: record._id,
+  });
+  await (
+    await tallyWebhookEvents()
+  ).insertOne({
+    _id: foreignEventId,
+    _creationTime: Date.now(),
+    eventType: "FORM_RESPONSE",
+    submissionId: `foreign-${record.tallySubmissionId}`,
+    status: "processed",
+    organizationId: newId(),
+    jobPostingId: posting._id,
+  });
+
+  await deleteJobPosting({ jobPostingId: posting._id });
+
+  expect(mocks.deleteWebhook).toHaveBeenCalledWith("webhook-1");
+  expect(mocks.deleteForm).toHaveBeenCalledWith("form-1");
+  expect(mocks.deleteWebhook.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.deleteForm.mock.invocationCallOrder[0],
+  );
+  expect(mocks.deleteObject).toHaveBeenCalledWith("applications/cv.pdf");
+  expect(await (await jobPostings()).findOne({ _id: posting._id })).toBeNull();
+  expect(await (await applications()).findOne({ _id: record._id })).toBeNull();
+  expect(
+    await (await tallyWebhookEvents()).findOne({ applicationId: record._id }),
+  ).toBeNull();
+  expect(
+    await (await tallyWebhookEvents()).findOne({ _id: foreignEventId }),
+  ).not.toBeNull();
+  expect(await (await logs()).findOne({ entityId: posting._id })).toMatchObject(
+    {
+      action: "jobPosting.delete",
+      userId: actorId,
+    },
+  );
+});
+
+test("deletes an unsynced draft without creating a Tally client", async () => {
+  const posting = await insertPosting({ status: "draft" });
+
+  await deleteJobPosting({ jobPostingId: posting._id });
+
+  expect(mocks.createConfiguredTallyClient).not.toHaveBeenCalled();
+  expect(await (await jobPostings()).findOne({ _id: posting._id })).toBeNull();
+});
+
+test("keeps local data when removing the Tally sync fails", async () => {
+  const posting = await insertPosting({
+    tallyFormId: "form-1",
+    tallyWebhookId: "webhook-1",
+  });
+  const record = application(posting._id);
+  await (await applications()).insertOne(record);
+  mocks.deleteForm.mockRejectedValue(new Error("Tally down"));
+
+  await expect(deleteJobPosting({ jobPostingId: posting._id })).rejects.toThrow(
+    "Tally down",
+  );
+
+  expect(
+    await (await jobPostings()).findOne({ _id: posting._id }),
+  ).not.toBeNull();
+  expect(
+    await (await applications()).findOne({ _id: record._id }),
+  ).not.toBeNull();
+  expect(mocks.deleteObject).not.toHaveBeenCalled();
+});
+
+test("cannot delete a posting from another organization", async () => {
+  const posting = await insertPosting({ organizationId: newId() });
+
+  await expect(deleteJobPosting({ jobPostingId: posting._id })).rejects.toThrow(
+    "Access denied",
+  );
+
+  expect(
+    await (await jobPostings()).findOne({ _id: posting._id }),
+  ).not.toBeNull();
+  expect(mocks.createConfiguredTallyClient).not.toHaveBeenCalled();
+});

--- a/app/lib/server/jobPostings/deletion.ts
+++ b/app/lib/server/jobPostings/deletion.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { z } from "zod";
+import { USER_PERMISSIONS } from "../../auth/roles";
+import { requirePermission } from "../../auth/session";
+import {
+  applications,
+  jobPostings,
+  tallyWebhookEvents,
+} from "../../db/collections";
+import { deleteObject } from "../../s3/storage";
+import { addLog } from "../logs";
+import { createConfiguredTallyClient } from "../tally/client";
+import { applicationFileStorageKey } from "../applications/fileStorage";
+import { requireOwnedJobPosting } from "./access";
+
+export async function deleteJobPosting(input: {
+  jobPostingId: string;
+}): Promise<void> {
+  const { jobPostingId } = z
+    .object({ jobPostingId: z.string().min(1) })
+    .parse(input);
+  const user = await requirePermission(USER_PERMISSIONS.recruiting);
+  const posting = await requireOwnedJobPosting(
+    jobPostingId,
+    user.organizationId,
+  );
+  const applicationRecords = await (
+    await applications()
+  )
+    .find({
+      organizationId: user.organizationId,
+      jobPostingId: posting._id,
+    })
+    .toArray();
+
+  if (posting.tallyWebhookId || posting.tallyFormId) {
+    const tally = createConfiguredTallyClient();
+    if (posting.tallyWebhookId) {
+      await tally.deleteWebhook(posting.tallyWebhookId);
+    }
+    if (posting.tallyFormId) {
+      await tally.deleteForm(posting.tallyFormId);
+    }
+  }
+
+  const storageKeys = new Set(
+    applicationRecords.flatMap((application) =>
+      application.files.map(
+        (file) =>
+          file.storageKey ?? applicationFileStorageKey(application._id, file),
+      ),
+    ),
+  );
+  await Promise.all([...storageKeys].map((key) => deleteObject(key)));
+
+  const applicationIds = applicationRecords.map(({ _id }) => _id);
+  await Promise.all([
+    (await applications()).deleteMany({
+      organizationId: user.organizationId,
+      jobPostingId: posting._id,
+    }),
+    (await tallyWebhookEvents()).deleteMany({
+      $and: [
+        {
+          $or: [
+            { organizationId: user.organizationId },
+            { organizationId: { $exists: false } },
+          ],
+        },
+        {
+          $or: [
+            { jobPostingId: posting._id },
+            { applicationId: { $in: applicationIds } },
+          ],
+        },
+      ],
+    }),
+  ]);
+
+  const result = await (
+    await jobPostings()
+  ).deleteOne({
+    _id: posting._id,
+    organizationId: user.organizationId,
+  });
+  if (result.deletedCount !== 1) {
+    throw new Error("Ausschreibung nicht gefunden");
+  }
+
+  await addLog(
+    user.organizationId,
+    user._id,
+    "jobPosting.delete",
+    posting._id,
+    posting.title,
+  );
+}

--- a/app/lib/server/jobPostings/lifecycle.test.ts
+++ b/app/lib/server/jobPostings/lifecycle.test.ts
@@ -158,6 +158,18 @@ test("archiveJobPosting archives and closes the form", async () => {
   });
 });
 
+test("archiveJobPosting also archives a draft", async () => {
+  const client = fakeClient();
+  const id = await insertPosting(orgA, { status: "draft" });
+
+  await archiveJobPosting({ jobPostingId: id });
+
+  expect((await read(id)).status).toBe("archived");
+  expect(client.updateForm).toHaveBeenCalledWith("form-1", {
+    settings: { isClosed: true },
+  });
+});
+
 test("a Tally sync failure is recorded, visible, and retryable idempotently", async () => {
   const updateForm = vi
     .fn()

--- a/app/lib/server/jobPostings/lifecycle.ts
+++ b/app/lib/server/jobPostings/lifecycle.ts
@@ -49,9 +49,7 @@ export async function reopenJobPosting(input: {
     );
   }
   if (isDeadlinePassed(posting.deadline, berlinToday())) {
-    throw new Error(
-      "Die Frist liegt in der Vergangenheit",
-    );
+    throw new Error("Die Frist liegt in der Vergangenheit");
   }
   const result = await applyStatusTransition({
     posting,
@@ -67,10 +65,8 @@ export async function archiveJobPosting(input: {
   jobPostingId: string;
 }): Promise<void> {
   const { user, posting } = await loadOwnedForAction(input);
-  if (posting.status !== "published" && posting.status !== "closed") {
-    throw new Error(
-      "Nur veröffentlichte oder geschlossene Ausschreibungen können archiviert werden",
-    );
+  if (posting.status === "archived") {
+    throw new Error("Die Ausschreibung ist bereits archiviert");
   }
   const result = await applyStatusTransition({
     posting,

--- a/app/lib/tally/client.test.ts
+++ b/app/lib/tally/client.test.ts
@@ -204,6 +204,39 @@ test("creates a signed FORM_RESPONSE webhook", async () => {
   });
 });
 
+test("deletes a webhook and form without a request body", async () => {
+  const fetcher = vi.fn(
+    async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(null, { status: 204 }),
+  );
+  const client = createTallyClient("token", fetcher as unknown as typeof fetch);
+
+  await client.deleteWebhook("webhook-1");
+  await client.deleteForm("form-1");
+
+  expect(fetcher.mock.calls).toHaveLength(2);
+  expect(fetcher.mock.calls[0][0]).toBe(
+    "https://api.tally.so/webhooks/webhook-1",
+  );
+  expect(fetcher.mock.calls[1][0]).toBe("https://api.tally.so/forms/form-1");
+  for (const [, init] of fetcher.mock.calls) {
+    expect(init?.method).toBe("DELETE");
+    expect(init?.body).toBeUndefined();
+    expect(new Headers(init?.headers).has("content-type")).toBe(false);
+  }
+});
+
+test("treats already deleted Tally resources as deleted", async () => {
+  const fetcher = vi.fn(
+    async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(null, { status: 404 }),
+  );
+  const client = createTallyClient("token", fetcher as unknown as typeof fetch);
+
+  await expect(client.deleteWebhook("missing")).resolves.toBeUndefined();
+  await expect(client.deleteForm("missing")).resolves.toBeUndefined();
+});
+
 test("reads a form with its blocks and settings", async () => {
   const fetcher = recordingFetch({
     id: "form-1",

--- a/app/lib/tally/client.ts
+++ b/app/lib/tally/client.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { tallyApiError } from "./apiError";
-import { TALLY_API_VERSION } from "./constants";
+import { createTallyRequest, TALLY_API_URL } from "./transport";
 import type {
   TallyBlock,
   TallyForm,
@@ -12,7 +11,6 @@ import type {
 
 type FormPatch = Partial<Pick<TallyForm, "blocks" | "settings" | "status">>;
 
-const TALLY_API_URL = "https://api.tally.so";
 const MAX_PAGES = 50;
 const itemSchema = z.object({ id: z.string(), name: z.string() });
 const formSchema = itemSchema.extend({
@@ -77,28 +75,7 @@ export function createTallyClient(
 ) {
   if (!apiToken) throw new Error("Tally API token is required");
 
-  async function request(
-    path: string,
-    init?: { method: string; body: unknown },
-  ): Promise<unknown> {
-    const response = await fetcher(`${apiUrl}${path}`, {
-      method: init?.method ?? "GET",
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        Accept: "application/json",
-        "tally-version": TALLY_API_VERSION,
-        ...(init ? { "Content-Type": "application/json" } : {}),
-      },
-      body: init ? JSON.stringify(init.body) : undefined,
-      cache: "no-store",
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) {
-      throw await tallyApiError(response);
-    }
-    if (response.status === 204) return {};
-    return response.json();
-  }
+  const request = createTallyRequest(apiToken, fetcher, apiUrl);
 
   async function listPages<T>(
     path: string,
@@ -192,5 +169,13 @@ export function createTallyClient(
     publishForm: (formId: string) =>
       updateForm(formId, { status: "PUBLISHED" }),
     createWebhook,
+    deleteForm: (formId: string) =>
+      request(`/forms/${formId}`, { method: "DELETE" }, true).then(
+        () => undefined,
+      ),
+    deleteWebhook: (webhookId: string) =>
+      request(`/webhooks/${webhookId}`, { method: "DELETE" }, true).then(
+        () => undefined,
+      ),
   };
 }

--- a/app/lib/tally/transport.ts
+++ b/app/lib/tally/transport.ts
@@ -1,0 +1,34 @@
+import { tallyApiError } from "./apiError";
+import { TALLY_API_VERSION } from "./constants";
+
+export const TALLY_API_URL = "https://api.tally.so";
+
+export function createTallyRequest(
+  apiToken: string,
+  fetcher: typeof fetch,
+  apiUrl: string,
+) {
+  return async function request(
+    path: string,
+    init?: { method: string; body?: unknown },
+    ignoreNotFound = false,
+  ): Promise<unknown> {
+    const hasBody = init?.body !== undefined;
+    const response = await fetcher(`${apiUrl}${path}`, {
+      method: init?.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Accept: "application/json",
+        "tally-version": TALLY_API_VERSION,
+        ...(hasBody ? { "Content-Type": "application/json" } : {}),
+      },
+      body: hasBody ? JSON.stringify(init.body) : undefined,
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (ignoreNotFound && response.status === 404) return {};
+    if (!response.ok) throw await tallyApiError(response);
+    if (response.status === 204) return {};
+    return response.json();
+  };
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -13,17 +13,32 @@ const envFiles = [
 ];
 dotenv.config({ path: envFiles, processEnv: env, quiet: true });
 
-const nextArgs = process.argv.slice(2);
+function withoutPortArguments(args) {
+  const filtered = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--port" || arg === "-p") {
+      index += 1;
+      continue;
+    }
+    if (
+      arg.startsWith("--port=") ||
+      arg.startsWith("-p=") ||
+      /^-p\d+$/.test(arg)
+    ) {
+      continue;
+    }
+    filtered.push(arg);
+  }
+  return filtered;
+}
+
+const nextArgs = withoutPortArguments(process.argv.slice(2));
 let mongo;
 
-if (
-  env.CONDUCTOR_PORT &&
-  !nextArgs.some(
-    (arg) => arg === "--port" || arg === "-p" || arg.startsWith("--port="),
-  )
-) {
-  nextArgs.push("--port", env.CONDUCTOR_PORT);
-}
+const localUrl = "http://localhost:3000";
+if (!env.AUTH_URL && !env.NEXTAUTH_URL) env.AUTH_URL = localUrl;
+if (!env.NEXT_PUBLIC_APP_URL) env.NEXT_PUBLIC_APP_URL = localUrl;
 
 const shouldStartTemporaryDatabase =
   !env.MONGODB_URI || (env.IS_TEST === "true" && !hasExplicitMongoUri);
@@ -38,7 +53,7 @@ if (shouldStartTemporaryDatabase) {
 
 const next = spawn(
   "pnpm",
-  ["exec", "next", "dev", "--turbopack", ...nextArgs],
+  ["exec", "next", "dev", "--turbopack", "--port", "3000", ...nextArgs],
   {
     env,
     stdio: "inherit",


### PR DESCRIPTION
## Summary
- Replaces the recruiting edit button with a three-dot menu for editing, archiving, and deleting job postings.
- Cascades deletion to linked Tally resources, applications, stored files, and webhook events with tenant checks and audit logging.
- Allows drafts to be archived and pins local development to port 3000 for a stable Google OAuth callback.

## Validation
- `pnpm vitest run` — 355 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `NEXT_DIST_DIR=.context/next-build pnpm build`