### PR TITLE
feat(members): add optional board positions

### DIFF
--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -62,8 +62,14 @@ export function MemberDrawerPanel({
             <Label htmlFor="member-position">Position (optional)</Label>
             <Input
               id="member-position"
-              value={form.position}
-              onChange={(event) => form.setPosition(event.target.value)}
+              value={
+                form.isBoardMember ? form.boardSecondaryRole : form.position
+              }
+              onChange={(event) =>
+                form.isBoardMember
+                  ? form.setBoardSecondaryRole(event.target.value)
+                  : form.setPosition(event.target.value)
+              }
               placeholder="z. B. Tech Lead"
             />
           </div>

--- a/app/(protected)/settings/members/MemberRow.tsx
+++ b/app/(protected)/settings/members/MemberRow.tsx
@@ -16,8 +16,12 @@ interface Props {
 }
 
 function positionLabel(member: User, teams: Team[]): string {
-  if (member.boardMembership?.isChair) return "Vorsitz";
-  if (member.boardMembership) return "Vorstand";
+  if (member.boardMembership) {
+    const boardRole = member.boardMembership.isChair ? "Vorsitz" : "Vorstand";
+    return member.boardMembership.secondaryRole
+      ? `${boardRole} · ${member.boardMembership.secondaryRole}`
+      : boardRole;
+  }
   if (teams.length > 0 && teams.every((team) => team.isChapter)) return "—";
   if (member.isTeamLead || member.isSecondaryTeamLead) return "Lead";
   return member.positionTitle || "—";

--- a/app/(protected)/settings/members/useBoardMembershipForm.ts
+++ b/app/(protected)/settings/members/useBoardMembershipForm.ts
@@ -1,0 +1,28 @@
+import type { User } from "@/lib/db/types";
+import { useState } from "react";
+
+export function useBoardMembershipForm(member: User) {
+  const [isBoardMember, setIsBoardMember] = useState(
+    member.boardMembership !== undefined,
+  );
+  const [boardDepartmentId, setBoardDepartmentId] = useState(
+    member.boardMembership?.departmentId ?? "",
+  );
+  const [boardIsChair, setBoardIsChair] = useState(
+    member.boardMembership?.isChair ?? false,
+  );
+  const [boardSecondaryRole, setBoardSecondaryRole] = useState(
+    member.boardMembership?.secondaryRole ?? "",
+  );
+
+  return {
+    isBoardMember,
+    setIsBoardMember,
+    boardDepartmentId,
+    setBoardDepartmentId,
+    boardIsChair,
+    setBoardIsChair,
+    boardSecondaryRole,
+    setBoardSecondaryRole,
+  };
+}

--- a/app/(protected)/settings/members/useMemberDrawerForm.ts
+++ b/app/(protected)/settings/members/useMemberDrawerForm.ts
@@ -5,6 +5,7 @@ import { useState } from "react";
 import toast from "react-hot-toast";
 import type { MemberDrawerProps } from "./MemberDrawer.types";
 import { memberOrganizationState } from "./memberOrganizationState";
+import { useBoardMembershipForm } from "./useBoardMembershipForm";
 
 const LAST_ADMIN_MESSAGE =
   "Der letzte Admin kann nicht entfernt werden. Mindestens ein Admin ist erforderlich.";
@@ -38,15 +39,7 @@ export function useMemberDrawerForm(
   const [isSecondaryTeamLead, setIsSecondaryTeamLead] = useState(
     member.isSecondaryTeamLead ?? false,
   );
-  const [isBoardMember, setIsBoardMember] = useState(
-    member.boardMembership !== undefined,
-  );
-  const [boardDepartmentId, setBoardDepartmentId] = useState(
-    member.boardMembership?.departmentId ?? "",
-  );
-  const [boardIsChair, setBoardIsChair] = useState(
-    member.boardMembership?.isChair ?? false,
-  );
+  const board = useBoardMembershipForm(member);
 
   const {
     teamOptions,
@@ -64,11 +57,11 @@ export function useMemberDrawerForm(
     onSavingChange(true);
 
     try {
-      if (isBoardMember && !boardDepartmentId) {
+      if (board.isBoardMember && !board.boardDepartmentId) {
         toast.error("Bitte wähle ein Department aus.");
         return;
       }
-      if (!isBoardMember && status === "active" && !teamId) {
+      if (!board.isBoardMember && status === "active" && !teamId) {
         toast.error("Bitte wähle ein Team aus.");
         return;
       }
@@ -87,37 +80,45 @@ export function useMemberDrawerForm(
         boardMembership?: {
           departmentId: string;
           isChair: boolean;
+          secondaryRole?: string;
         } | null;
       } = { userId: member._id };
-      if (isBoardMember) {
+      if (board.isBoardMember) {
         if (member.teamId) profile.teamId = null;
         if (member.secondaryTeamId) profile.secondaryTeamId = null;
       } else if (teamId && teamId !== member.teamId) {
         profile.teamId = teamId;
       }
       if (
-        !isBoardMember &&
+        !board.isBoardMember &&
         secondaryTeamId !== (member.secondaryTeamId ?? "")
       ) {
         profile.secondaryTeamId = secondaryTeamId || null;
       }
       const trimmed =
-        !isBoardMember && !hasNonChapterTeam ? "" : position.trim();
+        !board.isBoardMember && !hasNonChapterTeam ? "" : position.trim();
       const currentPosition = member.positionTitle?.trim() ?? "";
       if (trimmed !== currentPosition) {
         profile.positionTitle = trimmed || null;
       }
-      const nextIsTeamLead = isBoardMember ? false : isTeamLead;
+      const nextIsTeamLead = board.isBoardMember ? false : isTeamLead;
       if (nextIsTeamLead !== (member.isTeamLead ?? false)) {
         profile.isTeamLead = nextIsTeamLead;
       }
       const nextIsSecondaryTeamLead =
-        isBoardMember || !secondaryTeamId ? false : isSecondaryTeamLead;
+        board.isBoardMember || !secondaryTeamId ? false : isSecondaryTeamLead;
       if (nextIsSecondaryTeamLead !== (member.isSecondaryTeamLead ?? false)) {
         profile.isSecondaryTeamLead = nextIsSecondaryTeamLead;
       }
-      const nextBoardMembership = isBoardMember
-        ? { departmentId: boardDepartmentId, isChair: boardIsChair }
+      const trimmedBoardSecondaryRole = board.boardSecondaryRole.trim();
+      const nextBoardMembership = board.isBoardMember
+        ? {
+            departmentId: board.boardDepartmentId,
+            isChair: board.boardIsChair,
+            ...(trimmedBoardSecondaryRole
+              ? { secondaryRole: trimmedBoardSecondaryRole }
+              : {}),
+          }
         : null;
       const currentBoardMembership = member.boardMembership ?? null;
       if (
@@ -176,12 +177,7 @@ export function useMemberDrawerForm(
     setIsTeamLead,
     isSecondaryTeamLead,
     setIsSecondaryTeamLead,
-    isBoardMember,
-    setIsBoardMember,
-    boardDepartmentId,
-    setBoardDepartmentId,
-    boardIsChair,
-    setBoardIsChair,
+    ...board,
     teamOptions,
     departmentOptions,
     department,

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -12,6 +12,7 @@ export type ProfileImageSource = "google" | "upload";
 export interface BoardMembership {
   departmentId: string;
   isChair: boolean;
+  secondaryRole?: string;
 }
 
 export interface User {

--- a/app/lib/server/teamDirectory/feed.test.ts
+++ b/app/lib/server/teamDirectory/feed.test.ts
@@ -94,6 +94,16 @@ test("returns active members directly from their ybase profiles", async () => {
       boardMembership: {
         departmentId: "department-operations",
         isChair: true,
+        secondaryRole: "Finanzen",
+      },
+    }),
+    member({
+      _id: "member-board-without-secondary-role",
+      name: "Board Person Without Secondary Role",
+      teamId: undefined,
+      boardMembership: {
+        departmentId: "department-operations",
+        isChair: false,
       },
     }),
     member({
@@ -138,6 +148,14 @@ test("returns active members directly from their ybase profiles", async () => {
       name: "Board Person",
       role: "Operations",
       isChair: true,
+      secondaryRole: "Finanzen",
+    },
+    {
+      id: `ybase:${organizationId}:member:member-board-without-secondary-role`,
+      departmentId: `ybase:${organizationId}:department:department-operations`,
+      name: "Board Person Without Secondary Role",
+      role: "Operations",
+      isChair: false,
     },
   ]);
   expect(feed.data.departments).toHaveLength(1);

--- a/app/lib/server/teamDirectory/memberMappers.ts
+++ b/app/lib/server/teamDirectory/memberMappers.ts
@@ -72,5 +72,8 @@ export function boardMemberDto(
     name,
     role: department.name,
     isChair: boardMembership.isChair,
+    ...(boardMembership.secondaryRole
+      ? { secondaryRole: boardMembership.secondaryRole }
+      : {}),
   };
 }

--- a/app/lib/server/teamDirectory/types.ts
+++ b/app/lib/server/teamDirectory/types.ts
@@ -12,6 +12,7 @@ export interface TeamDirectoryBoardMember {
   name: string;
   role: string;
   isChair: boolean;
+  secondaryRole?: string;
 }
 
 export interface TeamDirectoryTeam {

--- a/app/lib/server/users/profile.ts
+++ b/app/lib/server/users/profile.ts
@@ -34,6 +34,7 @@ export async function updateMemberProfile(input: {
   boardMembership?: {
     departmentId: string;
     isChair: boolean;
+    secondaryRole?: string;
   } | null;
 }): Promise<void> {
   const {
@@ -56,6 +57,7 @@ export async function updateMemberProfile(input: {
         .object({
           departmentId: z.string().trim().min(1),
           isChair: z.boolean(),
+          secondaryRole: z.string().trim().min(1).optional(),
         })
         .nullable()
         .optional(),

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -387,17 +387,32 @@ test("updateMemberProfile assigns and removes a board membership", async () => {
   const departmentId = await seedDepartment(orgA);
   await updateMemberProfile({
     userId: memberA,
-    boardMembership: { departmentId, isChair: true },
+    boardMembership: {
+      departmentId,
+      isChair: true,
+      secondaryRole: "  Finanzen  ",
+    },
   });
   const assigned = await (await users()).findOne({ _id: memberA });
   expect(assigned?.boardMembership).toEqual({
     departmentId,
     isChair: true,
+    secondaryRole: "Finanzen",
   });
   expect(assigned?.teamId).toBeUndefined();
   expect(assigned?.secondaryTeamId).toBeUndefined();
   expect(assigned?.isTeamLead).toBe(false);
   expect(assigned?.isSecondaryTeamLead).toBe(false);
+
+  await updateMemberProfile({
+    userId: memberA,
+    boardMembership: { departmentId, isChair: true },
+  });
+  const withoutSecondaryRole = await (await users()).findOne({ _id: memberA });
+  expect(withoutSecondaryRole?.boardMembership).toEqual({
+    departmentId,
+    isChair: true,
+  });
 
   await updateMemberProfile({
     userId: memberA,

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -51,7 +51,7 @@ erDiagram
         string positionTitle
         boolean isTeamLead
         boolean isSecondaryTeamLead
-        object boardMembership
+        object boardMembership "departmentId, isChair, secondaryRole?"
         string applicationId
         string memberStatus
         string teamOnboardingStatus

--- a/docs/team-directory.md
+++ b/docs/team-directory.md
@@ -11,7 +11,9 @@ Teamstruktur werden außerdem ein aktives Department, ein aktives Team und ein
 Name vorausgesetzt. Die interne Position ist optional und wird nicht im
 Organigramm veröffentlicht. Eine optionale `boardMembership` ordnet ein
 Vorstandsmitglied direkt einem aktiven Department zu. Vorstandsmitglieder sind
-keinem Team innerhalb dieses Departments zugeordnet.
+keinem Team innerhalb dieses Departments zugeordnet. Die optionale
+`secondaryRole` innerhalb der Vorstandszuordnung wird als Nebenrolle
+veröffentlicht.
 
 Ein optionales `secondaryTeamId` veröffentlicht dieselbe Person zusätzlich als
 Mitglied eines zweiten Teams. `isTeamLead` markiert die Person im Hauptteam aus
@@ -37,8 +39,10 @@ Der Consumer stellt die Ebenen in dieser Reihenfolge dar:
 4. Teammitglieder
 
 Vorstandsmitglieder stehen auf Department-Ebene oberhalb der Teams. Innerhalb
+des Vorstands wird die optionale Position zusätzlich dargestellt. Innerhalb
 eines Teams stehen Leads vor den übrigen Mitgliedern und erhalten eine
-Lead-Hervorhebung. Weitere Positionen werden nicht dargestellt.
+Lead-Hervorhebung. Weitere Positionen von Teammitgliedern werden nicht
+dargestellt.
 
 ## Vertrag
 
@@ -54,7 +58,8 @@ Lead-Hervorhebung. Weitere Positionen werden nicht dargestellt.
         "departmentId": "ybase:org:department:department",
         "name": "Ada Beispiel",
         "role": "Operations",
-        "isChair": true
+        "isChair": true,
+        "secondaryRole": "Finanzen"
       }
     ],
     "departments": [


### PR DESCRIPTION
## summary

- let admins assign an optional position to board members using the same naming as regular members
- persist validated board positions and publish them as optional `secondaryRole` values in the team-directory feed

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed TypeScript files>`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm exec vitest run app/lib/server/users/users.test.ts app/lib/server/teamDirectory/feed.test.ts`
- `pnpm build`
- `git diff --check`