### PR TITLE
feat(storage): organize uploads by document context

### DIFF
--- a/app/(public)/_lib/http.ts
+++ b/app/(public)/_lib/http.ts
@@ -14,7 +14,7 @@ export async function postJson(url: string, body: unknown) {
 
 export async function uploadViaPresign(
   url: string,
-  body: { contentType: string },
+  body: { contentType: string } & Record<string, unknown>,
   file: Blob,
 ): Promise<string> {
   const { key, url: putUrl } = await postJson(url, body);

--- a/app/(public)/_lib/reimbursements.ts
+++ b/app/(public)/_lib/reimbursements.ts
@@ -70,9 +70,14 @@ export async function validateReimbursementLink(
   }
 }
 
-export function reimbursementUploadUrl(id: string, contentType: string) {
+export function reimbursementUploadUrl(
+  id: string,
+  contentType: string,
+  documentType: "receipt" | "signature",
+) {
   return postJson(`/api/public/reimbursement/${id}/upload-url`, {
     contentType,
+    documentType,
   }) as Promise<{ key: string; url: string }>;
 }
 

--- a/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
+++ b/app/(public)/erstattung/[id]/_components/useReimbursementForm.ts
@@ -96,7 +96,8 @@ export function useReimbursementForm(id: string) {
       );
 
   const generateUploadUrl = useCallback(
-    (contentType: string) => reimbursementUploadUrl(id, contentType),
+    (contentType: string) =>
+      reimbursementUploadUrl(id, contentType, "receipt"),
     [id],
   );
   const getFileUrl = useCallback(
@@ -107,7 +108,7 @@ export function useReimbursementForm(id: string) {
     (blob: Blob) =>
       uploadViaPresign(
         `/api/public/reimbursement/${id}/upload-url`,
-        { contentType: "image/png" },
+        { contentType: "image/png", documentType: "signature" },
         blob,
       ),
     [id],

--- a/app/api/public/reimbursement/[id]/upload-url/route.ts
+++ b/app/api/public/reimbursement/[id]/upload-url/route.ts
@@ -2,14 +2,19 @@ import { z } from "zod";
 import { createPublicReimbursementUpload } from "@/lib/server/reimbursements/public";
 
 type RouteContext = { params: Promise<{ id: string }> };
-const bodySchema = z.object({ contentType: z.string().optional() });
+const bodySchema = z.object({
+  contentType: z.string().optional(),
+  documentType: z.enum(["receipt", "signature"]),
+});
 
 export async function POST(request: Request, context: RouteContext) {
   const { id } = await context.params;
   try {
-    const { contentType } = bodySchema.parse(await request.json());
+    const { contentType, documentType } = bodySchema.parse(
+      await request.json(),
+    );
     return Response.json(
-      await createPublicReimbursementUpload(id, contentType),
+      await createPublicReimbursementUpload(id, contentType, documentType),
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Invalid request";

--- a/app/components/Reimbursements/ReceiptUpload.tsx
+++ b/app/components/Reimbursements/ReceiptUpload.tsx
@@ -3,6 +3,7 @@
 import { FileText, Upload } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
+import type { ReimbursementType } from "@/lib/db/types";
 import {
   convertToJPG,
   FileConversionError,
@@ -17,9 +18,14 @@ import { ReceiptDropzone } from "./ReceiptDropzone";
 interface Props {
   onUploadComplete: (key: string) => void;
   storageId?: string;
+  reimbursementType: ReimbursementType;
 }
 
-export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
+export function ReceiptUpload({
+  onUploadComplete,
+  storageId,
+  reimbursementType,
+}: Props) {
   const [isUploading, setIsUploading] = useState(false);
   const [isPdf, setIsPdf] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -57,7 +63,11 @@ export function ReceiptUpload({ onUploadComplete, storageId }: Props) {
     setIsUploading(true);
     try {
       const convertedFile = await convertToJPG(file);
-      const { key, url } = await generateUploadUrl(convertedFile.type);
+      const { key, url } = await generateUploadUrl(
+        convertedFile.type,
+        reimbursementType,
+        "receipt",
+      );
       const result = await fetch(url, {
         method: "PUT",
         headers: { "Content-Type": convertedFile.type },

--- a/app/components/Reimbursements/ReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/ReimbursementFormUI.tsx
@@ -46,6 +46,7 @@ export function ReimbursementFormUI({
               <SignatureField
                 onSignatureComplete={form.setSignature}
                 storageId={form.signature || undefined}
+                reimbursementType="expense"
               />
             </div>
           </>

--- a/app/components/Reimbursements/SignatureCanvas.tsx
+++ b/app/components/Reimbursements/SignatureCanvas.tsx
@@ -6,14 +6,20 @@ import toast from "react-hot-toast";
 import SignaturePad from "react-signature-canvas";
 import { Button } from "@/components/ui/button";
 import { useSignatureResize } from "@/lib/hooks/useSignatureResize";
+import type { ReimbursementStorageType } from "@/lib/s3/keys";
 import { generateUploadUrl } from "@/lib/server/reimbursements/files";
 
 type Props = {
   onUploadComplete: (key: string) => void;
   uploadSignature?: (blob: Blob) => Promise<string>;
+  reimbursementType?: ReimbursementStorageType;
 };
 
-export function SignatureCanvas({ onUploadComplete, uploadSignature }: Props) {
+export function SignatureCanvas({
+  onUploadComplete,
+  uploadSignature,
+  reimbursementType,
+}: Props) {
   const padRef = useRef<SignaturePad>(null);
   const [uploading, setUploading] = useState(false);
   useSignatureResize(padRef);
@@ -33,7 +39,14 @@ export function SignatureCanvas({ onUploadComplete, uploadSignature }: Props) {
       if (uploadSignature) {
         onUploadComplete(await uploadSignature(blob));
       } else {
-        const { key, url } = await generateUploadUrl("image/png");
+        if (!reimbursementType) {
+          throw new Error("Upload context is required");
+        }
+        const { key, url } = await generateUploadUrl(
+          "image/png",
+          reimbursementType,
+          "signature",
+        );
         const response = await fetch(url, {
           method: "PUT",
           headers: { "Content-Type": "image/png" },

--- a/app/components/Reimbursements/SignatureField.tsx
+++ b/app/components/Reimbursements/SignatureField.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, PenLine, RotateCcw, Smartphone } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import type { ReimbursementStorageType } from "@/lib/s3/keys";
 import { getFileUrlAction } from "@/lib/server/reimbursements/files";
 import { SignatureCanvas } from "./SignatureCanvas";
 import { SignatureQRPanel } from "./SignatureQRPanel";
@@ -14,6 +15,7 @@ interface Props {
   getFileUrl?: (storageId: string) => Promise<string | null>;
   onClear?: () => void;
   allowMobileHandoff?: boolean;
+  reimbursementType?: ReimbursementStorageType;
 }
 
 export function SignatureField({
@@ -23,6 +25,7 @@ export function SignatureField({
   getFileUrl = getFileUrlAction,
   onClear,
   allowMobileHandoff = true,
+  reimbursementType,
 }: Props) {
   const [mode, setMode] = useState<"direct" | "mobile">("direct");
 
@@ -65,9 +68,15 @@ export function SignatureField({
         <SignatureCanvas
           onUploadComplete={onSignatureComplete}
           uploadSignature={uploadSignature}
+          reimbursementType={reimbursementType}
         />
       ) : (
-        <SignatureQRPanel onSignatureComplete={onSignatureComplete} />
+        reimbursementType && (
+          <SignatureQRPanel
+            onSignatureComplete={onSignatureComplete}
+            reimbursementType={reimbursementType}
+          />
+        )
       )}
     </div>
   );

--- a/app/components/Reimbursements/SignatureQRPanel.tsx
+++ b/app/components/Reimbursements/SignatureQRPanel.tsx
@@ -6,14 +6,17 @@ import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { signStatus } from "@/(public)/_lib/signatures";
 import { Button } from "@/components/ui/button";
+import type { ReimbursementStorageType } from "@/lib/s3/keys";
 import { createToken } from "@/lib/server/signatures/actions";
 
 const POLL_INTERVAL_MS = 2000;
 
 export function SignatureQRPanel({
   onSignatureComplete,
+  reimbursementType,
 }: {
   onSignatureComplete: (key: string) => void;
+  reimbursementType: ReimbursementStorageType;
 }) {
   const [token, setToken] = useState<string | null>(null);
   const [tokenFailed, setTokenFailed] = useState(false);
@@ -23,7 +26,7 @@ export function SignatureQRPanel({
 
   useEffect(() => {
     let active = true;
-    createToken()
+    createToken(reimbursementType)
       .then((value) => {
         if (active) setToken(value);
       })
@@ -33,7 +36,7 @@ export function SignatureQRPanel({
     return () => {
       active = false;
     };
-  }, []);
+  }, [reimbursementType]);
 
   useEffect(() => {
     if (!token) return;

--- a/app/components/Reimbursements/TravelReimbursementFormUI.tsx
+++ b/app/components/Reimbursements/TravelReimbursementFormUI.tsx
@@ -78,6 +78,7 @@ export function TravelReimbursementFormUI({
               <SignatureField
                 onSignatureComplete={form.setSignature}
                 storageId={form.signature || undefined}
+                reimbursementType="travel"
               />
             </div>
           </>

--- a/app/components/Reimbursements/VolunteerAllowanceFormUI.tsx
+++ b/app/components/Reimbursements/VolunteerAllowanceFormUI.tsx
@@ -67,6 +67,7 @@ export function VolunteerAllowanceFormUI({
         <SignatureField
           onSignatureComplete={setSignature}
           storageId={signature || undefined}
+          reimbursementType="volunteer-allowance"
         />
       </div>
 

--- a/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
+++ b/app/components/Reimbursements/reimbursementForm/ReceiptDraftFields.tsx
@@ -135,6 +135,7 @@ export function ReceiptDraftFields({
         <ReceiptUpload
           onUploadComplete={(id) => setDraft({ ...draft, file: id })}
           storageId={draft.file || undefined}
+          reimbursementType="expense"
         />
       </div>
 

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -169,6 +169,7 @@ export function ReceiptCard({
             <ReceiptUpload
               onUploadComplete={(id) => onUpdate({ fileStorageId: id })}
               storageId={receipt.fileStorageId || undefined}
+              reimbursementType="travel"
             />
           </div>
         )}

--- a/app/lib/db/signature.ts
+++ b/app/lib/db/signature.ts
@@ -1,9 +1,12 @@
+import type { ReimbursementStorageType } from "../s3/keys";
+
 export interface SignatureToken {
   _id: string;
   _creationTime: number;
   token: string;
   organizationId: string;
   createdBy: string;
+  reimbursementType?: ReimbursementStorageType;
   expiresAt: number;
   signatureStorageId?: string;
   pendingSignatureStorageId?: string;

--- a/app/lib/s3/keys.test.ts
+++ b/app/lib/s3/keys.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  profileImageUploadDirectory,
+  reimbursementUploadDirectory,
+} from "./keys";
+
+describe("profileImageUploadDirectory", () => {
+  test("builds a user-scoped profile image directory", () => {
+    expect(profileImageUploadDirectory("user-123")).toBe(
+      "profile-images/user-123",
+    );
+  });
+});
+
+describe("reimbursementUploadDirectory", () => {
+  test.each([
+    [
+      "expense",
+      "receipt",
+      "reimbursements/expense/org-123/receipts",
+    ],
+    [
+      "travel",
+      "signature",
+      "reimbursements/travel/org-123/signatures",
+    ],
+    [
+      "volunteer-allowance",
+      "signature",
+      "reimbursements/volunteer-allowance/org-123/signatures",
+    ],
+  ] as const)("builds the %s %s directory", (type, documentType, expected) => {
+    expect(
+      reimbursementUploadDirectory(type, "org-123", documentType),
+    ).toBe(expected);
+  });
+
+  test("rejects organization IDs that could escape their directory", () => {
+    expect(() =>
+      reimbursementUploadDirectory("expense", "../other", "receipt"),
+    ).toThrow("Invalid organization ID");
+  });
+});

--- a/app/lib/s3/keys.ts
+++ b/app/lib/s3/keys.ts
@@ -1,0 +1,34 @@
+export const REIMBURSEMENT_STORAGE_TYPES = [
+  "expense",
+  "travel",
+  "volunteer-allowance",
+] as const;
+
+export type ReimbursementStorageType =
+  (typeof REIMBURSEMENT_STORAGE_TYPES)[number];
+export type ReimbursementDocumentType = "receipt" | "signature";
+
+const DOCUMENT_DIRECTORIES: Record<ReimbursementDocumentType, string> = {
+  receipt: "receipts",
+  signature: "signatures",
+};
+
+function assertSafePathSegment(value: string, name: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+    throw new Error(`Invalid ${name}`);
+  }
+}
+
+export function profileImageUploadDirectory(userId: string): string {
+  assertSafePathSegment(userId, "user ID");
+  return `profile-images/${userId}`;
+}
+
+export function reimbursementUploadDirectory(
+  type: ReimbursementStorageType,
+  organizationId: string,
+  documentType: ReimbursementDocumentType,
+): string {
+  assertSafePathSegment(organizationId, "organization ID");
+  return `reimbursements/${type}/${organizationId}/${DOCUMENT_DIRECTORIES[documentType]}`;
+}

--- a/app/lib/s3/storage.ts
+++ b/app/lib/s3/storage.ts
@@ -53,12 +53,13 @@ const ALLOWED_UPLOAD_TYPES = new Set([
 ]);
 
 export async function presignUpload(
-  contentType?: string,
+  contentType: string | undefined,
+  directory: string,
 ): Promise<{ key: string; url: string }> {
   if (!contentType || !ALLOWED_UPLOAD_TYPES.has(contentType)) {
     throw new Error("Unsupported file type");
   }
-  const key = crypto.randomUUID();
+  const key = `${directory.replace(/\/+$/, "")}/${crypto.randomUUID()}`;
   const url = await getSignedUrl(
     s3(),
     new PutObjectCommand({

--- a/app/lib/server/profile/actions.ts
+++ b/app/lib/server/profile/actions.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { requireAuthenticatedUser } from "../../auth/session";
 import { users } from "../../db/collections";
+import { profileImageUploadDirectory } from "../../s3/keys";
 import {
   getObjectBuffer,
   getObjectSize,
@@ -47,7 +48,10 @@ export async function generateProfileImageUpload(
     throw new Error("Bitte verwende ein JPEG- oder PNG-Bild");
   }
 
-  const upload = await presignUpload(contentType);
+  const upload = await presignUpload(
+    contentType,
+    profileImageUploadDirectory(user._id),
+  );
   await registerPendingUpload(upload.key, {
     organizationId: user.organizationId,
     userId: user._id,

--- a/app/lib/server/reimbursements/files.ts
+++ b/app/lib/server/reimbursements/files.ts
@@ -1,6 +1,11 @@
 "use server";
 
 import { requireUser } from "../../auth/session";
+import {
+  type ReimbursementDocumentType,
+  type ReimbursementStorageType,
+  reimbursementUploadDirectory,
+} from "../../s3/keys";
 import { presignUpload } from "../../s3/storage";
 import { getOrganization } from "../organizations/data";
 import { getProjectById } from "../projects/data";
@@ -21,9 +26,21 @@ export type ReimbursementPdfData = {
 
 export async function generateUploadUrl(
   contentType?: string,
+  reimbursementType?: ReimbursementStorageType,
+  documentType?: ReimbursementDocumentType,
 ): Promise<{ key: string; url: string }> {
   const user = await requireUser();
-  const upload = await presignUpload(contentType);
+  if (!reimbursementType || !documentType) {
+    throw new Error("Upload context is required");
+  }
+  const upload = await presignUpload(
+    contentType,
+    reimbursementUploadDirectory(
+      reimbursementType,
+      user.organizationId,
+      documentType,
+    ),
+  );
   await registerPendingUpload(upload.key, {
     organizationId: user.organizationId,
     userId: user._id,

--- a/app/lib/server/reimbursements/public.ts
+++ b/app/lib/server/reimbursements/public.ts
@@ -5,6 +5,10 @@ import {
   travelDetails,
 } from "../../db/collections";
 import { YFN_ORGANIZATION } from "../../organization";
+import {
+  type ReimbursementDocumentType,
+  reimbursementUploadDirectory,
+} from "../../s3/keys";
 import { presignDownload, presignUpload } from "../../s3/storage";
 import { contextOwnsUpload, registerPendingUpload } from "../uploads/ownership";
 
@@ -69,9 +73,18 @@ export async function getPublicReimbursement(id: string) {
 export async function createPublicReimbursementUpload(
   id: string,
   contentType?: string,
+  documentType?: ReimbursementDocumentType,
 ) {
   const doc = await requireOpenSharedReimbursement(id);
-  const upload = await presignUpload(contentType);
+  if (!documentType) throw new Error("Upload context is required");
+  const upload = await presignUpload(
+    contentType,
+    reimbursementUploadDirectory(
+      doc.type,
+      doc.organizationId,
+      documentType,
+    ),
+  );
   const result = await (
     await reimbursements()
   ).updateOne(

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -38,6 +38,7 @@ import {
   deleteObject,
   getDownloadInfo,
   presignDownload,
+  presignUpload,
 } from "../../s3/storage";
 import {
   createTestActor,
@@ -45,7 +46,11 @@ import {
   insertTestProject,
 } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
-import { submitPublicSignature } from "../signatures/public";
+import { createToken } from "../signatures/actions";
+import {
+  createPublicSignatureUpload,
+  submitPublicSignature,
+} from "../signatures/public";
 import {
   claimPendingUploads,
   registerPendingUpload,
@@ -60,8 +65,11 @@ import {
   sendSubmissionReceivedEmail,
   sendSubmissionRequestedEmail,
 } from "./email";
-import { getReimbursementPdfData } from "./files";
-import { getPublicReimbursementFileUrl } from "./public";
+import { generateUploadUrl, getReimbursementPdfData } from "./files";
+import {
+  createPublicReimbursementUpload,
+  getPublicReimbursementFileUrl,
+} from "./public";
 import { submitPublicReimbursement } from "./publicSubmission";
 import { approve, decline, markAsPaid, requestChanges } from "./review";
 import { createReimbursementLink, getPendingSharedLinks } from "./sharing";
@@ -152,6 +160,43 @@ function reimbursementInput() {
     ],
   };
 }
+
+test("creates reimbursement uploads below their typed storage directory", async () => {
+  await generateUploadUrl("application/pdf", "travel", "receipt");
+
+  expect(presignUpload).toHaveBeenCalledWith(
+    "application/pdf",
+    `reimbursements/travel/${orgA}/receipts`,
+  );
+});
+
+test("creates shared expense uploads below their document directory", async () => {
+  const id = await createReimbursementLink({
+    projectId: projectA,
+    type: "expense",
+  });
+
+  await createPublicReimbursementUpload(id, "image/png", "signature");
+
+  expect(presignUpload).toHaveBeenCalledWith(
+    "image/png",
+    `reimbursements/expense/${orgA}/signatures`,
+  );
+});
+
+test("keeps the reimbursement type for mobile signature uploads", async () => {
+  const token = await createToken("travel");
+
+  await createPublicSignatureUpload(token, "image/png");
+
+  expect(presignUpload).toHaveBeenCalledWith(
+    "image/png",
+    `reimbursements/travel/${orgA}/signatures`,
+  );
+  expect(
+    await (await signatureTokens()).findOne({ token }),
+  ).toMatchObject({ reimbursementType: "travel" });
+});
 
 async function completeMobileSignature(storageKey: string): Promise<void> {
   const tokenId = newId();

--- a/app/lib/server/signatures/actions.ts
+++ b/app/lib/server/signatures/actions.ts
@@ -1,13 +1,21 @@
 "use server";
 
+import { z } from "zod";
 import { requireUser } from "../../auth/session";
 import { signatureTokens } from "../../db/collections";
 import { newId } from "../../db/ids";
+import {
+  REIMBURSEMENT_STORAGE_TYPES,
+  type ReimbursementStorageType,
+} from "../../s3/keys";
 
 const TOKEN_EXPIRY_MS = 30 * 60 * 1000;
 
-export async function createToken(): Promise<string> {
+export async function createToken(
+  input: ReimbursementStorageType,
+): Promise<string> {
   const user = await requireUser();
+  const reimbursementType = z.enum(REIMBURSEMENT_STORAGE_TYPES).parse(input);
   const token = crypto.randomUUID();
 
   await (
@@ -18,6 +26,7 @@ export async function createToken(): Promise<string> {
     token,
     organizationId: user.organizationId,
     createdBy: user._id,
+    reimbursementType,
     expiresAt: Date.now() + TOKEN_EXPIRY_MS,
   });
 

--- a/app/lib/server/signatures/public.ts
+++ b/app/lib/server/signatures/public.ts
@@ -1,4 +1,5 @@
 import { signatureTokens } from "../../db/collections";
+import { reimbursementUploadDirectory } from "../../s3/keys";
 import { presignUpload } from "../../s3/storage";
 import {
   claimPendingUploads,
@@ -39,7 +40,15 @@ export async function createPublicSignatureUpload(
   contentType?: string,
 ) {
   const doc = await requireOpenToken(token);
-  const upload = await presignUpload(contentType);
+  if (!doc.reimbursementType) throw new Error("Upload context is missing");
+  const upload = await presignUpload(
+    contentType,
+    reimbursementUploadDirectory(
+      doc.reimbursementType,
+      doc.organizationId,
+      "signature",
+    ),
+  );
   const result = await (
     await signatureTokens()
   ).updateOne(

--- a/app/lib/server/volunteerAllowance/public.ts
+++ b/app/lib/server/volunteerAllowance/public.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import { projects, volunteerAllowance } from "../../db/collections";
 import { YFN_ORGANIZATION } from "../../organization";
+import { reimbursementUploadDirectory } from "../../s3/keys";
 import { presignUpload } from "../../s3/storage";
 import type { volunteerAllowanceSubmissionSchema } from "../../volunteerAllowance/schemas";
 import { addLog } from "../logs";
@@ -79,7 +80,14 @@ export async function createPublicAllowanceUpload(
   contentType?: string,
 ) {
   const doc = await requireOpenSharedAllowance(id);
-  const upload = await presignUpload(contentType);
+  const upload = await presignUpload(
+    contentType,
+    reimbursementUploadDirectory(
+      "volunteer-allowance",
+      doc.organizationId,
+      "signature",
+    ),
+  );
   const result = await (
     await volunteerAllowance()
   ).updateOne(


### PR DESCRIPTION
## summary

- store reimbursement receipts and signatures in type-, organization-, and document-scoped object storage directories
- preserve the reimbursement type through shared and mobile signature flows, and keep profile image uploads out of the bucket root
- existing bucket objects were migrated manually; no one-off migration script remains

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm test` (437 tests)
- `pnpm build`