### PR TITLE
feat(recruiting): add default job posting summary

### DIFF
--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -12,6 +12,8 @@ import { sanitizeRichText } from "./sanitize";
 import { provisionTallyFormDraft } from "./tallyFormProvisioning";
 
 const optionalText = z.string().trim().optional();
+const DEFAULT_SHORT_TEXT =
+  "Baue mit uns die größte Community für junge (angehende) Gründer:innen im deutschsprachigen Raum auf.";
 
 const contentSchema = z.object({
   title: z.string().trim().min(1),
@@ -76,6 +78,7 @@ export async function createJobPostingDraft(input: {
     teamId,
     status: "draft",
     title,
+    shortText: DEFAULT_SHORT_TEXT,
     createdBy: user._id,
   });
   await addLog(user.organizationId, user._id, "jobPosting.create", _id, title);

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -106,7 +106,13 @@ test("createJobPostingDraft stores a draft scoped to the org without a departmen
 
   const list = await getJobPostings();
   expect(list).toHaveLength(1);
-  expect(list[0]).toMatchObject({ _id: id, title: "Vorstand", teamId: teamA });
+  expect(list[0]).toMatchObject({
+    _id: id,
+    title: "Vorstand",
+    teamId: teamA,
+    shortText:
+      "Baue mit uns die größte Community für junge (angehende) Gründer:innen im deutschsprachigen Raum auf.",
+  });
   expect(list[0].status).toBe("draft");
   expect(list[0]).not.toHaveProperty("departmentId");
   expect(provisionTallyFormDraft).toHaveBeenCalledWith(


### PR DESCRIPTION
## summary

- prefill new job posting drafts with YFN-specific German summary copy
- cover the persisted default in the recruiting action integration test

## validation

- `pnpm exec prettier --check app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm exec biome lint app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run app/lib/server/jobPostings/jobPostings.test.ts`
- `git diff --check`