### PR TITLE
fix(members): remove inactive lifecycle status

### DIFF
--- a/app/(protected)/OffboardedNotice.tsx
+++ b/app/(protected)/OffboardedNotice.tsx
@@ -7,7 +7,7 @@ export function OffboardedNotice() {
   return (
     <div className="flex min-h-screen items-center justify-center p-8">
       <div className="w-full max-w-sm space-y-4 text-center">
-        <h1 className="text-2xl font-bold">Mitgliedsprofil inaktiv</h1>
+        <h1 className="text-2xl font-bold">Mitgliedsprofil gesperrt</h1>
         <p className="text-muted-foreground text-sm">
           Dein Account bleibt vorerst bestehen, hat aber keinen Zugriff auf
           ybase. Bitte wende dich an People &amp; Culture, wenn das ein Fehler

--- a/app/(protected)/settings/members/memberLabels.test.ts
+++ b/app/(protected)/settings/members/memberLabels.test.ts
@@ -7,7 +7,6 @@ describe("memberStatusOptions", () => {
       "active",
       "offboarding_planned",
       "offboarding",
-      "inactive",
       "archived",
     ]);
   });
@@ -19,7 +18,6 @@ describe("memberStatusOptions", () => {
         "active",
         "offboarding_planned",
         "offboarding",
-        "inactive",
         "archived",
       ],
     );

--- a/app/(protected)/settings/members/memberLabels.ts
+++ b/app/(protected)/settings/members/memberLabels.ts
@@ -14,7 +14,6 @@ const MEMBER_STATUS_OPTIONS: Option<MemberStatus>[] = [
   { value: "active", label: "Vereinsmitglied" },
   { value: "offboarding_planned", label: "Offboarding vorgemerkt" },
   { value: "offboarding", label: "Offboarding" },
-  { value: "inactive", label: "Inaktiv" },
   { value: "archived", label: "Archiviert" },
 ];
 

--- a/app/(protected)/settings/members/memberStagePresentation.ts
+++ b/app/(protected)/settings/members/memberStagePresentation.ts
@@ -28,10 +28,6 @@ export const MEMBER_STAGE_EMPTY_TEXT: Partial<Record<MemberStage, EmptyText>> =
       title: "Keine Vereinsmitglieder gefunden",
       description: "Passe Suche oder Filter an, um Mitglieder anzuzeigen.",
     },
-    inactive: {
-      title: "Keine inaktiven Mitglieder",
-      description: "Vorübergehend inaktive Mitglieder erscheinen hier.",
-    },
     offboarding_planned: {
       title: "Kein Offboarding vorgemerkt",
       description:

--- a/app/components/Members/MemberStageBadge.tsx
+++ b/app/components/Members/MemberStageBadge.tsx
@@ -11,8 +11,6 @@ const MEMBER_STAGE_BADGE_STYLES: Record<MemberStage, string> = {
     "border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950/60 dark:text-blue-200",
   active:
     "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/60 dark:text-emerald-200",
-  inactive:
-    "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-200",
   offboarding_planned:
     "border-orange-200 bg-orange-50 text-orange-800 dark:border-orange-800 dark:bg-orange-950/60 dark:text-orange-200",
   offboarding:

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -2,7 +2,6 @@ export type UserRole = "admin" | "finance" | "people_culture" | "member";
 export type MemberStatus =
   | "onboarding"
   | "active"
-  | "inactive"
   | "offboarding_planned"
   | "offboarding"
   | "archived"

--- a/app/lib/members/stages.test.ts
+++ b/app/lib/members/stages.test.ts
@@ -54,7 +54,6 @@ describe("member lifecycle stages", () => {
   const members = [
     member("onboarding-member", "onboarding"),
     member("active-member", "active"),
-    member("inactive-member", "inactive"),
     member("planned-member", "offboarding_planned"),
     member("offboarding-member", "offboarding"),
     member("archived-member", "archived"),
@@ -104,9 +103,6 @@ describe("member lifecycle stages", () => {
 
   test("keeps offboarding phases separate and maps legacy records to archive", () => {
     expect(
-      membersForStage(members, "inactive").map((entry) => entry._id),
-    ).toEqual(["inactive-member"]);
-    expect(
       membersForStage(members, "offboarding_planned").map((entry) => entry._id),
     ).toEqual(["planned-member"]);
     expect(
@@ -123,7 +119,6 @@ describe("member lifecycle stages", () => {
       interview: 1,
       onboarding: 2,
       active: 1,
-      inactive: 1,
       offboarding_planned: 1,
       offboarding: 1,
       archived: 2,

--- a/app/lib/members/stages.ts
+++ b/app/lib/members/stages.ts
@@ -11,7 +11,6 @@ export const MEMBER_STAGE_OPTIONS = [
   { value: "active", label: "Vereinsmitglied" },
   { value: "offboarding_planned", label: "Offboarding vorgemerkt" },
   { value: "offboarding", label: "Offboarding" },
-  { value: "inactive", label: "Inaktiv" },
   { value: "archived", label: "Archiviert" },
 ] as const;
 
@@ -47,7 +46,6 @@ const MEMBER_STATUSES_BY_STAGE: Partial<
   Record<MemberStage, readonly MemberStatus[]>
 > = {
   active: ["active"],
-  inactive: ["inactive"],
   offboarding_planned: ["offboarding_planned"],
   offboarding: ["offboarding"],
   archived: ["archived", "offboarded"],

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -15,7 +15,6 @@ import { memberStatusPatch, teamOnboardingPatch } from "./memberLifecycle";
 const memberStatusSchema = z.enum([
   "onboarding",
   "active",
-  "inactive",
   "offboarding_planned",
   "offboarding",
   "archived",

--- a/app/lib/server/users/memberLifecycle.test.ts
+++ b/app/lib/server/users/memberLifecycle.test.ts
@@ -31,12 +31,9 @@ test("archiving a member records the completion timestamp", () => {
   });
 });
 
-test("member status without a target timestamp only updates the status", () => {
+test("returning to onboarding only updates the status", () => {
   expect(memberStatusPatch("active", "onboarding", NOW)).toEqual({
     memberStatus: "onboarding",
-  });
-  expect(memberStatusPatch("active", "inactive", NOW)).toEqual({
-    memberStatus: "inactive",
   });
 });
 

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -250,12 +250,6 @@ test("setMemberStatus maps legacy offboarded writes to archived", async () => {
   expect(typeof updated?.archivedAt).toBe("number");
 });
 
-test("setMemberStatus marks a member as inactive", async () => {
-  await setMemberStatus({ userId: memberA, status: "inactive" });
-  const updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.memberStatus).toBe("inactive");
-});
-
 test("setMemberStatus cannot touch a user from another org", async () => {
   await expect(
     setMemberStatus({ userId: memberB, status: "archived" }),


### PR DESCRIPTION
## summary

- remove the obsolete inactive member stage from tabs, filters, badges, form options, API validation, and shared types
- keep the historical inactive-to-archived migration script for auditability while production remains at 0 inactive members
- rename the unavailable-account heading from inactive to locked to avoid obsolete lifecycle wording

## validation

- `node scripts/archive-inactive-members.mjs` (dry run: 0 inactive members)
- `pnpm exec vitest run app/(protected)/settings/members/memberLabels.test.ts app/lib/members/stages.test.ts app/lib/server/users/memberLifecycle.test.ts app/lib/server/users/users.test.ts app/(protected)/settings/members/filterMembers.test.ts` (48 passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `git diff --check`
- `pnpm build`