### PR TITLE
fix(recruiting): surface application decision errors

### DIFF
--- a/app/components/Applications/ApplicationDecisionDialog.tsx
+++ b/app/components/Applications/ApplicationDecisionDialog.tsx
@@ -70,6 +70,7 @@ function WorkspaceEmailField({
           type="button"
           variant="outline"
           size="icon"
+          className="h-auto"
           disabled={isSending}
           aria-label={
             isUnlocked ? "YFN-E-Mail sperren" : "YFN-E-Mail bearbeiten"
@@ -77,9 +78,9 @@ function WorkspaceEmailField({
           onClick={() => setIsUnlocked((value) => !value)}
         >
           {isUnlocked ? (
-            <Lock aria-hidden="true" />
+            <Lock className="size-5" aria-hidden="true" />
           ) : (
-            <Unlock aria-hidden="true" />
+            <Unlock className="size-5" aria-hidden="true" />
           )}
         </Button>
       </div>
@@ -103,9 +104,9 @@ export function ApplicationDecisionDialog({
           <DialogTitle>
             {accepts ? "Zusage senden" : "Absage versenden"}
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className={accepts ? "sr-only" : undefined}>
             {accepts
-              ? "Prüfe die YFN-E-Mail. Das Workspace-Konto wird vor dem Versand erstellt."
+              ? "Zusage mit neuer YFN-E-Mail senden."
               : "Prüfe Betreff und Nachricht. Der Status ändert sich erst nach dem Versand."}
           </DialogDescription>
         </DialogHeader>

--- a/app/lib/client/applications/hooks/useApplicationMutations.ts
+++ b/app/lib/client/applications/hooks/useApplicationMutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { sendApplicationDecision } from "@/lib/server/applications/decision";
+import { submitApplicationDecision } from "@/lib/server/applications/decisionAction";
 import { updateApplicationManagement } from "@/lib/server/applications/management";
 import {
   setApplicationOnboardingCompleted,
@@ -22,7 +22,12 @@ export function useApplicationMutations() {
       onSuccess: invalidate,
     }),
     sendDecision: useMutation({
-      mutationFn: sendApplicationDecision,
+      mutationFn: async (
+        input: Parameters<typeof submitApplicationDecision>[0],
+      ) => {
+        const result = await submitApplicationDecision(input);
+        if (!result.ok) throw new Error(result.error);
+      },
       onSuccess: invalidate,
     }),
     setYfnEmail: useMutation({

--- a/app/lib/googleWorkspace/users.test.ts
+++ b/app/lib/googleWorkspace/users.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   provisionWorkspaceUser,
   type WorkspaceDirectory,
@@ -12,6 +12,8 @@ const input = {
   givenName: "Alex",
   familyName: "Beispiel",
 };
+
+afterEach(() => vi.unstubAllEnvs());
 
 function directory(overrides: Partial<WorkspaceDirectory> = {}) {
   const created: WorkspaceUser = {
@@ -82,5 +84,13 @@ describe("provisionWorkspaceUser", () => {
       "bereits vergeben",
     );
     expect(workspace.resetPassword).not.toHaveBeenCalled();
+  });
+
+  test("reports a missing Workspace configuration", async () => {
+    vi.stubEnv("GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON_BASE64", "");
+
+    await expect(provisionWorkspaceUser(input)).rejects.toThrow(
+      "Google-Workspace-Integration ist nicht konfiguriert",
+    );
   });
 });

--- a/app/lib/googleWorkspace/users.ts
+++ b/app/lib/googleWorkspace/users.ts
@@ -2,6 +2,12 @@ import { randomBytes } from "node:crypto";
 import { WorkspaceApiError, workspaceRequest } from "./client";
 
 const APPLICATION_ID_TYPE = "ybase_application_id";
+const DISPLAYABLE_WORKSPACE_ERRORS = new Set([
+  "Google-Workspace-Integration ist nicht konfiguriert",
+  "Google-Workspace-Konfiguration ist ungültig",
+  "Google-Workspace-Authentifizierung fehlgeschlagen",
+  "Google hat kein Zugriffstoken zurückgegeben",
+]);
 
 export type WorkspaceUser = {
   id: string;
@@ -148,6 +154,12 @@ function createTemporaryPassword(): string {
 }
 
 function workspaceApiError(error: unknown): Error {
+  if (
+    error instanceof Error &&
+    DISPLAYABLE_WORKSPACE_ERRORS.has(error.message)
+  ) {
+    return error;
+  }
   if (error instanceof WorkspaceApiError && error.status === 409) {
     return new Error("Diese Workspace-E-Mail ist bereits vergeben");
   }

--- a/app/lib/server/applications/decision.ts
+++ b/app/lib/server/applications/decision.ts
@@ -1,67 +1,28 @@
 "use server";
 
-import { z } from "zod";
-import { appendWorkspaceAccessDetails } from "../../applications/decisionEmail";
 import { APPLICATION_STATUS_LABELS } from "../../applications/status";
+import type { ApplicationDecision } from "../../applications/decisionEmail";
 import { isApplicationStatusTransitionAllowed } from "../../applications/transitions";
 import { applications, jobPostings } from "../../db/collections";
-import { sendMail } from "../../email/brevo";
-import { BREVO_TEMPLATE_IDS } from "../../email/templates";
-import { provisionWorkspaceUser } from "../../googleWorkspace/users";
-import { YFN_ORGANIZATION } from "../../organization";
+import type { Application } from "../../db/types";
 import { addLog } from "../logs";
 import { loadOwnedApplication } from "./access";
-import { createApplicationHistoryEntry } from "./history";
+import { prepareAcceptance, sendDecisionEmail } from "./decisionDelivery";
 import {
-  recordWorkspaceDeliveryFailure,
-  recordWorkspaceProvisioned,
-  recordWorkspaceProvisioningFailure,
-  reserveWorkspaceProvisioning,
-  workspaceApplicantName,
-  ybaseLoginUrl,
-} from "./workspaceProvisioning";
-
-const messageSchema = {
-  applicationId: z.string().min(1),
-  subject: z.string().trim().min(1).max(200),
-  message: z.string().trim().min(1).max(10_000),
-};
-
-const inputSchema = z.discriminatedUnion("decision", [
-  z.object({
-    ...messageSchema,
-    decision: z.literal("accepted"),
-    yfnEmail: z.string().trim().email().max(320),
-  }),
-  z.object({
-    ...messageSchema,
-    decision: z.literal("rejected"),
-  }),
-]);
-
-const templateIds = {
-  accepted: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
-  rejected: BREVO_TEMPLATE_IDS.APPLICATION_REJECTED,
-};
+  applicationDecisionInputSchema,
+  type ApplicationDecisionInput,
+  type ParsedApplicationDecision,
+} from "./decisionInput";
+import { createApplicationHistoryEntry } from "./history";
 
 export async function sendApplicationDecision(
-  input: z.input<typeof inputSchema>,
+  input: ApplicationDecisionInput,
 ): Promise<void> {
-  const parsed = inputSchema.parse(input);
+  const decision = applicationDecisionInputSchema.parse(input);
   const { user, application } = await loadOwnedApplication(
-    parsed.applicationId,
+    decision.applicationId,
   );
-  if (
-    !isApplicationStatusTransitionAllowed(application.status, parsed.decision)
-  ) {
-    throw new Error("Dieser Statuswechsel ist nicht zulässig");
-  }
-  const isProvisioning =
-    application.workspaceProvisioningStatus === "pending" ||
-    application.workspaceProvisioningStatus === "provisioned";
-  if (parsed.decision === "rejected" && isProvisioning) {
-    throw new Error("Das Workspace-Konto wird bereits eingerichtet");
-  }
+  assertDecisionAllowed(application, decision.decision);
 
   const posting = await (
     await jobPostings()
@@ -71,106 +32,85 @@ export async function sendApplicationDecision(
   });
   if (!posting) throw new Error("Ausschreibung nicht gefunden");
 
-  let message = parsed.message;
-  let workspaceUserId: string | undefined;
-  if (parsed.decision === "accepted") {
-    const loginUrl = ybaseLoginUrl();
-    const reservation = await reserveWorkspaceProvisioning({
-      application,
-      organizationDomain: YFN_ORGANIZATION.domain,
-      yfnEmail: parsed.yfnEmail,
-    });
-    try {
-      const account = await provisionWorkspaceUser({
-        applicationId: application._id,
-        existingUserId: reservation.existingWorkspaceUserId,
-        primaryEmail: reservation.yfnEmail,
-        recoveryEmail: application.applicantEmail,
-        ...workspaceApplicantName(application),
-      });
-      workspaceUserId = account.userId;
-      await recordWorkspaceProvisioned({
-        applicationId: application._id,
-        organizationId: user.organizationId,
-        workspaceUserId,
-      });
-      message = appendWorkspaceAccessDetails({
-        message,
-        primaryEmail: account.primaryEmail,
-        temporaryPassword: account.temporaryPassword,
-        loginUrl,
-      });
-    } catch (error) {
-      await recordWorkspaceProvisioningFailure({
-        applicationId: application._id,
-        organizationId: user.organizationId,
-        error,
-      });
-      throw error;
-    }
-  }
+  const prepared =
+    decision.decision === "accepted"
+      ? await prepareAcceptance({
+          application,
+          organizationId: user.organizationId,
+          message: decision.message,
+          yfnEmail: decision.yfnEmail,
+        })
+      : { message: decision.message, workspaceUserId: undefined };
 
-  let delivery: Awaited<ReturnType<typeof sendMail>>;
-  try {
-    delivery = await sendMail({
-      to: [
-        { email: application.applicantEmail, name: application.applicantName },
-      ],
-      templateId: templateIds[parsed.decision],
-      subject: parsed.subject,
-      params: {
-        applicantName: application.applicantName ?? "",
-        jobTitle: posting.title,
-        organizationName: YFN_ORGANIZATION.name,
-        message,
-      },
-      tags: ["ybase", "application", `application-${parsed.decision}`],
-    });
-  } catch (error) {
-    if (workspaceUserId) {
-      await recordWorkspaceDeliveryFailure({
-        applicationId: application._id,
-        organizationId: user.organizationId,
-      });
-    }
-    throw error;
-  }
-  if (delivery.status !== "sent") {
-    if (workspaceUserId) {
-      await recordWorkspaceDeliveryFailure({
-        applicationId: application._id,
-        organizationId: user.organizationId,
-      });
-    }
-    throw new Error("E-Mail konnte nicht versendet werden");
-  }
+  await sendDecisionEmail({
+    application,
+    decision: decision.decision,
+    jobTitle: posting.title,
+    message: prepared.message,
+    organizationId: user.organizationId,
+    subject: decision.subject,
+    workspaceUserId: prepared.workspaceUserId,
+  });
+  await persistDecision({
+    application,
+    decision,
+    userId: user._id,
+    organizationId: user.organizationId,
+    workspaceUserId: prepared.workspaceUserId,
+  });
+}
 
+function assertDecisionAllowed(
+  application: Application,
+  decision: ApplicationDecision,
+): void {
+  if (!isApplicationStatusTransitionAllowed(application.status, decision)) {
+    throw new Error("Dieser Statuswechsel ist nicht zulässig");
+  }
+  const isProvisioning =
+    application.workspaceProvisioningStatus === "pending" ||
+    application.workspaceProvisioningStatus === "provisioned";
+  if (decision === "rejected" && isProvisioning) {
+    throw new Error("Das Workspace-Konto wird bereits eingerichtet");
+  }
+}
+
+async function persistDecision(input: {
+  application: Application;
+  decision: ParsedApplicationDecision;
+  organizationId: string;
+  userId: string;
+  workspaceUserId?: string;
+}): Promise<void> {
   const entry = createApplicationHistoryEntry(
-    user._id,
+    input.userId,
     "status_changed",
-    `${APPLICATION_STATUS_LABELS[application.status]} → ${APPLICATION_STATUS_LABELS[parsed.decision]}`,
-    { fromStatus: application.status, toStatus: parsed.decision },
+    `${APPLICATION_STATUS_LABELS[input.application.status]} → ${APPLICATION_STATUS_LABELS[input.decision.decision]}`,
+    {
+      fromStatus: input.application.status,
+      toStatus: input.decision.decision,
+    },
   );
   const result = await (
     await applications()
   ).updateOne(
     {
-      _id: application._id,
-      organizationId: user.organizationId,
-      status: application.status,
-      ...(workspaceUserId
+      _id: input.application._id,
+      organizationId: input.organizationId,
+      status: input.application.status,
+      ...(input.workspaceUserId
         ? { workspaceProvisioningStatus: "provisioned" }
         : {}),
     },
     {
       $set: {
-        status: parsed.decision,
+        status: input.decision.decision,
         updatedAt: entry.timestamp,
-        ...(workspaceUserId
+        ...(input.workspaceUserId
           ? { workspaceProvisioningStatus: "invited" as const }
           : {}),
       },
-      ...(workspaceUserId
+      ...(input.workspaceUserId
         ? { $unset: { workspaceProvisioningError: "" } }
         : {}),
       $push: { history: entry },
@@ -179,20 +119,21 @@ export async function sendApplicationDecision(
   if (result.modifiedCount !== 1) {
     throw new Error("Bewerbung wurde zwischenzeitlich geändert");
   }
+
   await addLog(
-    user.organizationId,
-    user._id,
+    input.organizationId,
+    input.userId,
     "application.status_change",
-    application._id,
+    input.application._id,
     entry.details,
   );
-  if (workspaceUserId && parsed.decision === "accepted") {
+  if (input.workspaceUserId && input.decision.decision === "accepted") {
     await addLog(
-      user.organizationId,
-      user._id,
+      input.organizationId,
+      input.userId,
       "application.workspace_provisioned",
-      application._id,
-      parsed.yfnEmail,
+      input.application._id,
+      input.decision.yfnEmail,
     );
   }
 }

--- a/app/lib/server/applications/decisionAction.ts
+++ b/app/lib/server/applications/decisionAction.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { ZodError } from "zod";
+import type { ApplicationDecisionInput } from "./decisionInput";
+import { sendApplicationDecision } from "./decision";
+
+export type ApplicationDecisionResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+const DISPLAYABLE_DECISION_ERRORS = new Set([
+  "Bewerbung nicht gefunden",
+  "Dieser Statuswechsel ist nicht zulässig",
+  "Das Workspace-Konto wird bereits eingerichtet",
+  "Ausschreibung nicht gefunden",
+  "YBase-URL ist nicht konfiguriert",
+  "Diese Workspace-E-Mail ist bereits einer Bewerbung zugeordnet",
+  "Diese Workspace-E-Mail gehört bereits zu einem YBase-Profil",
+  "Diese Workspace-E-Mail ist bereits vergeben",
+  "Das Workspace-Konto verwendet eine andere E-Mail",
+  "Google-Workspace-Integration ist nicht konfiguriert",
+  "Google-Workspace-Konfiguration ist ungültig",
+  "Google-Workspace-Authentifizierung fehlgeschlagen",
+  "Google hat kein Zugriffstoken zurückgegeben",
+  "Google Workspace hat die Kontoerstellung nicht autorisiert",
+  "Google Workspace-Konto konnte nicht erstellt werden",
+  "Workspace-Konto konnte nicht gespeichert werden",
+  "E-Mail konnte nicht versendet werden",
+  "Bewerbung wurde zwischenzeitlich geändert",
+]);
+
+function decisionErrorMessage(
+  error: unknown,
+  decision: ApplicationDecisionInput["decision"],
+): string {
+  if (error instanceof ZodError) {
+    return "Prüfe die YFN-E-Mail, den Betreff und die Nachricht.";
+  }
+  if (
+    error instanceof Error &&
+    (DISPLAYABLE_DECISION_ERRORS.has(error.message) ||
+      /^Die Workspace-E-Mail muss auf @[^ ]+ enden$/.test(error.message))
+  ) {
+    return error.message;
+  }
+  return decision === "accepted"
+    ? "Die Zusage konnte nicht gesendet werden. Bitte versuche es erneut."
+    : "Die Absage konnte nicht gesendet werden. Bitte versuche es erneut.";
+}
+
+export async function submitApplicationDecision(
+  input: ApplicationDecisionInput,
+): Promise<ApplicationDecisionResult> {
+  try {
+    await sendApplicationDecision(input);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: decisionErrorMessage(error, input.decision),
+    };
+  }
+}

--- a/app/lib/server/applications/decisionDelivery.ts
+++ b/app/lib/server/applications/decisionDelivery.ts
@@ -1,0 +1,116 @@
+import { appendWorkspaceAccessDetails } from "../../applications/decisionEmail";
+import type { ApplicationDecision } from "../../applications/decisionEmail";
+import type { Application } from "../../db/types";
+import { sendMail } from "../../email/brevo";
+import { BREVO_TEMPLATE_IDS } from "../../email/templates";
+import { provisionWorkspaceUser } from "../../googleWorkspace/users";
+import { YFN_ORGANIZATION } from "../../organization";
+import {
+  recordWorkspaceDeliveryFailure,
+  recordWorkspaceProvisioned,
+  recordWorkspaceProvisioningFailure,
+  reserveWorkspaceProvisioning,
+  workspaceApplicantName,
+  ybaseLoginUrl,
+} from "./workspaceProvisioning";
+
+const templateIds = {
+  accepted: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
+  rejected: BREVO_TEMPLATE_IDS.APPLICATION_REJECTED,
+};
+
+export async function prepareAcceptance(input: {
+  application: Application;
+  organizationId: string;
+  message: string;
+  yfnEmail: string;
+}): Promise<{ message: string; workspaceUserId: string }> {
+  const loginUrl = ybaseLoginUrl();
+  const reservation = await reserveWorkspaceProvisioning({
+    application: input.application,
+    organizationDomain: YFN_ORGANIZATION.domain,
+    yfnEmail: input.yfnEmail,
+  });
+
+  try {
+    const account = await provisionWorkspaceUser({
+      applicationId: input.application._id,
+      existingUserId: reservation.existingWorkspaceUserId,
+      primaryEmail: reservation.yfnEmail,
+      recoveryEmail: input.application.applicantEmail,
+      ...workspaceApplicantName(input.application),
+    });
+    await recordWorkspaceProvisioned({
+      applicationId: input.application._id,
+      organizationId: input.organizationId,
+      workspaceUserId: account.userId,
+    });
+    return {
+      workspaceUserId: account.userId,
+      message: appendWorkspaceAccessDetails({
+        message: input.message,
+        primaryEmail: account.primaryEmail,
+        temporaryPassword: account.temporaryPassword,
+        loginUrl,
+      }),
+    };
+  } catch (error) {
+    await recordWorkspaceProvisioningFailure({
+      applicationId: input.application._id,
+      organizationId: input.organizationId,
+      error,
+    });
+    throw error;
+  }
+}
+
+export async function sendDecisionEmail(input: {
+  application: Application;
+  decision: ApplicationDecision;
+  jobTitle: string;
+  message: string;
+  organizationId: string;
+  subject: string;
+  workspaceUserId?: string;
+}): Promise<void> {
+  let delivery: Awaited<ReturnType<typeof sendMail>>;
+  try {
+    delivery = await sendMail({
+      to: [
+        {
+          email: input.application.applicantEmail,
+          name: input.application.applicantName,
+        },
+      ],
+      templateId: templateIds[input.decision],
+      subject: input.subject,
+      params: {
+        applicantName: input.application.applicantName ?? "",
+        jobTitle: input.jobTitle,
+        organizationName: YFN_ORGANIZATION.name,
+        message: input.message,
+      },
+      tags: ["ybase", "application", `application-${input.decision}`],
+    });
+  } catch (error) {
+    await recordDeliveryFailure(input);
+    throw error;
+  }
+
+  if (delivery.status !== "sent") {
+    await recordDeliveryFailure(input);
+    throw new Error("E-Mail konnte nicht versendet werden");
+  }
+}
+
+async function recordDeliveryFailure(input: {
+  application: Application;
+  organizationId: string;
+  workspaceUserId?: string;
+}): Promise<void> {
+  if (!input.workspaceUserId) return;
+  await recordWorkspaceDeliveryFailure({
+    applicationId: input.application._id,
+    organizationId: input.organizationId,
+  });
+}

--- a/app/lib/server/applications/decisionInput.ts
+++ b/app/lib/server/applications/decisionInput.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const messageSchema = {
+  applicationId: z.string().min(1),
+  subject: z.string().trim().min(1).max(200),
+  message: z.string().trim().min(1).max(10_000),
+};
+
+export const applicationDecisionInputSchema = z.discriminatedUnion("decision", [
+  z.object({
+    ...messageSchema,
+    decision: z.literal("accepted"),
+    yfnEmail: z.string().trim().email().max(320),
+  }),
+  z.object({
+    ...messageSchema,
+    decision: z.literal("rejected"),
+  }),
+]);
+
+export type ApplicationDecisionInput = z.input<
+  typeof applicationDecisionInputSchema
+>;
+
+export type ParsedApplicationDecision = z.output<
+  typeof applicationDecisionInputSchema
+>;

--- a/app/lib/server/applications/decisionProvisioning.test.ts
+++ b/app/lib/server/applications/decisionProvisioning.test.ts
@@ -15,6 +15,7 @@ import { provisionWorkspaceUser } from "../../googleWorkspace/users";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { sendApplicationDecision } from "./decision";
+import { submitApplicationDecision } from "./decisionAction";
 import { reserveWorkspaceProvisioning } from "./workspaceProvisioning";
 
 setupTestDatabase();
@@ -133,4 +134,21 @@ test("validates the YBase URL before creating an account", async () => {
     }),
   ).rejects.toThrow("YBase-URL");
   expect(provisionWorkspaceUser).not.toHaveBeenCalled();
+});
+
+test("returns expected failures without a masked server action error", async () => {
+  vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+
+  await expect(
+    submitApplicationDecision({
+      applicationId,
+      decision: "accepted",
+      yfnEmail: "alex@youngfounders.network",
+      subject: "Zusage",
+      message: "Willkommen!",
+    }),
+  ).resolves.toEqual({
+    ok: false,
+    error: "YBase-URL ist nicht konfiguriert",
+  });
 });


### PR DESCRIPTION
## summary

- align the workspace email lock control and remove the visible provisioning helper copy
- return safe application decision failures to the client with actionable Workspace configuration messages
- split decision input, action, delivery, and orchestration into focused modules under 200 lines

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/googleWorkspace/users.test.ts app/lib/server/applications/decision.test.ts app/lib/server/applications/decisionProvisioning.test.ts`
- `pnpm lint:lines`
- `pnpm build`