### PR TITLE
fix(members): align empty state presentation

### DIFF
--- a/app/components/Applications/ApplicationsTable/ApplicationsTable.tsx
+++ b/app/components/Applications/ApplicationsTable/ApplicationsTable.tsx
@@ -36,9 +36,12 @@ export function ApplicationsTable({
   if (applications.length === 0) {
     return (
       <div className="rounded-md border py-12 text-center">
-        <Inbox className="mx-auto size-10 text-muted-foreground" />
-        <h3 className="mt-3 font-semibold">{emptyTitle}</h3>
-        <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p>
+        <Inbox
+          aria-hidden="true"
+          className="mx-auto size-12 text-muted-foreground"
+        />
+        <h3 className="mt-4 text-lg font-semibold">{emptyTitle}</h3>
+        <p className="mt-2 text-muted-foreground">{emptyDescription}</p>
       </div>
     );
   }


### PR DESCRIPTION
## summary

- align application empty-state icon sizing with every member lifecycle state
- use the same title and description typography across application and member lists
- mark the decorative application icon as hidden from assistive technology

## validation

- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check app/components/Applications/ApplicationsTable/ApplicationsTable.tsx`
- `pnpm exec biome lint app/components/Applications/ApplicationsTable/ApplicationsTable.tsx`
- `pnpm lint:lines`
- `git diff --check`
- `pnpm build`