### PR TITLE
feat(members): model public organization roles

### DIFF
--- a/app/(protected)/settings/members/MemberDrawer.tsx
+++ b/app/(protected)/settings/members/MemberDrawer.tsx
@@ -1,18 +1,31 @@
 "use client";
 
 import { DetailDrawer } from "@/components/Layout/DetailDrawer";
+import type { User } from "@/lib/db/types";
+import { useState } from "react";
 import type { MemberDrawerProps } from "./MemberDrawer.types";
 import { MemberDrawerPanel } from "./MemberDrawerPanel";
 import { useMemberDrawerForm } from "./useMemberDrawerForm";
 
-export function MemberDrawer(props: MemberDrawerProps) {
-  const { member, onClose } = props;
-  const form = useMemberDrawerForm(props);
-  const displayName =
+function memberDisplayName(member: User) {
+  return (
     member.name ||
     [member.firstName, member.lastName].filter(Boolean).join(" ") ||
-    "Teammitglied";
-  const content = (
+    "Teammitglied"
+  );
+}
+
+function MemberDrawerForm({
+  onSavingChange,
+  ...props
+}: MemberDrawerProps & {
+  onSavingChange: (isSaving: boolean) => void;
+}) {
+  const { member, onClose } = props;
+  const form = useMemberDrawerForm(props, onSavingChange);
+  const displayName = memberDisplayName(member);
+
+  return (
     <MemberDrawerPanel
       member={member}
       displayName={displayName}
@@ -20,6 +33,12 @@ export function MemberDrawer(props: MemberDrawerProps) {
       onClose={onClose}
     />
   );
+}
+
+export function MemberDrawer(props: MemberDrawerProps) {
+  const { member, onClose } = props;
+  const [isSaving, setIsSaving] = useState(false);
+  const displayName = memberDisplayName(member);
 
   return (
     <DetailDrawer
@@ -27,9 +46,13 @@ export function MemberDrawer(props: MemberDrawerProps) {
       description={`Teammitglied ${displayName} bearbeiten`}
       ariaLabel={`Teammitglied ${displayName} bearbeiten`}
       onClose={onClose}
-      closeDisabled={form.isSaving}
+      closeDisabled={isSaving}
     >
-      {content}
+      <MemberDrawerForm
+        key={member._id}
+        {...props}
+        onSavingChange={setIsSaving}
+      />
     </DetailDrawer>
   );
 }

--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -12,6 +12,7 @@ import { Loader2 } from "lucide-react";
 import { LabeledSelect } from "./LabeledSelect";
 import { MemberStatusField } from "./MemberStatusField";
 import { ROLE_OPTIONS, TEAM_ONBOARDING_OPTIONS } from "./memberLabels";
+import { PublicOrganizationFields } from "./PublicOrganizationFields";
 import type { MemberDrawerFormState } from "./useMemberDrawerForm";
 
 interface Props {
@@ -55,17 +56,9 @@ export function MemberDrawerPanel({
       </div>
 
       <div className="flex flex-1 flex-col gap-4 px-6">
-        <LabeledSelect
-          id="member-team"
-          label="Team"
-          value={form.teamId}
-          onValueChange={form.setTeamId}
-          options={form.teamOptions}
-          placeholder="Team wählen"
-          hint={`Department: ${form.department?.name ?? "—"}`}
-        />
+        <PublicOrganizationFields form={form} />
         <div className="grid gap-1.5">
-          <Label htmlFor="member-position">Position</Label>
+          <Label htmlFor="member-position">Position (optional)</Label>
           <Input
             id="member-position"
             value={form.position}
@@ -90,7 +83,7 @@ export function MemberDrawerPanel({
         />
         <LabeledSelect
           id="member-role"
-          label="Rolle"
+          label="Berechtigungen"
           value={form.role}
           onValueChange={(value) => form.setRole(value as UserRole)}
           options={ROLE_OPTIONS}

--- a/app/(protected)/settings/members/MemberStatusField.tsx
+++ b/app/(protected)/settings/members/MemberStatusField.tsx
@@ -24,7 +24,7 @@ export function MemberStatusField({ status, onboarding, onChange }: Props) {
       options={options}
       hint={
         isApprovalAllowed
-          ? "Aktive Mitglieder werden automatisch auf der Team-Seite synchronisiert."
+          ? undefined
           : "Die Aktivierung ist erst möglich, wenn alle Onboarding-Aufgaben abgeschlossen sind."
       }
     />

--- a/app/(protected)/settings/members/MembersClient.tsx
+++ b/app/(protected)/settings/members/MembersClient.tsx
@@ -173,7 +173,6 @@ export function MembersClient({
 
       {selectedMember && (
         <MemberDrawer
-          key={selectedMember._id}
           member={selectedMember}
           teams={teams}
           departments={departments}

--- a/app/(protected)/settings/members/PublicOrganizationFields.tsx
+++ b/app/(protected)/settings/members/PublicOrganizationFields.tsx
@@ -1,0 +1,70 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { LabeledSelect } from "./LabeledSelect";
+import type { MemberDrawerFormState } from "./useMemberDrawerForm";
+
+export function PublicOrganizationFields({
+  form,
+}: {
+  form: MemberDrawerFormState;
+}) {
+  return (
+    <fieldset className="grid gap-4 border-t pt-5">
+      <legend className="pr-3 text-sm font-semibold">Organisation</legend>
+
+      <div className="flex items-center gap-3">
+        <Checkbox
+          id="member-board"
+          checked={form.isBoardMember}
+          onCheckedChange={(checked) => form.setIsBoardMember(checked === true)}
+        />
+        <Label htmlFor="member-board">Vorstand</Label>
+      </div>
+
+      {form.isBoardMember ? (
+        <div className="grid gap-4">
+          <LabeledSelect
+            id="member-board-department"
+            label="Department"
+            value={form.boardDepartmentId}
+            onValueChange={form.setBoardDepartmentId}
+            options={form.departmentOptions}
+            placeholder="Department wählen"
+          />
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="member-board-chair"
+              checked={form.boardIsChair}
+              onCheckedChange={(checked) =>
+                form.setBoardIsChair(checked === true)
+              }
+            />
+            <Label htmlFor="member-board-chair">Vorsitz</Label>
+          </div>
+        </div>
+      ) : (
+        <>
+          <LabeledSelect
+            id="member-team"
+            label="Team"
+            value={form.teamId}
+            onValueChange={form.setTeamId}
+            options={form.teamOptions}
+            placeholder="Team wählen"
+            hint={`Department: ${form.department?.name ?? "—"}`}
+          />
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="member-team-lead"
+              checked={form.isTeamLead}
+              onCheckedChange={(checked) =>
+                form.setIsTeamLead(checked === true)
+              }
+            />
+            <Label htmlFor="member-team-lead">Team-Lead</Label>
+          </div>
+        </>
+      )}
+    </fieldset>
+  );
+}

--- a/app/(protected)/settings/members/useMemberDrawerForm.ts
+++ b/app/(protected)/settings/members/useMemberDrawerForm.ts
@@ -35,11 +35,28 @@ export function useMemberDrawerForm(
     member.teamOnboardingStatus,
   );
   const [role, setRole] = useState<UserRole>(member.role ?? "member");
+  const [isTeamLead, setIsTeamLead] = useState(member.isTeamLead ?? false);
+  const [isBoardMember, setIsBoardMember] = useState(
+    member.boardMembership !== undefined,
+  );
+  const [boardDepartmentId, setBoardDepartmentId] = useState(
+    member.boardMembership?.departmentId ?? "",
+  );
+  const [boardIsChair, setBoardIsChair] = useState(
+    member.boardMembership?.isChair ?? false,
+  );
 
   const activeTeams = teams.filter((team) => !team.isArchived);
+  const activeDepartments = departments.filter(
+    (department) => !department.isArchived,
+  );
   const teamOptions = activeTeams.map((team) => ({
     value: team._id,
     label: team.name,
+  }));
+  const departmentOptions = activeDepartments.map((department) => ({
+    value: department._id,
+    label: department.name,
   }));
   const selectedTeam = activeTeams.find((team) => team._id === teamId);
   const department = selectedTeam
@@ -55,17 +72,57 @@ export function useMemberDrawerForm(
     onSavingChange(true);
 
     try {
+      if (isBoardMember && !boardDepartmentId) {
+        toast.error("Bitte wähle ein Department aus.");
+        return;
+      }
+      if (!isBoardMember && status === "active" && !teamId) {
+        toast.error("Bitte wähle ein Team aus.");
+        return;
+      }
+
       const profile: {
         userId: string;
-        teamId?: string;
-        positionTitle?: string;
+        teamId?: string | null;
+        positionTitle?: string | null;
+        isTeamLead?: boolean;
+        boardMembership?: {
+          departmentId: string;
+          isChair: boolean;
+        } | null;
       } = { userId: member._id };
-      if (teamId && teamId !== member.teamId) profile.teamId = teamId;
+      if (isBoardMember) {
+        if (member.teamId) profile.teamId = null;
+      } else if (teamId && teamId !== member.teamId) {
+        profile.teamId = teamId;
+      }
       const trimmed = position.trim();
-      if (trimmed && trimmed !== member.positionTitle)
-        profile.positionTitle = trimmed;
-      if (profile.teamId || profile.positionTitle)
+      const currentPosition = member.positionTitle?.trim() ?? "";
+      if (trimmed !== currentPosition) {
+        profile.positionTitle = trimmed || null;
+      }
+      const nextIsTeamLead = isBoardMember ? false : isTeamLead;
+      if (nextIsTeamLead !== (member.isTeamLead ?? false)) {
+        profile.isTeamLead = nextIsTeamLead;
+      }
+      const nextBoardMembership = isBoardMember
+        ? { departmentId: boardDepartmentId, isChair: boardIsChair }
+        : null;
+      const currentBoardMembership = member.boardMembership ?? null;
+      if (
+        JSON.stringify(nextBoardMembership) !==
+        JSON.stringify(currentBoardMembership)
+      ) {
+        profile.boardMembership = nextBoardMembership;
+      }
+      if (
+        profile.teamId ||
+        profile.positionTitle !== undefined ||
+        profile.isTeamLead !== undefined ||
+        profile.boardMembership !== undefined
+      ) {
         await updateProfile.mutateAsync(profile);
+      }
 
       if (onboarding !== member.teamOnboardingStatus)
         await setOnboardingMutation.mutateAsync({
@@ -107,7 +164,16 @@ export function useMemberDrawerForm(
     setOnboarding,
     role,
     setRole,
+    isTeamLead,
+    setIsTeamLead,
+    isBoardMember,
+    setIsBoardMember,
+    boardDepartmentId,
+    setBoardDepartmentId,
+    boardIsChair,
+    setBoardIsChair,
     teamOptions,
+    departmentOptions,
     department,
     canEditRoles,
     isSaving,

--- a/app/(protected)/settings/members/useMemberDrawerForm.ts
+++ b/app/(protected)/settings/members/useMemberDrawerForm.ts
@@ -11,14 +11,17 @@ import type { MemberDrawerProps } from "./MemberDrawer.types";
 const LAST_ADMIN_MESSAGE =
   "Der letzte Admin kann nicht entfernt werden. Mindestens ein Admin ist erforderlich.";
 
-export function useMemberDrawerForm({
-  member,
-  teams,
-  departments,
-  canEditRoles,
-  adminCount,
-  onClose,
-}: MemberDrawerProps) {
+export function useMemberDrawerForm(
+  {
+    member,
+    teams,
+    departments,
+    canEditRoles,
+    adminCount,
+    onClose,
+  }: MemberDrawerProps,
+  onSavingChange: (isSaving: boolean) => void,
+) {
   const {
     updateProfile,
     setStatus: setStatusMutation,
@@ -49,6 +52,8 @@ export function useMemberDrawerForm({
     updateRole.isPending;
 
   const handleSave = async () => {
+    onSavingChange(true);
+
     try {
       const profile: {
         userId: string;
@@ -86,6 +91,8 @@ export function useMemberDrawerForm({
       toast.error(
         error instanceof Error ? error.message : "Fehler beim Speichern",
       );
+    } finally {
+      onSavingChange(false);
     }
   };
 

--- a/app/api/v1/team-directory/route.test.ts
+++ b/app/api/v1/team-directory/route.test.ts
@@ -33,7 +33,7 @@ test("GET returns the versioned feed and revision ETag", async () => {
     version: "v1",
     generatedAt: "2026-07-27T12:00:00.000Z",
     revision: "revision-1",
-    data: { departments: [] },
+    data: { board: [], departments: [] },
   });
 
   const response = await GET(
@@ -54,7 +54,7 @@ test("GET returns 304 when the feed revision is unchanged", async () => {
     version: "v1",
     generatedAt: "2026-07-27T12:00:00.000Z",
     revision: "revision-1",
-    data: { departments: [] },
+    data: { board: [], departments: [] },
   });
 
   const response = await GET(

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -16,6 +16,7 @@ export type { CostType, MealAllowance, MealAllowanceLine } from "./travelTypes";
 export type { SignatureToken } from "./signature";
 export type { UploadContextType, UploadOwnership } from "./upload";
 export type {
+  BoardMembership,
   MemberStatus,
   ProfileImageSource,
   TeamOnboardingStatus,

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -3,6 +3,11 @@ export type MemberStatus = "onboarding" | "active" | "inactive" | "offboarded";
 export type TeamOnboardingStatus = "not_started" | "in_progress" | "completed";
 export type ProfileImageSource = "google" | "upload";
 
+export interface BoardMembership {
+  departmentId: string;
+  isChair: boolean;
+}
+
 export interface User {
   _id: string;
   _creationTime: number;
@@ -30,6 +35,8 @@ export interface User {
   accountHolder?: string;
   teamId?: string;
   positionTitle?: string;
+  isTeamLead?: boolean;
+  boardMembership?: BoardMembership;
   applicationId?: string;
   memberStatus: MemberStatus;
   teamOnboardingStatus: TeamOnboardingStatus;

--- a/app/lib/server/teamDirectory/feed.test.ts
+++ b/app/lib/server/teamDirectory/feed.test.ts
@@ -71,17 +71,32 @@ test("returns active members directly from their ybase profiles", async () => {
     member({
       _id: "member-visible",
       name: "Ada Beispiel",
+      isTeamLead: true,
       profileImageStorageKey: "profile-image",
       publicProfileCompletedAt: 100,
     }),
     member({
+      _id: "member-board",
+      name: "Board Person",
+      teamId: undefined,
+      boardMembership: {
+        departmentId: "department-operations",
+        isChair: true,
+      },
+    }),
+    member({
       _id: "member-defaults",
-      name: "Default Person",
+      name: "Aaron Default",
     }),
     member({
       _id: "member-offboarded",
       name: "Former Person",
+      teamId: undefined,
       memberStatus: "offboarded",
+      boardMembership: {
+        departmentId: "department-operations",
+        isChair: false,
+      },
     }),
     member({
       _id: "member-archived-team",
@@ -94,35 +109,53 @@ test("returns active members directly from their ybase profiles", async () => {
 
   expect(feed.version).toBe("v1");
   expect(feed.revision).toHaveLength(64);
+  expect(feed.data.board).toEqual([
+    {
+      id: `ybase:${organizationId}:member:member-board`,
+      departmentId: `ybase:${organizationId}:department:department-operations`,
+      name: "Board Person",
+      role: "Operations",
+      isChair: true,
+    },
+  ]);
   expect(feed.data.departments).toHaveLength(1);
   expect(feed.data.departments[0]?.teams[0]?.members).toEqual([
     {
       id: `ybase:${organizationId}:member:member-visible`,
       name: "Ada Beispiel",
-      role: "People Lead",
+      role: "Lead",
+      isLead: true,
       imageUrl: `${publicOrigin}/api/v1/team-directory/images/member-visible`,
     },
     {
       id: `ybase:${organizationId}:member:member-defaults`,
-      name: "Default Person",
-      role: "People Lead",
+      name: "Aaron Default",
+      role: "",
+      isLead: false,
     },
   ]);
 });
 
-test("omits incomplete profiles and teams without public members", async () => {
+test("includes members without a position", async () => {
   await (
     await users()
   ).insertOne(
     member({
-      _id: "member-without-role",
+      _id: "member-without-position",
       positionTitle: undefined,
     }),
   );
 
   const feed = await getTeamDirectory(organizationId, publicOrigin);
 
-  expect(feed.data).toEqual({ departments: [] });
+  expect(feed.data.departments[0]?.teams[0]?.members).toEqual([
+    {
+      id: `ybase:${organizationId}:member:member-without-position`,
+      name: "Test Member",
+      role: "",
+      isLead: false,
+    },
+  ]);
 });
 
 function member(

--- a/app/lib/server/teamDirectory/feed.ts
+++ b/app/lib/server/teamDirectory/feed.ts
@@ -1,33 +1,20 @@
 import { createHash } from "node:crypto";
 import { departments, teams, users } from "../../db/collections";
-import type { Department, Team, User } from "../../db/types";
+import type { Department, Team } from "../../db/types";
+import {
+  boardMemberDto,
+  byBoardRole,
+  byLeadAndName,
+  byName,
+  type DirectoryUser,
+  memberDto,
+  profileName,
+} from "./memberMappers";
 import type {
   TeamDirectoryData,
   TeamDirectoryDepartment,
   TeamDirectoryFeed,
-  TeamDirectoryMember,
 } from "./types";
-
-type DirectoryUser = Pick<
-  User,
-  | "_id"
-  | "name"
-  | "teamId"
-  | "positionTitle"
-  | "profileImageStorageKey"
-  | "publicProfileCompletedAt"
->;
-
-const byName = (left: { name: string }, right: { name: string }) =>
-  left.name.localeCompare(right.name, "de");
-
-function profileName(user: DirectoryUser): string {
-  return user.name?.trim() ?? "";
-}
-
-function profileRole(user: DirectoryUser): string {
-  return user.positionTitle?.trim() ?? "";
-}
 
 function namespacedId(
   organizationId: string,
@@ -35,23 +22,6 @@ function namespacedId(
   id: string,
 ): string {
   return `ybase:${organizationId}:${entity}:${id}`;
-}
-
-function memberDto(
-  user: DirectoryUser,
-  organizationId: string,
-  publicOrigin: string,
-): TeamDirectoryMember {
-  return {
-    id: namespacedId(organizationId, "member", user._id),
-    name: profileName(user),
-    role: profileRole(user),
-    ...(user.profileImageStorageKey && user.publicProfileCompletedAt
-      ? {
-          imageUrl: `${publicOrigin}/api/v1/team-directory/images/${encodeURIComponent(user._id)}`,
-        }
-      : {}),
-  };
 }
 
 export async function getTeamDirectory(
@@ -70,7 +40,8 @@ export async function getTeamDirectory(
         _id: 1,
         name: 1,
         teamId: 1,
-        positionTitle: 1,
+        isTeamLead: 1,
+        boardMembership: 1,
         profileImageStorageKey: 1,
         publicProfileCompletedAt: 1,
       })
@@ -87,13 +58,24 @@ export async function getTeamDirectory(
   const eligibleMembers = memberDocs.filter(
     (member) =>
       Boolean(member.teamId && activeTeamIds.has(member.teamId)) &&
-      Boolean(profileName(member)) &&
-      Boolean(profileRole(member)),
+      Boolean(profileName(member)),
   );
   const teamsByDepartment = groupTeams(activeTeams);
   const membersByTeam = groupMembers(eligibleMembers);
 
   const data: TeamDirectoryData = {
+    board: memberDocs
+      .flatMap((member) => {
+        const boardMember = boardMemberDto(
+          member,
+          organizationId,
+          member.boardMembership
+            ? activeDepartments.get(member.boardMembership.departmentId)
+            : undefined,
+        );
+        return boardMember ? [boardMember] : [];
+      })
+      .sort(byBoardRole),
     departments: departmentDocs
       .map((department) =>
         departmentDto(
@@ -158,7 +140,7 @@ function departmentDto(
         name: team.name,
         members: (membersByTeam.get(team._id) ?? [])
           .map((member) => memberDto(member, organizationId, publicOrigin))
-          .sort(byName),
+          .sort(byLeadAndName),
       }))
       .filter((team) => team.members.length > 0)
       .sort(byName),

--- a/app/lib/server/teamDirectory/memberMappers.ts
+++ b/app/lib/server/teamDirectory/memberMappers.ts
@@ -1,0 +1,74 @@
+import type { Department, User } from "../../db/types";
+import type { TeamDirectoryBoardMember, TeamDirectoryMember } from "./types";
+
+export type DirectoryUser = Pick<
+  User,
+  | "_id"
+  | "name"
+  | "teamId"
+  | "isTeamLead"
+  | "boardMembership"
+  | "profileImageStorageKey"
+  | "publicProfileCompletedAt"
+>;
+
+export const byName = (left: { name: string }, right: { name: string }) =>
+  left.name.localeCompare(right.name, "de");
+
+export const byLeadAndName = (
+  left: TeamDirectoryMember,
+  right: TeamDirectoryMember,
+) => Number(right.isLead) - Number(left.isLead) || byName(left, right);
+
+export const byBoardRole = (
+  left: TeamDirectoryBoardMember,
+  right: TeamDirectoryBoardMember,
+) =>
+  Number(right.isChair) - Number(left.isChair) ||
+  left.role.localeCompare(right.role, "de") ||
+  byName(left, right);
+
+export function profileName(user: DirectoryUser): string {
+  return user.name?.trim() ?? "";
+}
+
+function memberId(organizationId: string, userId: string): string {
+  return `ybase:${organizationId}:member:${userId}`;
+}
+
+export function memberDto(
+  user: DirectoryUser,
+  organizationId: string,
+  publicOrigin: string,
+): TeamDirectoryMember {
+  const isLead = user.isTeamLead ?? false;
+  return {
+    id: memberId(organizationId, user._id),
+    name: profileName(user),
+    role: isLead ? "Lead" : "",
+    isLead,
+    ...(user.profileImageStorageKey && user.publicProfileCompletedAt
+      ? {
+          imageUrl: `${publicOrigin}/api/v1/team-directory/images/${encodeURIComponent(user._id)}`,
+        }
+      : {}),
+  };
+}
+
+export function boardMemberDto(
+  user: DirectoryUser,
+  organizationId: string,
+  department: Pick<Department, "_id" | "name"> | undefined,
+): TeamDirectoryBoardMember | null {
+  const boardMembership = user.boardMembership;
+  const name = profileName(user);
+  if (!boardMembership || !department || !name) return null;
+
+  return {
+    id: memberId(organizationId, user._id),
+    departmentId: `ybase:${organizationId}:department:${department._id}`,
+    name,
+    role: department.name,
+    isChair: boardMembership.isChair,
+  };
+}

--- a/app/lib/server/teamDirectory/types.ts
+++ b/app/lib/server/teamDirectory/types.ts
@@ -2,7 +2,16 @@ export interface TeamDirectoryMember {
   id: string;
   name: string;
   role: string;
+  isLead: boolean;
   imageUrl?: string;
+}
+
+export interface TeamDirectoryBoardMember {
+  id: string;
+  departmentId: string;
+  name: string;
+  role: string;
+  isChair: boolean;
 }
 
 export interface TeamDirectoryTeam {
@@ -18,6 +27,7 @@ export interface TeamDirectoryDepartment {
 }
 
 export interface TeamDirectoryData {
+  board: TeamDirectoryBoardMember[];
   departments: TeamDirectoryDepartment[];
 }
 

--- a/app/lib/server/users/access.ts
+++ b/app/lib/server/users/access.ts
@@ -1,5 +1,5 @@
 import { requirePermission } from "../../auth/session";
-import { teams, users } from "../../db/collections";
+import { departments, teams, users } from "../../db/collections";
 
 export async function loadManagedMember(userId: string) {
   const currentUser = await requirePermission("manage_members");
@@ -23,4 +23,19 @@ export async function requireActiveOrganizationTeam(
   });
   if (!team) throw new Error("Team nicht verfügbar");
   return team;
+}
+
+export async function requireActiveOrganizationDepartment(
+  departmentId: string,
+  organizationId: string,
+) {
+  const department = await (
+    await departments()
+  ).findOne({
+    _id: departmentId,
+    organizationId,
+    isArchived: false,
+  });
+  if (!department) throw new Error("Department nicht verfügbar");
+  return department;
 }

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 import { users } from "../../db/collections";
 import type { MemberStatus } from "../../db/types";
 import { addLog } from "../logs";
-import { loadManagedMember, requireActiveOrganizationTeam } from "./access";
+import {
+  loadManagedMember,
+  requireActiveOrganizationDepartment,
+  requireActiveOrganizationTeam,
+} from "./access";
 import { memberStatusPatch, teamOnboardingPatch } from "./memberLifecycle";
 
 const memberStatusSchema = z.enum([
@@ -33,19 +37,30 @@ export async function setMemberStatus(input: {
     );
   }
   if (status === "active") {
-    if (
-      !target.teamId ||
-      !target.name?.trim() ||
-      !target.positionTitle?.trim()
-    ) {
-      throw new Error(
-        "Aktive Mitglieder benötigen einen Namen, ein aktives Team und eine Position.",
+    if (!target.name?.trim()) {
+      throw new Error("Aktive Mitglieder benötigen einen Namen.");
+    }
+    if (target.boardMembership) {
+      if (target.teamId) {
+        throw new Error(
+          "Vorstandsmitglieder dürfen keinem Team direkt zugeordnet sein.",
+        );
+      }
+      await requireActiveOrganizationDepartment(
+        target.boardMembership.departmentId,
+        currentUser.organizationId,
+      );
+    } else {
+      if (!target.teamId) {
+        throw new Error(
+          "Aktive Mitglieder benötigen ein aktives Team oder ein Vorstands-Department.",
+        );
+      }
+      await requireActiveOrganizationTeam(
+        target.teamId,
+        currentUser.organizationId,
       );
     }
-    await requireActiveOrganizationTeam(
-      target.teamId,
-      currentUser.organizationId,
-    );
   }
 
   const patch = memberStatusPatch(target.memberStatus, status, Date.now());

--- a/app/lib/server/users/profile.ts
+++ b/app/lib/server/users/profile.ts
@@ -1,11 +1,16 @@
 "use server";
 
 import { z } from "zod";
+import type { UpdateFilter } from "mongodb";
 import { requireUser } from "../../auth/session";
 import { users } from "../../db/collections";
 import type { User } from "../../db/types";
 import { bankDetailsSchema } from "../bankDetails";
-import { loadManagedMember, requireActiveOrganizationTeam } from "./access";
+import {
+  loadManagedMember,
+  requireActiveOrganizationDepartment,
+  requireActiveOrganizationTeam,
+} from "./access";
 
 export async function updateBankDetails(input: {
   iban: string;
@@ -21,24 +26,80 @@ export async function updateBankDetails(input: {
 
 export async function updateMemberProfile(input: {
   userId: string;
-  teamId?: string;
-  positionTitle?: string;
+  teamId?: string | null;
+  positionTitle?: string | null;
+  isTeamLead?: boolean;
+  boardMembership?: {
+    departmentId: string;
+    isChair: boolean;
+  } | null;
 }): Promise<void> {
-  const { userId, teamId, positionTitle } = z
+  const { userId, teamId, positionTitle, isTeamLead, boardMembership } = z
     .object({
       userId: z.string(),
-      teamId: z.string().trim().min(1).optional(),
-      positionTitle: z.string().trim().min(1).optional(),
+      teamId: z.string().trim().min(1).nullable().optional(),
+      positionTitle: z.string().trim().min(1).nullable().optional(),
+      isTeamLead: z.boolean().optional(),
+      boardMembership: z
+        .object({
+          departmentId: z.string().trim().min(1),
+          isChair: z.boolean(),
+        })
+        .nullable()
+        .optional(),
     })
     .parse(input);
   const { currentUser, target } = await loadManagedMember(userId);
+  const hasBoardAssignment =
+    boardMembership !== null &&
+    (boardMembership !== undefined || target.boardMembership !== undefined);
+  if (
+    hasBoardAssignment &&
+    (typeof teamId === "string" || isTeamLead === true)
+  ) {
+    throw new Error(
+      "Vorstandsmitglieder werden einem Department statt einem Team zugeordnet.",
+    );
+  }
 
-  const patch: Pick<User, "teamId" | "positionTitle"> = {};
-  if (teamId !== undefined) {
+  const patch: Partial<
+    Pick<User, "teamId" | "positionTitle" | "isTeamLead" | "boardMembership">
+  > = {};
+  if (teamId !== undefined && teamId !== null) {
     await requireActiveOrganizationTeam(teamId, currentUser.organizationId);
     patch.teamId = teamId;
   }
-  if (positionTitle !== undefined) patch.positionTitle = positionTitle;
-  if (Object.keys(patch).length === 0) return;
-  await (await users()).updateOne({ _id: target._id }, { $set: patch });
+  if (positionTitle !== undefined && positionTitle !== null) {
+    patch.positionTitle = positionTitle;
+  }
+  if (isTeamLead !== undefined) patch.isTeamLead = isTeamLead;
+  if (boardMembership !== undefined && boardMembership !== null) {
+    await requireActiveOrganizationDepartment(
+      boardMembership.departmentId,
+      currentUser.organizationId,
+    );
+    patch.boardMembership = boardMembership;
+    patch.isTeamLead = false;
+  }
+
+  const update: UpdateFilter<User> = {};
+  if (Object.keys(patch).length > 0) update.$set = patch;
+  if (
+    teamId === null ||
+    positionTitle === null ||
+    (boardMembership !== undefined && boardMembership !== null) ||
+    boardMembership === null
+  ) {
+    update.$unset = {
+      ...(teamId === null ||
+      (boardMembership !== undefined && boardMembership !== null)
+        ? { teamId: "" }
+        : {}),
+      ...(boardMembership === null ? { boardMembership: "" } : {}),
+      ...(positionTitle === null ? { positionTitle: "" } : {}),
+    };
+  }
+  if (Object.keys(update).length === 0) return;
+
+  await (await users()).updateOne({ _id: target._id }, update);
 }

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -11,7 +11,13 @@ import {
   requireRole,
   requireUser,
 } from "../../auth/session";
-import { logs, organizations, teams, users } from "../../db/collections";
+import {
+  departments,
+  logs,
+  organizations,
+  teams,
+  users,
+} from "../../db/collections";
 import { newId } from "../../db/ids";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
@@ -168,7 +174,6 @@ test("setMemberStatus approves a fully onboarded member", async () => {
   await updateMemberProfile({
     userId: memberA,
     teamId: "team-1",
-    positionTitle: "Teammitglied",
   });
   await setMemberStatus({ userId: memberA, status: "active" });
   const updated = await (await users()).findOne({ _id: memberA });
@@ -178,12 +183,27 @@ test("setMemberStatus approves a fully onboarded member", async () => {
   expect(log?.entityId).toBe(memberA);
 });
 
-test("setMemberStatus requires complete team settings before activation", async () => {
+test("setMemberStatus requires a team assignment before activation", async () => {
   await setTeamOnboardingStatus({ userId: memberA, status: "completed" });
 
   await expect(
     setMemberStatus({ userId: memberA, status: "active" }),
-  ).rejects.toThrow("einen Namen, ein aktives Team und eine Position");
+  ).rejects.toThrow("ein aktives Team");
+});
+
+test("setMemberStatus activates a board member without a team", async () => {
+  await setTeamOnboardingStatus({ userId: memberA, status: "completed" });
+  const departmentId = await seedDepartment(orgA);
+  await updateMemberProfile({
+    userId: memberA,
+    boardMembership: { departmentId, isChair: true },
+  });
+
+  await setMemberStatus({ userId: memberA, status: "active" });
+
+  const updated = await (await users()).findOne({ _id: memberA });
+  expect(updated?.memberStatus).toBe("active");
+  expect(updated?.teamId).toBeUndefined();
 });
 
 test("completed onboarding stays locked after member approval", async () => {
@@ -245,16 +265,99 @@ async function seedTeam(
   });
 }
 
-test("updateMemberProfile assigns an active team and position title", async () => {
+async function seedDepartment(
+  organizationId: string,
+  isArchived = false,
+): Promise<string> {
+  const departmentId = newId();
+  await (
+    await departments()
+  ).insertOne({
+    _id: departmentId,
+    _creationTime: Date.now(),
+    name: "Operations",
+    organizationId,
+    isArchived,
+    createdBy: adminA,
+  });
+  return departmentId;
+}
+
+test("updateMemberProfile assigns a team and can clear an optional position", async () => {
   await seedTeam("team-1", orgA);
   await updateMemberProfile({
     userId: memberA,
     teamId: "team-1",
     positionTitle: "Treasurer",
+    isTeamLead: true,
   });
   const updated = await (await users()).findOne({ _id: memberA });
   expect(updated?.teamId).toBe("team-1");
   expect(updated?.positionTitle).toBe("Treasurer");
+  expect(updated?.isTeamLead).toBe(true);
+
+  await updateMemberProfile({
+    userId: memberA,
+    positionTitle: null,
+  });
+  const cleared = await (await users()).findOne({ _id: memberA });
+  expect(cleared?.positionTitle).toBeUndefined();
+});
+
+test("updateMemberProfile assigns and removes a board membership", async () => {
+  await seedTeam("team-1", orgA);
+  await updateMemberProfile({
+    userId: memberA,
+    teamId: "team-1",
+    isTeamLead: true,
+  });
+  const departmentId = await seedDepartment(orgA);
+  await updateMemberProfile({
+    userId: memberA,
+    boardMembership: { departmentId, isChair: true },
+  });
+  const assigned = await (await users()).findOne({ _id: memberA });
+  expect(assigned?.boardMembership).toEqual({
+    departmentId,
+    isChair: true,
+  });
+  expect(assigned?.teamId).toBeUndefined();
+  expect(assigned?.isTeamLead).toBe(false);
+
+  await updateMemberProfile({
+    userId: memberA,
+    teamId: "team-1",
+    boardMembership: null,
+  });
+  const removed = await (await users()).findOne({ _id: memberA });
+  expect(removed).not.toHaveProperty("boardMembership");
+  expect(removed?.teamId).toBe("team-1");
+});
+
+test("updateMemberProfile rejects an unavailable board department", async () => {
+  const foreignDepartmentId = await seedDepartment(orgB);
+  await expect(
+    updateMemberProfile({
+      userId: memberA,
+      boardMembership: {
+        departmentId: foreignDepartmentId,
+        isChair: false,
+      },
+    }),
+  ).rejects.toThrow("Department nicht verfügbar");
+});
+
+test("updateMemberProfile prevents a board member from joining a team", async () => {
+  const departmentId = await seedDepartment(orgA);
+  await updateMemberProfile({
+    userId: memberA,
+    boardMembership: { departmentId, isChair: false },
+  });
+  await seedTeam("team-1", orgA);
+
+  await expect(
+    updateMemberProfile({ userId: memberA, teamId: "team-1" }),
+  ).rejects.toThrow("einem Department statt einem Team");
 });
 
 test("updateMemberProfile rejects a team from another org", async () => {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -48,9 +48,19 @@ erDiagram
         string role
         string teamId
         string positionTitle
+        boolean isTeamLead
+        object boardMembership
         string applicationId
         string memberStatus
         string teamOnboardingStatus
+    }
+
+    teams {
+        string _id
+        string organizationId
+        string departmentId
+        string name
+        boolean isArchived
     }
 
     projects {

--- a/docs/team-directory.md
+++ b/docs/team-directory.md
@@ -1,0 +1,80 @@
+# Team-Directory-Sync
+
+YBase ist die Quelle für die öffentliche Organisationsstruktur. Der
+read-only Endpoint `GET /api/v1/team-directory` veröffentlicht die Daten der
+Organisation aus `YFN_TEAM_DIRECTORY_ORGANIZATION_ID`.
+
+## Sichtbarkeit
+
+Der Feed enthält ausschließlich aktive Mitglieder. Für die operative
+Teamstruktur werden außerdem ein aktives Department, ein aktives Team und ein
+Name vorausgesetzt. Die interne Position ist optional und wird nicht im
+Organigramm veröffentlicht. Eine optionale `boardMembership` ordnet ein
+Vorstandsmitglied direkt einem aktiven Department zu. Vorstandsmitglieder sind
+keinem Team innerhalb dieses Departments zugeordnet.
+
+`isTeamLead` markiert Mitglieder, die im jeweiligen Team hervorgehoben werden.
+Für bestehende Consumer enthält `role` bei diesen Mitgliedern zusätzlich
+`"Lead"` und ist für alle anderen Mitglieder leer.
+
+Interne Berechtigungsrollen wie `admin`, `finance` oder `people_culture` werden
+nicht veröffentlicht.
+
+## Darstellung im Organigramm
+
+Der Consumer stellt die Ebenen in dieser Reihenfolge dar:
+
+1. Vorstand
+2. Departments
+3. Teams
+4. Teammitglieder
+
+Vorstandsmitglieder stehen auf Department-Ebene oberhalb der Teams. Innerhalb
+eines Teams stehen Leads vor den übrigen Mitgliedern und erhalten eine
+Lead-Hervorhebung. Weitere Positionen werden nicht dargestellt.
+
+## Vertrag
+
+```json
+{
+  "version": "v1",
+  "generatedAt": "2026-07-28T12:00:00.000Z",
+  "revision": "sha256",
+  "data": {
+    "board": [
+      {
+        "id": "ybase:org:member:user",
+        "departmentId": "ybase:org:department:department",
+        "name": "Ada Beispiel",
+        "role": "Operations",
+        "isChair": true
+      }
+    ],
+    "departments": [
+      {
+        "id": "ybase:org:department:department",
+        "name": "Programs",
+        "teams": [
+          {
+            "id": "ybase:org:team:team",
+            "name": "Startup in School",
+            "members": [
+              {
+                "id": "ybase:org:member:user",
+                "name": "Ada Beispiel",
+                "role": "Lead",
+                "isLead": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Die `revision` ist ein Hash über `data` und wird als ETag ausgeliefert. Der
+YBase-Endpoint darf 60 Sekunden gecacht und bis zu 300 Sekunden veraltet
+weiterverwendet werden. Der Landingpage-Consumer lädt den Feed serverseitig und
+revalidiert ihn derzeit alle fünf Minuten.


### PR DESCRIPTION
## summary

- add department-level board memberships and team-lead assignments to member management
- keep positions optional and publish only board/lead organization data through the team-directory feed
- preserve the drawer while switching profiles and remove redundant sync guidance

## validation

- `pnpm exec prettier --check <changed files>`
- `BIOME_THREADS=2 pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec vitest run app/api/v1/team-directory/route.test.ts app/lib/server/teamDirectory/feed.test.ts app/lib/server/users/users.test.ts`
- `pnpm test` (452 tests)