### PR TITLE
fix(recruiting): keep application sidebar fixed on reload

### DIFF
--- a/app/components/Applications/ApplicationReviewSidebar.tsx
+++ b/app/components/Applications/ApplicationReviewSidebar.tsx
@@ -11,7 +11,7 @@ export function ApplicationReviewSidebar({
     <aside
       data-application-review-sidebar
       aria-label="Bewerbungsverwaltung"
-      className="mt-8 border-t pt-6 min-[1280px]:fixed min-[1280px]:inset-y-4 min-[1280px]:right-4 min-[1280px]:z-40 min-[1280px]:mt-0 min-[1280px]:w-(--application-review-sidebar-width) min-[1280px]:overflow-hidden min-[1280px]:border-0 min-[1280px]:pt-0 min-[1280px]:transition-[width] min-[1280px]:duration-400 min-[1280px]:ease-[cubic-bezier(0.22,1,0.36,1)] min-[1280px]:starting:w-0 motion-reduce:transition-none"
+      className="mt-8 border-t pt-6 min-[1280px]:fixed min-[1280px]:inset-y-4 min-[1280px]:right-4 min-[1280px]:z-40 min-[1280px]:mt-0 min-[1280px]:w-(--application-review-sidebar-width) min-[1280px]:overflow-hidden min-[1280px]:border-0 min-[1280px]:pt-0"
     >
       <div className="flex flex-col min-[1280px]:absolute min-[1280px]:inset-y-0 min-[1280px]:left-0 min-[1280px]:w-(--application-review-sidebar-width) min-[1280px]:overflow-hidden min-[1280px]:rounded-[0.25rem] min-[1280px]:border min-[1280px]:bg-background">
         <div className="space-y-6 min-[1280px]:min-h-0 min-[1280px]:flex-1 min-[1280px]:overflow-y-auto min-[1280px]:px-6 min-[1280px]:pt-8 [&>div:first-child>section:first-child]:border-t-0 [&>div:first-child>section:first-child]:pt-0">


### PR DESCRIPTION
## summary

- keep the application review sidebar at its fixed width from the initial render
- remove the mount-only width transition that caused the sidebar to fly in after reloads

## validation

- `pnpm exec prettier --check app/components/Applications/ApplicationReviewSidebar.tsx`
- `pnpm exec biome lint app/components/Applications/ApplicationReviewSidebar.tsx`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `pnpm exec biome check app/components/Applications/ApplicationReviewSidebar.tsx` (formatter-only mismatch with the repository's Prettier style; lint passes)
- not run (tests are skipped for styling-only changes per repository guidance)
