### PR TITLE
feat(recruiting): show application activity in posting view

### DIFF
--- a/app/components/Applications/ApplicationsTable.tsx
+++ b/app/components/Applications/ApplicationsTable.tsx
@@ -52,7 +52,9 @@ export function ApplicationsTable({
             <TableHead className="pl-4">Bewerber:in</TableHead>
             {showJobPosting ? <TableHead>Ausschreibung</TableHead> : null}
             <TableHead>Status</TableHead>
-            <TableHead>Zuständig</TableHead>
+            <TableHead>
+              {showJobPosting ? "Zuständig" : "Letzte Aktivität"}
+            </TableHead>
             <TableHead className="pr-4">Eingang</TableHead>
           </TableRow>
         </TableHeader>
@@ -103,9 +105,17 @@ export function ApplicationsTable({
                 <TableCell>
                   <ApplicationStatusBadge status={application.status} />
                 </TableCell>
-                <TableCell className="max-w-56 truncate">
-                  {responsibilityLabel}
-                </TableCell>
+                {showJobPosting ? (
+                  <TableCell className="max-w-56 truncate">
+                    {responsibilityLabel}
+                  </TableCell>
+                ) : (
+                  <TableCell className="text-muted-foreground">
+                    {DATE_FORMAT.format(
+                      application.updatedAt ?? application.submittedAt,
+                    )}
+                  </TableCell>
+                )}
                 <TableCell className="pr-4 text-muted-foreground">
                   {DATE_FORMAT.format(application.submittedAt)}
                 </TableCell>


### PR DESCRIPTION
## summary

- keep the responsibility column in the cross-posting application overview
- show the last application activity instead in a posting-specific application list
- fall back to the submission timestamp when an application has not changed yet

## validation

- `pnpm exec biome lint app/components/Applications/ApplicationsTable.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/components/Applications/applicationTable.test.ts`
- `pnpm lint:lines`
