### PR TITLE
feat(members): link workspace accounts and serve stored avatars

### DIFF
--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -7,6 +7,7 @@ import { SheetFooter } from "@/components/ui/sheet";
 import type { TeamOnboardingStatus, User, UserRole } from "@/lib/db/types";
 import { getInitials } from "@/lib/formatters/getInitials";
 import { memberStageForStatus } from "@/lib/members/stages";
+import { profileAvatarUrl } from "@/lib/profile/avatar";
 import { Loader2 } from "lucide-react";
 import { LabeledSelect } from "./LabeledSelect";
 import { MemberStatusField } from "./MemberStatusField";
@@ -31,7 +32,7 @@ export function MemberDrawerPanel({
       <div className="flex flex-row items-center gap-5 px-6 pt-8 pb-6 text-left">
         <Avatar className="size-24">
           <AvatarImage
-            src={member.image}
+            src={profileAvatarUrl(member)}
             alt={`Profilbild von ${displayName}`}
             className="object-cover"
           />

--- a/app/(protected)/settings/members/MemberRow.tsx
+++ b/app/(protected)/settings/members/MemberRow.tsx
@@ -6,6 +6,7 @@ import { TableCell, TableRow } from "@/components/ui/table";
 import type { Department, Team, User } from "@/lib/db/types";
 import { getInitials } from "@/lib/formatters/getInitials";
 import { memberStageForStatus } from "@/lib/members/stages";
+import { profileAvatarUrl } from "@/lib/profile/avatar";
 
 interface Props {
   member: User;
@@ -30,7 +31,7 @@ export function MemberRow({
         <div className="flex items-center gap-2">
           <Avatar className="size-8">
             <AvatarImage
-              src={member.image}
+              src={profileAvatarUrl(member)}
               alt={`Profilbild von ${displayName}`}
               className="object-cover"
             />

--- a/app/api/profile-images/[userId]/route.test.ts
+++ b/app/api/profile-images/[userId]/route.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireUser: vi.fn(),
+  findOne: vi.fn(),
+  getObjectBuffer: vi.fn(),
+  validateProfileImage: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({ requireUser: mocks.requireUser }));
+vi.mock("@/lib/db/collections", () => ({
+  users: vi.fn(async () => ({ findOne: mocks.findOne })),
+}));
+vi.mock("@/lib/s3/storage", () => ({
+  getObjectBuffer: mocks.getObjectBuffer,
+}));
+vi.mock("@/lib/server/profile/validation", () => ({
+  validateProfileImage: mocks.validateProfileImage,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ userId: "member-id" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireUser.mockResolvedValue({ organizationId: "organization-id" });
+  mocks.findOne.mockResolvedValue({
+    _id: "member-id",
+    profileImageStorageKey: "profile-image",
+  });
+  mocks.getObjectBuffer.mockResolvedValue(Buffer.from([0xff, 0xd8, 0xff]));
+  mocks.validateProfileImage.mockReturnValue("image/jpeg");
+});
+
+test("returns a private stored profile image from the actor organization", async () => {
+  const response = await GET(
+    new Request("http://localhost/api/profile-images/member-id?v=123"),
+    context,
+  );
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("image/jpeg");
+  expect(response.headers.get("cache-control")).toContain("private");
+  expect(response.headers.get("cache-control")).toContain("max-age=300");
+  expect(mocks.findOne).toHaveBeenCalledWith({
+    _id: "member-id",
+    organizationId: "organization-id",
+    profileImageStorageKey: { $exists: true },
+  });
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+    new Uint8Array([0xff, 0xd8, 0xff]),
+  );
+});
+
+test("rejects unauthenticated image requests", async () => {
+  mocks.requireUser.mockRejectedValue(new Error("Unauthorized"));
+
+  const response = await GET(
+    new Request("http://localhost/api/profile-images/member-id"),
+    context,
+  );
+
+  expect(response.status).toBe(401);
+  expect(mocks.findOne).not.toHaveBeenCalled();
+});
+
+test("hides missing or foreign profile images", async () => {
+  mocks.findOne.mockResolvedValue(null);
+
+  const response = await GET(
+    new Request("http://localhost/api/profile-images/member-id"),
+    context,
+  );
+
+  expect(response.status).toBe(404);
+  expect(mocks.getObjectBuffer).not.toHaveBeenCalled();
+});
+
+test("does not serve invalid stored image data", async () => {
+  mocks.validateProfileImage.mockImplementation(() => {
+    throw new Error("Invalid image");
+  });
+
+  const response = await GET(
+    new Request("http://localhost/api/profile-images/member-id"),
+    context,
+  );
+
+  expect(response.status).toBe(404);
+});

--- a/app/api/profile-images/[userId]/route.ts
+++ b/app/api/profile-images/[userId]/route.ts
@@ -1,0 +1,49 @@
+import { requireUser } from "@/lib/auth/session";
+import { users } from "@/lib/db/collections";
+import { getObjectBuffer } from "@/lib/s3/storage";
+import { validateProfileImage } from "@/lib/server/profile/validation";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ userId: string }> };
+
+const PRIVATE_IMAGE_HEADERS = {
+  "Cache-Control": "private, max-age=300",
+  "X-Content-Type-Options": "nosniff",
+};
+const ERROR_HEADERS = { "Cache-Control": "private, no-store" };
+
+export async function GET(_request: Request, context: RouteContext) {
+  let actor: Awaited<ReturnType<typeof requireUser>>;
+  try {
+    actor = await requireUser();
+  } catch {
+    return new Response(null, { status: 401, headers: ERROR_HEADERS });
+  }
+
+  const { userId } = await context.params;
+  const member = await (
+    await users()
+  ).findOne({
+    _id: userId,
+    organizationId: actor.organizationId,
+    profileImageStorageKey: { $exists: true },
+  });
+  if (!member?.profileImageStorageKey) {
+    return new Response(null, { status: 404, headers: ERROR_HEADERS });
+  }
+
+  try {
+    const bytes = await getObjectBuffer(member.profileImageStorageKey);
+    const contentType = validateProfileImage(bytes);
+    return new Response(new Uint8Array(bytes), {
+      headers: {
+        ...PRIVATE_IMAGE_HEADERS,
+        "Content-Type": contentType,
+        "Content-Length": String(bytes.byteLength),
+      },
+    });
+  } catch {
+    return new Response(null, { status: 404, headers: ERROR_HEADERS });
+  }
+}

--- a/app/auth.d.ts
+++ b/app/auth.d.ts
@@ -7,6 +7,8 @@ declare module "next-auth" {
       id: string;
       organizationId?: string;
       role?: UserRole;
+      profileImageStorageKey?: string;
+      publicProfileCompletedAt?: number;
     } & DefaultSession["user"];
   }
 
@@ -21,5 +23,7 @@ declare module "next-auth/jwt" {
     userId?: string;
     organizationId?: string;
     role?: UserRole;
+    profileImageStorageKey?: string;
+    publicProfileCompletedAt?: number;
   }
 }

