### PR TITLE
feat(recruiting): prefill job posting age requirement

### DIFF
--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -14,6 +14,7 @@ import { provisionTallyFormDraft } from "./tallyFormProvisioning";
 const optionalText = z.string().trim().optional();
 const DEFAULT_SHORT_TEXT =
   "Baue mit uns die größte Community für junge (angehende) Gründer:innen im deutschsprachigen Raum auf.";
+const DEFAULT_REQUIREMENTS = "<ul><li>Alter (&lt;25 Jahre)</li></ul>";
 
 const contentSchema = z.object({
   title: z.string().trim().min(1),
@@ -79,6 +80,7 @@ export async function createJobPostingDraft(input: {
     status: "draft",
     title,
     shortText: DEFAULT_SHORT_TEXT,
+    requirements: DEFAULT_REQUIREMENTS,
     createdBy: user._id,
   });
   await addLog(user.organizationId, user._id, "jobPosting.create", _id, title);

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -112,6 +112,7 @@ test("createJobPostingDraft stores a draft scoped to the org without a departmen
     teamId: teamA,
     shortText:
       "Baue mit uns die größte Community für junge (angehende) Gründer:innen im deutschsprachigen Raum auf.",
+    requirements: "<ul><li>Alter (&lt;25 Jahre)</li></ul>",
   });
   expect(list[0].status).toBe("draft");
   expect(list[0]).not.toHaveProperty("departmentId");


### PR DESCRIPTION
## summary

- prefill new job postings with an editable under-25 age requirement
- store the default as rich text so it appears as a bullet and reaches initial Tally drafts

## validation

- `pnpm exec prettier --check app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm exec biome lint app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm test app/lib/server/jobPostings/jobPostings.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`