### PR TITLE
chore: sync application list controls to stage

### DIFF
--- a/app/components/Applications/ApplicationManagement.tsx
+++ b/app/components/Applications/ApplicationManagement.tsx
@@ -24,7 +24,7 @@ export function ApplicationManagement({
         applicationId: application._id,
         ownerIds: nextOwnerIds,
       });
-      toast.success("Verantwortliche aktualisiert");
+      toast.success("Interne Zuständigkeit aktualisiert");
     } catch (error) {
       setOwnerIds(previousOwnerIds);
       toast.error(
@@ -35,13 +35,13 @@ export function ApplicationManagement({
 
   return (
     <section className="space-y-3 border-t pt-5">
-      <h3 className="text-xl font-semibold">Verantwortliche</h3>
+      <h3 className="text-xl font-semibold">Interne Zuständigkeit</h3>
       <SelectMembers
         id="application-owners"
         members={owners}
         value={ownerIds}
         onValueChange={updateOwners}
-        placeholder="Verantwortliche auswählen"
+        placeholder="Zuständige Personen auswählen"
         searchPlaceholder="Name oder E-Mail suchen"
         disabled={updateManagement.isPending}
       />

--- a/app/components/Applications/ApplicationsPanel.tsx
+++ b/app/components/Applications/ApplicationsPanel.tsx
@@ -42,6 +42,7 @@ export function ApplicationsPanel({ jobPostingId }: Props) {
       <ApplicationsToolbar
         filters={filters}
         owners={owners}
+        showOwnerFilter={!jobPostingId}
         onChange={(patch) =>
           setFilters((current) => ({ ...current, ...patch }))
         }
@@ -51,13 +52,6 @@ export function ApplicationsPanel({ jobPostingId }: Props) {
         ownersById={ownersById}
         isLoading={isLoading}
         showJobPosting={!jobPostingId}
-        sortDirection={filters.sortDirection}
-        onSort={() =>
-          setFilters((current) => ({
-            ...current,
-            sortDirection: current.sortDirection === "desc" ? "asc" : "desc",
-          }))
-        }
         onSelect={(application: ApplicationWithFiles) =>
           router.push(`/applications/${application._id}`)
         }

--- a/app/components/Applications/ApplicationsTable.tsx
+++ b/app/components/Applications/ApplicationsTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { ArrowDown, ArrowUp, Inbox } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Inbox } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -23,8 +22,6 @@ interface Props {
   ownersById: Map<string, User>;
   isLoading: boolean;
   showJobPosting: boolean;
-  sortDirection: "asc" | "desc";
-  onSort: () => void;
   onSelect: (application: ApplicationWithFiles) => void;
 }
 
@@ -33,8 +30,6 @@ export function ApplicationsTable({
   ownersById,
   isLoading,
   showJobPosting,
-  sortDirection,
-  onSort,
   onSelect,
 }: Props) {
   if (!isLoading && applications.length === 0) {
@@ -57,13 +52,8 @@ export function ApplicationsTable({
             <TableHead className="pl-4">Bewerber:in</TableHead>
             {showJobPosting ? <TableHead>Ausschreibung</TableHead> : null}
             <TableHead>Status</TableHead>
-            <TableHead>Verantwortlich</TableHead>
-            <TableHead className="pr-4">
-              <Button variant="ghost" size="sm" onClick={onSort}>
-                Eingang
-                {sortDirection === "desc" ? <ArrowDown /> : <ArrowUp />}
-              </Button>
-            </TableHead>
+            <TableHead>Zuständig</TableHead>
+            <TableHead className="pr-4">Eingang</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/app/components/Applications/ApplicationsToolbar.tsx
+++ b/app/components/Applications/ApplicationsToolbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/select";
 import { APPLICATION_STATUS_LABELS } from "@/lib/applications/status";
 import type { ApplicationStatus, User } from "@/lib/db/types";
+import { cn } from "@/lib/utils";
 import { ALL_APPLICATIONS, type ApplicationFilters } from "./applicationTable";
 
 const STATUSES = Object.entries(APPLICATION_STATUS_LABELS) as [
@@ -21,10 +22,16 @@ const STATUSES = Object.entries(APPLICATION_STATUS_LABELS) as [
 interface Props {
   filters: ApplicationFilters;
   owners: User[];
+  showOwnerFilter: boolean;
   onChange: (patch: Partial<ApplicationFilters>) => void;
 }
 
-export function ApplicationsToolbar({ filters, owners, onChange }: Props) {
+export function ApplicationsToolbar({
+  filters,
+  owners,
+  showOwnerFilter,
+  onChange,
+}: Props) {
   const ownerOptions = owners.map((owner) => ({
     value: owner._id,
     label: owner.name || owner.email || "Unbenannt",
@@ -33,7 +40,14 @@ export function ApplicationsToolbar({ filters, owners, onChange }: Props) {
   }));
 
   return (
-    <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(9rem,12rem)_minmax(10rem,14rem)]">
+    <div
+      className={cn(
+        "grid gap-2",
+        showOwnerFilter
+          ? "md:grid-cols-[minmax(0,1fr)_minmax(8rem,11rem)_minmax(9rem,13rem)_minmax(10rem,12rem)]"
+          : "md:grid-cols-[minmax(0,1fr)_minmax(9rem,12rem)_minmax(10rem,12rem)]",
+      )}
+    >
       <Input
         value={filters.search}
         onChange={(e) => onChange({ search: e.target.value })}
@@ -59,16 +73,34 @@ export function ApplicationsToolbar({ filters, owners, onChange }: Props) {
           ))}
         </SelectContent>
       </Select>
-      <MultiSelect
-        value={filters.ownerIds}
-        onValueChange={(ownerIds) => onChange({ ownerIds })}
-        options={ownerOptions}
-        placeholder="Verantwortlich"
-        searchPlaceholder="Person suchen …"
-        renderValue={(selected, count) =>
-          count === 1 ? selected[0]?.label : `${count} Verantwortliche`
+      {showOwnerFilter ? (
+        <MultiSelect
+          value={filters.ownerIds}
+          onValueChange={(ownerIds) => onChange({ ownerIds })}
+          options={ownerOptions}
+          placeholder="Zuständig"
+          searchPlaceholder="Person suchen …"
+          renderValue={(selected, count) =>
+            count === 1 ? selected[0]?.label : `${count} Zuständige`
+          }
+        />
+      ) : null}
+      <Select
+        value={filters.sortDirection}
+        onValueChange={(sortDirection) =>
+          onChange({
+            sortDirection: sortDirection as ApplicationFilters["sortDirection"],
+          })
         }
-      />
+      >
+        <SelectTrigger aria-label="Nach Eingang sortieren" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="desc">Neueste zuerst</SelectItem>
+          <SelectItem value="asc">Älteste zuerst</SelectItem>
+        </SelectContent>
+      </Select>
     </div>
   );
 }


### PR DESCRIPTION
## summary

- sync the latest application list controls from `main` to `develop`
- update stage with the renamed responsibility label and explicit sort filter

## validation

- `pnpm vitest run app/components/Applications/applicationTable.test.ts`
- `pnpm exec biome lint app/components/Applications/ApplicationManagement.tsx app/components/Applications/ApplicationsPanel.tsx app/components/Applications/ApplicationsTable.tsx app/components/Applications/ApplicationsToolbar.tsx`
- `pnpm exec tsc --noEmit`
- GitHub checks on #183: unit and CodeQL passed