--- a/app/components/Selectors/SelectMembers.tsx
+++ b/app/components/Selectors/SelectMembers.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { User } from "@/lib/db/types";
 import { getInitials } from "@/lib/formatters/getInitials";
+import { profileAvatarUrl } from "@/lib/profile/avatar";
 import { MultiSelect, type MultiSelectOption } from "./MultiSelect";
 
 interface MemberOption extends MultiSelectOption {
@@ -32,7 +33,7 @@ function renderMemberOption(option: MemberOption) {
   return (
     <span className="flex min-w-0 items-center gap-3">
       <Avatar className="size-8">
-        <AvatarImage src={member.image} alt="" />
+        <AvatarImage src={profileAvatarUrl(member)} alt="" />
         <AvatarFallback className="text-xs font-semibold">
           {getInitials(member.name, member.email)}
         </AvatarFallback>
@@ -61,7 +62,7 @@ function renderSelectedMembers(options: MemberOption[], selectedCount: number) {
               key={member._id}
               className="size-7 border-2 border-background"
             >
-              <AvatarImage src={member.image} alt="" />
+              <AvatarImage src={profileAvatarUrl(member)} alt="" />
               <AvatarFallback className="text-[10px] font-semibold">
                 {getInitials(member.name, member.email)}
               </AvatarFallback>

--- a/app/components/Sidebar/UserNav.tsx
+++ b/app/components/Sidebar/UserNav.tsx
@@ -19,18 +19,27 @@ import {
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { signOutWithPostHog } from "@/lib/posthog-client";
+import { profileAvatarUrl } from "@/lib/profile/avatar";
 
 type NavUserData = {
+  id: string;
   name?: string | null;
   email?: string | null;
   image?: string | null;
+  profileImageStorageKey?: string;
+  publicProfileCompletedAt?: number;
 };
 
 function UserAvatar({ user }: { user: NavUserData }) {
   return (
     <Avatar className="size-9 rounded-full group-data-[collapsible=icon]:size-8">
       <AvatarImage
-        src={user.image ?? undefined}
+        src={profileAvatarUrl({
+          _id: user.id,
+          image: user.image ?? undefined,
+          profileImageStorageKey: user.profileImageStorageKey,
+          publicProfileCompletedAt: user.publicProfileCompletedAt,
+        })}
         alt={user.name ?? ""}
         referrerPolicy="no-referrer"
       />

--- a/app/lib/auth/config.test.ts
+++ b/app/lib/auth/config.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   ensureAppUser: vi.fn(),
+  isLinkedWorkspaceUser: vi.fn(),
 }));
 
 vi.mock("./provisioning", () => ({
   ensureAppUser: mocks.ensureAppUser,
+  isLinkedWorkspaceUser: mocks.isLinkedWorkspaceUser,
 }));
 
 import { authConfig } from "./config";
@@ -13,6 +15,7 @@ import { authConfig } from "./config";
 describe("auth config", () => {
   beforeEach(() => {
     mocks.ensureAppUser.mockReset();
+    mocks.isLinkedWorkspaceUser.mockReset();
   });
 
   it("refreshes a persisted session against the current database", async () => {
@@ -22,6 +25,8 @@ describe("auth config", () => {
       email: "local@example.com",
       organizationId: "new-organization-id",
       role: "finance",
+      profileImageStorageKey: "profile-image",
+      publicProfileCompletedAt: 123,
     });
     const token = {
       email: "local@example.com",
@@ -37,6 +42,7 @@ describe("auth config", () => {
 
     expect(mocks.ensureAppUser).toHaveBeenCalledWith({
       email: "local@example.com",
+      googleWorkspaceUserId: undefined,
       name: undefined,
       image: undefined,
       firstName: undefined,
@@ -46,7 +52,38 @@ describe("auth config", () => {
       userId: "new-user-id",
       organizationId: "new-organization-id",
       role: "finance",
+      profileImageStorageKey: "profile-image",
+      publicProfileCompletedAt: 123,
     });
+  });
+
+  it("allows linked accounts from another Workspace domain", async () => {
+    mocks.isLinkedWorkspaceUser.mockResolvedValue(true);
+
+    const result = await authConfig.callbacks.signIn({
+      user: { id: "google-id", email: "member@ybudget.de" },
+      account: {
+        provider: "google",
+        providerAccountId: "google-id",
+      },
+    } as Parameters<typeof authConfig.callbacks.signIn>[0]);
+
+    expect(result).toBe(true);
+    expect(mocks.isLinkedWorkspaceUser).toHaveBeenCalledWith("google-id");
+  });
+
+  it("rejects unknown accounts from another domain", async () => {
+    mocks.isLinkedWorkspaceUser.mockResolvedValue(false);
+
+    const result = await authConfig.callbacks.signIn({
+      user: { id: "google-id", email: "unknown@example.com" },
+      account: {
+        provider: "google",
+        providerAccountId: "google-id",
+      },
+    } as Parameters<typeof authConfig.callbacks.signIn>[0]);
+
+    expect(result).toBe(false);
   });
 
   it("keeps the People & Culture role in the session", () => {

--- a/app/lib/auth/config.ts
+++ b/app/lib/auth/config.ts
@@ -2,10 +2,10 @@ import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 import { YFN_ORGANIZATION } from "../organization";
 import { getGooglePhotoIsDefault } from "./googlePeople";
-import { ensureAppUser } from "./provisioning";
+import { ensureAppUser, isLinkedWorkspaceUser } from "./provisioning";
 import { normalizeOptionalUserRole } from "./roles";
 
-function isAllowedEmail(email: string | null | undefined): boolean {
+function isYfnEmail(email: string | null | undefined): boolean {
   return Boolean(email?.toLowerCase().endsWith(`@${YFN_ORGANIZATION.domain}`));
 }
 
@@ -14,9 +14,6 @@ const google = Google({
     params: { prompt: "select_account", hd: YFN_ORGANIZATION.domain },
   },
   profile(profile) {
-    if (!isAllowedEmail(profile.email)) {
-      throw new Error("Nur youngfounders.network-Konten sind zugelassen");
-    }
     return {
       id: profile.sub,
       email: profile.email,
@@ -36,8 +33,11 @@ export const authConfig = {
   pages: { signIn: "/login" },
   providers: [google],
   callbacks: {
-    signIn({ user }) {
-      return isAllowedEmail(user.email);
+    async signIn({ user, account }) {
+      if (isYfnEmail(user.email)) return true;
+      const googleWorkspaceUserId =
+        account?.provider === "google" ? account.providerAccountId : undefined;
+      return isLinkedWorkspaceUser(googleWorkspaceUserId);
     },
     async jwt({ token, user, account }) {
       const email = user?.email ?? (token.email as string | undefined);
@@ -48,6 +48,10 @@ export const authConfig = {
             : undefined;
         const appUser = await ensureAppUser({
           email,
+          googleWorkspaceUserId:
+            account?.provider === "google"
+              ? account.providerAccountId
+              : undefined,
           name: user?.name ?? (token.name as string | undefined),
           image: user?.image ?? undefined,
           firstName: user?.firstName,
@@ -58,6 +62,8 @@ export const authConfig = {
         token.organizationId = appUser.organizationId;
         token.role = appUser.role;
         token.email = appUser.email;
+        token.profileImageStorageKey = appUser.profileImageStorageKey;
+        token.publicProfileCompletedAt = appUser.publicProfileCompletedAt;
       }
       return token;
     },
@@ -68,6 +74,11 @@ export const authConfig = {
           | string
           | undefined;
         session.user.role = normalizeOptionalUserRole(token.role);
+        session.user.profileImageStorageKey = token.profileImageStorageKey as
+          | string
+          | undefined;
+        session.user.publicProfileCompletedAt =
+          token.publicProfileCompletedAt as number | undefined;
       }
       return session;
     },

--- a/app/lib/auth/provisioning.ts
+++ b/app/lib/auth/provisioning.ts
@@ -6,6 +6,7 @@ import { linkAcceptedApplication } from "./applicationLinking";
 
 type SignInProfile = {
   email: string;
+  googleWorkspaceUserId?: string;
   name?: string;
   image?: string;
   firstName?: string;
@@ -16,8 +17,19 @@ type SignInProfile = {
 export async function ensureAppUser(profile: SignInProfile): Promise<User> {
   const usersCol = await users();
   const normalizedEmail = profile.email.trim().toLowerCase();
+  const googleWorkspaceUserId = profile.googleWorkspaceUserId?.trim();
 
-  let user = await usersCol.findOne({ email: normalizedEmail });
+  const [emailUser, workspaceUser] = await Promise.all([
+    usersCol.findOne({ email: normalizedEmail }),
+    googleWorkspaceUserId
+      ? usersCol.findOne({ googleWorkspaceUserId })
+      : Promise.resolve(null),
+  ]);
+  if (emailUser && workspaceUser && emailUser._id !== workspaceUser._id) {
+    throw new Error("Google Workspace account is linked to another user");
+  }
+
+  let user = workspaceUser ?? emailUser;
   if (!user) {
     const now = Date.now();
     user = {
@@ -30,6 +42,7 @@ export async function ensureAppUser(profile: SignInProfile): Promise<User> {
       publicProfileSetupRequired: true,
       firstName: profile.firstName,
       lastName: profile.lastName,
+      googleWorkspaceUserId,
       emailVerificationTime: now,
       memberStatus: "onboarding",
       teamOnboardingStatus: "not_started",
@@ -37,7 +50,19 @@ export async function ensureAppUser(profile: SignInProfile): Promise<User> {
     };
     await usersCol.insertOne(user);
   } else {
+    if (
+      googleWorkspaceUserId &&
+      user.googleWorkspaceUserId &&
+      googleWorkspaceUserId !== user.googleWorkspaceUserId
+    ) {
+      throw new Error("User is linked to another Google Workspace account");
+    }
     const profileUpdates = {
+      ...(normalizedEmail !== user.email ? { email: normalizedEmail } : {}),
+      ...(googleWorkspaceUserId &&
+      googleWorkspaceUserId !== user.googleWorkspaceUserId
+        ? { googleWorkspaceUserId }
+        : {}),
       ...(profile.name && profile.name !== user.name
         ? { name: profile.name }
         : {}),
@@ -87,6 +112,20 @@ export async function ensureAppUser(profile: SignInProfile): Promise<User> {
   }
 
   return linkAcceptedApplication(user);
+}
+
+export async function isLinkedWorkspaceUser(
+  googleWorkspaceUserId: string | undefined,
+): Promise<boolean> {
+  const normalizedId = googleWorkspaceUserId?.trim();
+  if (!normalizedId) return false;
+  const user = await (
+    await users()
+  ).findOne(
+    { googleWorkspaceUserId: normalizedId },
+    { projection: { _id: 1 } },
+  );
+  return Boolean(user);
 }
 
 function isYfnEmail(email: string): boolean {

--- a/app/lib/db/foundation.test.ts
+++ b/app/lib/db/foundation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { ensureAppUser } from "../auth/provisioning";
+import { ensureAppUser, isLinkedWorkspaceUser } from "../auth/provisioning";
 import { YFN_ORGANIZATION } from "../organization";
 import { setupTestDatabase } from "../test/setupTestDatabase";
 import { getDb } from "./client";
@@ -62,6 +62,39 @@ test("ensureAppUser is idempotent for the same email", async () => {
   expect(second._id).toBe(first._id);
   const db = await getDb();
   expect(await db.collection("users").countDocuments()).toBe(1);
+});
+
+test("ensureAppUser links and follows a stable Google Workspace user ID", async () => {
+  const first = await ensureAppUser({
+    email: "alice@youngfounders.network",
+    googleWorkspaceUserId: "google-user-1",
+  });
+  const second = await ensureAppUser({
+    email: "alice.renamed@youngfounders.network",
+    googleWorkspaceUserId: "google-user-1",
+  });
+
+  expect(second).toMatchObject({
+    _id: first._id,
+    email: "alice.renamed@youngfounders.network",
+    googleWorkspaceUserId: "google-user-1",
+  });
+  await expect(isLinkedWorkspaceUser("google-user-1")).resolves.toBe(true);
+  expect(await (await getDb()).collection("users").countDocuments()).toBe(1);
+});
+
+test("ensureAppUser rejects a Google Workspace account conflict", async () => {
+  await ensureAppUser({
+    email: "alice@youngfounders.network",
+    googleWorkspaceUserId: "google-user-1",
+  });
+
+  await expect(
+    ensureAppUser({
+      email: "alice@youngfounders.network",
+      googleWorkspaceUserId: "google-user-2",
+    }),
+  ).rejects.toThrow("another Google Workspace account");
 });
 
 test("ensureAppUser updates an existing user from the current login profile", async () => {

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -12,6 +12,7 @@ export async function ensureIndexes(): Promise<void> {
 
   await db.collection("users").createIndexes([
     { key: { email: 1 }, unique: true, sparse: true },
+    { key: { googleWorkspaceUserId: 1 }, unique: true, sparse: true },
     { key: { applicationId: 1 }, unique: true, sparse: true },
     { key: { organizationId: 1 } },
     {

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -22,6 +22,7 @@ export interface User {
   isAnonymous?: boolean;
   firstName?: string;
   lastName?: string;
+  googleWorkspaceUserId?: string;
   organizationId?: string;
   role?: UserRole;
   iban?: string;

--- a/app/lib/profile/avatar.test.ts
+++ b/app/lib/profile/avatar.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { profileAvatarUrl } from "./avatar";
+
+test("uses the stored ybase profile image before a remote URL", () => {
+  expect(
+    profileAvatarUrl({
+      _id: "member/id",
+      image: "https://example.com/old-avatar.jpg",
+      profileImageStorageKey: "profile-images/member/image",
+      publicProfileCompletedAt: 123,
+    }),
+  ).toBe("/api/profile-images/member%2Fid?v=123");
+});
+
+test("falls back to the remote URL when no stored image exists", () => {
+  expect(
+    profileAvatarUrl({
+      _id: "member-id",
+      image: "https://example.com/current-avatar.jpg",
+    }),
+  ).toBe("https://example.com/current-avatar.jpg");
+});
+
+test("returns no source when the profile has no image", () => {
+  expect(profileAvatarUrl({ _id: "member-id" })).toBeUndefined();
+});

--- a/app/lib/profile/avatar.ts
+++ b/app/lib/profile/avatar.ts
@@ -1,0 +1,12 @@
+import type { User } from "../db/types";
+
+type AvatarUser = Pick<
+  User,
+  "_id" | "image" | "profileImageStorageKey" | "publicProfileCompletedAt"
+>;
+
+export function profileAvatarUrl(user: AvatarUser): string | undefined {
+  if (!user.profileImageStorageKey) return user.image;
+  const version = user.publicProfileCompletedAt ?? 1;
+  return `/api/profile-images/${encodeURIComponent(user._id)}?v=${version}`;
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -44,6 +44,7 @@ erDiagram
         string _id
         string organizationId
         string email
+        string googleWorkspaceUserId
         string role
         string teamId
         string positionTitle


### PR DESCRIPTION
## summary

- Link Google Workspace identities to existing ybase members so renamed and secondary-domain accounts resolve to the correct account.
- Serve stored profile images through an organization-scoped route and use them consistently across member lists, selectors, drawers, and the sidebar.
- Keep the one-time Workspace import and cleanup tooling outside the tracked application code.

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm vitest run` (440 tests)
- `pnpm build`