### PR TITLE
fix(members): separate member and application archives

### DIFF
--- a/app/(protected)/settings/members/MembersClient.tsx
+++ b/app/(protected)/settings/members/MembersClient.tsx
@@ -84,12 +84,6 @@ export function MembersClient({
         teamsById,
       )
     : [];
-  const showsApplications = [
-    "application",
-    "interview",
-    "onboarding",
-    "archived",
-  ].includes(stage);
   const showsMembers = memberStatuses.length > 0;
 
   const adminCount = members.filter((member) => member.role === "admin").length;
@@ -112,11 +106,8 @@ export function MembersClient({
         }}
       />
 
-      {showsApplications && selectedApplicationEmptyText ? (
-        <section className={stage === "archived" ? "space-y-4" : undefined}>
-          {stage === "archived" ? (
-            <h2 className="text-lg font-semibold">Archivierte Bewerbungen</h2>
-          ) : null}
+      {selectedApplicationEmptyText ? (
+        <section>
           <ApplicationsPanel
             applications={stagedApplications}
             members={members}

--- a/app/(protected)/settings/members/memberStagePresentation.ts
+++ b/app/(protected)/settings/members/memberStagePresentation.ts
@@ -20,10 +20,6 @@ export const APPLICATION_STAGE_EMPTY_TEXT: Partial<
     title: "Niemand im Onboarding",
     description: "Zugesagte und registrierte neue Mitglieder erscheinen hier.",
   },
-  archived: {
-    title: "Keine archivierten Bewerbungen",
-    description: "Abgelehnte und zurückgezogene Bewerbungen erscheinen hier.",
-  },
 };
 
 export const MEMBER_STAGE_EMPTY_TEXT: Partial<Record<MemberStage, EmptyText>> =

--- a/app/lib/members/stages.test.ts
+++ b/app/lib/members/stages.test.ts
@@ -90,7 +90,7 @@ describe("member lifecycle stages", () => {
       applicationsForStage(applications, "archived", memberStatusesById).map(
         (entry) => entry._id,
       ),
-    ).toEqual(["rejected", "withdrawn"]);
+    ).toEqual([]);
   });
 
   test("keeps accepted applications in one onboarding list", () => {
@@ -126,7 +126,7 @@ describe("member lifecycle stages", () => {
       inactive: 1,
       offboarding_planned: 1,
       offboarding: 1,
-      archived: 4,
+      archived: 2,
     });
   });
 });

--- a/app/lib/members/stages.ts
+++ b/app/lib/members/stages.ts
@@ -36,12 +36,11 @@ export function memberStageForStatus(status: MemberStatus): MemberStage {
 }
 
 const APPLICATION_STAGE_STATUSES: Record<
-  Extract<MemberStage, "application" | "interview" | "archived">,
+  Extract<MemberStage, "application" | "interview">,
   readonly ApplicationDisplayStatus[]
 > = {
   application: ["received", "review"],
   interview: ["interview"],
-  archived: ["rejected", "withdrawn"],
 };
 
 const MEMBER_STATUSES_BY_STAGE: Partial<

--- a/scripts/archive-inactive-members.mjs
+++ b/scripts/archive-inactive-members.mjs
@@ -1,0 +1,73 @@
+import dotenv from "dotenv";
+import { MongoClient } from "mongodb";
+
+dotenv.config({ quiet: true });
+
+const apply = process.argv.includes("--apply");
+const expectedCountArgument = process.argv.find((argument) =>
+  argument.startsWith("--expected-count="),
+);
+const expectedCount = expectedCountArgument
+  ? Number(expectedCountArgument.split("=")[1])
+  : undefined;
+const uri = process.env.MONGODB_URI;
+const databaseName = process.env.MONGODB_DB ?? "ybase";
+
+if (!uri) throw new Error("MONGODB_URI is required");
+if (
+  expectedCount !== undefined &&
+  (!Number.isSafeInteger(expectedCount) || expectedCount < 0)
+) {
+  throw new Error("--expected-count must be a non-negative integer");
+}
+
+const client = new MongoClient(uri);
+await client.connect();
+
+try {
+  const members = client.db(databaseName).collection("users");
+  const filter = { memberStatus: "inactive" };
+  const currentCount = await members.countDocuments(filter);
+
+  console.info(
+    `${apply ? "Apply" : "Dry run"}: ${currentCount} inactive member(s) in "${databaseName}".`,
+  );
+
+  if (!apply) {
+    console.info(
+      `Re-run with --apply --expected-count=${currentCount} after verifying a current backup.`,
+    );
+  } else {
+    if (expectedCount === undefined) {
+      throw new Error("--expected-count is required with --apply");
+    }
+    if (currentCount !== expectedCount) {
+      throw new Error(
+        `Expected ${expectedCount} inactive members, found ${currentCount}.`,
+      );
+    }
+
+    const now = Date.now();
+    const result = await members.updateMany(filter, [
+      {
+        $set: {
+          memberStatus: "archived",
+          archivedAt: { $ifNull: ["$archivedAt", now] },
+        },
+      },
+    ]);
+    const remainingCount = await members.countDocuments(filter);
+    const archivedCount = await members.countDocuments({
+      memberStatus: "archived",
+    });
+
+    console.info(
+      `Matched ${result.matchedCount}, modified ${result.modifiedCount}, remaining inactive ${remainingCount}, archived total ${archivedCount}.`,
+    );
+    if (remainingCount !== 0 || result.matchedCount !== expectedCount) {
+      throw new Error("Migration verification failed");
+    }
+  }
+} finally {
+  await client.close();
+}


### PR DESCRIPTION
## summary

- keep the archived member stage focused exclusively on archived and legacy-offboarded members
- leave rejected and withdrawn applications with their job posting in Recruiting, where the existing status filter remains available
- add a guarded inactive-to-archived migration with dry-run and expected-count verification
- production migration completed separately after a verified full backup: 51 inactive members archived, 0 inactive members remaining

## validation

- `pnpm exec vitest run app/lib/members/stages.test.ts app/lib/members/status.test.ts app/lib/server/teamDirectory/feed.test.ts app/components/Applications/applicationTable.test.ts` (15 passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `pnpm build`
- `node scripts/archive-inactive-members.mjs --apply --expected-count=51` (51 matched and modified; 0 inactive remaining)