### PR TITLE
fix(workspace): delegate admin sdk requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 # Google Workspace service account JSON (Base64)
 GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON_BASE64=
+# Workspace administrator impersonated through domain-wide delegation
+GOOGLE_WORKSPACE_ADMIN_EMAIL=
 GOOGLE_WORKSPACE_ORG_UNIT_PATH=/
 
 # Hetzner Object Storage

--- a/app/lib/googleWorkspace/client.test.ts
+++ b/app/lib/googleWorkspace/client.test.ts
@@ -1,0 +1,43 @@
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+test("reports domain-wide delegation rejected by Google", async () => {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  vi.stubEnv(
+    "GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON_BASE64",
+    Buffer.from(
+      JSON.stringify({
+        client_email: "ybase@example.iam.gserviceaccount.com",
+        private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+        token_uri: "https://oauth.example/token",
+      }),
+    ).toString("base64"),
+  );
+  vi.stubEnv(
+    "GOOGLE_WORKSPACE_ADMIN_EMAIL",
+    "admin@youngfounders.network",
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      Response.json(
+        { error: "unauthorized_client" },
+        {
+          status: 400,
+        },
+      ),
+    ),
+  );
+
+  const { workspaceRequest } = await import("./client");
+
+  await expect(workspaceRequest("users/example")).rejects.toThrow(
+    "Google-Workspace-Domaindelegierung ist nicht autorisiert",
+  );
+});

--- a/app/lib/googleWorkspace/client.ts
+++ b/app/lib/googleWorkspace/client.ts
@@ -43,18 +43,28 @@ function credentials(): ServiceAccountCredentials {
   }
 }
 
+function delegatedAdminEmail(): string {
+  const email = process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim().toLowerCase();
+  if (!email) {
+    throw new Error("Google-Workspace-Admin ist nicht konfiguriert");
+  }
+  return email;
+}
+
 async function accessToken(): Promise<string> {
   if (cachedToken && cachedToken.expiresAt > Date.now() + 60_000) {
     return cachedToken.accessToken;
   }
 
   const account = credentials();
+  const delegatedAdmin = delegatedAdminEmail();
   const tokenUri = account.token_uri ?? "https://oauth2.googleapis.com/token";
   const issuedAt = Math.floor(Date.now() / 1_000);
   const header = encode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
   const payload = encode(
     JSON.stringify({
       iss: account.client_email,
+      sub: delegatedAdmin,
       scope: DIRECTORY_SCOPE,
       aud: tokenUri,
       iat: issuedAt,
@@ -78,13 +88,19 @@ async function accessToken(): Promise<string> {
     }),
     signal: AbortSignal.timeout(10_000),
   });
-  if (!response.ok) {
-    throw new Error("Google-Workspace-Authentifizierung fehlgeschlagen");
-  }
-  const data = (await response.json()) as {
+  const data = (await response.json().catch(() => ({}))) as {
     access_token?: string;
     expires_in?: number;
+    error?: string;
   };
+  if (!response.ok) {
+    if (data.error === "unauthorized_client") {
+      throw new Error(
+        "Google-Workspace-Domaindelegierung ist nicht autorisiert",
+      );
+    }
+    throw new Error("Google-Workspace-Authentifizierung fehlgeschlagen");
+  }
   if (!data.access_token) {
     throw new Error("Google hat kein Zugriffstoken zurückgegeben");
   }

--- a/app/lib/googleWorkspace/users.test.ts
+++ b/app/lib/googleWorkspace/users.test.ts
@@ -93,4 +93,21 @@ describe("provisionWorkspaceUser", () => {
       "Google-Workspace-Integration ist nicht konfiguriert",
     );
   });
+
+  test("reports a missing delegated Workspace admin", async () => {
+    vi.stubEnv(
+      "GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON_BASE64",
+      Buffer.from(
+        JSON.stringify({
+          client_email: "ybase@example.iam.gserviceaccount.com",
+          private_key: "unused",
+        }),
+      ).toString("base64"),
+    );
+    vi.stubEnv("GOOGLE_WORKSPACE_ADMIN_EMAIL", "");
+
+    await expect(provisionWorkspaceUser(input)).rejects.toThrow(
+      "Google-Workspace-Admin ist nicht konfiguriert",
+    );
+  });
 });

--- a/app/lib/googleWorkspace/users.ts
+++ b/app/lib/googleWorkspace/users.ts
@@ -5,6 +5,8 @@ const APPLICATION_ID_TYPE = "ybase_application_id";
 const DISPLAYABLE_WORKSPACE_ERRORS = new Set([
   "Google-Workspace-Integration ist nicht konfiguriert",
   "Google-Workspace-Konfiguration ist ungültig",
+  "Google-Workspace-Admin ist nicht konfiguriert",
+  "Google-Workspace-Domaindelegierung ist nicht autorisiert",
   "Google-Workspace-Authentifizierung fehlgeschlagen",
   "Google hat kein Zugriffstoken zurückgegeben",
 ]);

--- a/app/lib/server/applications/decisionAction.ts
+++ b/app/lib/server/applications/decisionAction.ts
@@ -20,6 +20,8 @@ const DISPLAYABLE_DECISION_ERRORS = new Set([
   "Das Workspace-Konto verwendet eine andere E-Mail",
   "Google-Workspace-Integration ist nicht konfiguriert",
   "Google-Workspace-Konfiguration ist ungültig",
+  "Google-Workspace-Admin ist nicht konfiguriert",
+  "Google-Workspace-Domaindelegierung ist nicht autorisiert",
   "Google-Workspace-Authentifizierung fehlgeschlagen",
   "Google hat kein Zugriffstoken zurückgegeben",
   "Google Workspace hat die Kontoerstellung nicht autorisiert",

--- a/app/lib/server/profile/googleWorkspace.test.ts
+++ b/app/lib/server/profile/googleWorkspace.test.ts
@@ -7,7 +7,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test("authenticates the service account directly and updates the user photo", async () => {
+test("delegates to a Workspace admin and updates the user photo", async () => {
   const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
   const tokenUri = "https://oauth.example/token";
   const encodedCredentials = Buffer.from(
@@ -20,6 +20,10 @@ test("authenticates the service account directly and updates the user photo", as
   vi.stubEnv(
     "GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON_BASE64",
     encodedCredentials,
+  );
+  vi.stubEnv(
+    "GOOGLE_WORKSPACE_ADMIN_EMAIL",
+    "Admin@youngfounders.network ",
   );
 
   const fetchMock = vi
@@ -44,9 +48,9 @@ test("authenticates the service account directly and updates the user photo", as
   );
   expect(payload).toMatchObject({
     iss: "profile-sync@example.iam.gserviceaccount.com",
+    sub: "admin@youngfounders.network",
     scope: "https://www.googleapis.com/auth/admin.directory.user",
   });
-  expect(payload).not.toHaveProperty("sub");
 
   const photoRequest = fetchMock.mock.calls[1];
   expect(photoRequest?.[0]).toContain(


### PR DESCRIPTION
## summary

- impersonate the configured Workspace administrator when requesting Admin SDK access tokens
- surface missing or rejected domain-wide delegation and document the required environment variable

## validation

- `pnpm exec vitest run app/lib/googleWorkspace/client.test.ts app/lib/googleWorkspace/users.test.ts app/lib/server/profile/googleWorkspace.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint app/lib/googleWorkspace/client.ts app/lib/googleWorkspace/client.test.ts app/lib/googleWorkspace/users.ts app/lib/googleWorkspace/users.test.ts app/lib/server/applications/decisionAction.ts app/lib/server/profile/googleWorkspace.test.ts`
- `pnpm build`
