### PR TITLE
feat(recruiting): add job posting urgency

### DIFF
--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -18,6 +18,8 @@ import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPos
 import { useJobPostings } from "@/lib/client/jobPostings/hooks/useJobPostings";
 import { useTeamDirectory } from "@/lib/client/teams/hooks/useTeamDirectory";
 import type { JobPosting } from "@/lib/db/types";
+import { jobPostingUrgency } from "@/lib/jobPostings/urgency";
+import { cn } from "@/lib/utils";
 import { Megaphone, Plus } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -93,8 +95,16 @@ export function RecruitingClient() {
               <TableBody>
                 {jobPostings.map((posting) => {
                   const info = lookup.get(posting.teamId);
+                  const isUrgent =
+                    jobPostingUrgency(posting.urgency) === "urgent";
                   return (
-                    <TableRow key={posting._id}>
+                    <TableRow
+                      key={posting._id}
+                      className={cn(
+                        isUrgent &&
+                          "border-l-4 border-l-secondary bg-secondary/[0.06] hover:bg-secondary/10",
+                      )}
+                    >
                       <TableCell className="font-medium">
                         <Link
                           href={`/recruiting/${posting._id}`}
@@ -111,7 +121,9 @@ export function RecruitingClient() {
                       <TableCell className="text-right">
                         <JobPostingActionsMenu
                           posting={posting}
-                          disabled={archive.isPending || deletePosting.isPending}
+                          disabled={
+                            archive.isPending || deletePosting.isPending
+                          }
                           onArchive={() => void handleArchive(posting)}
                           onDelete={() => setPostingToDelete(posting)}
                         />

--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SelectJobPostingUrgency } from "@/components/Selectors/SelectJobPostingUrgency";
 import { SelectMembers } from "@/components/Selectors/SelectMembers";
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
 import { Input } from "@/components/ui/input";
@@ -58,7 +59,15 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
         </div>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="jp-urgency">Dringlichkeit</Label>
+          <SelectJobPostingUrgency
+            id="jp-urgency"
+            value={values.urgency}
+            onValueChange={(urgency) => onChange({ urgency })}
+          />
+        </div>
         <div className="flex flex-col gap-2">
           <Label htmlFor="jp-time">Zeitaufwand</Label>
           <Input

--- a/app/components/Dialogs/CreateJobPostingDialog.tsx
+++ b/app/components/Dialogs/CreateJobPostingDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SelectDepartment } from "@/components/Selectors/SelectDepartment";
+import { SelectJobPostingUrgency } from "@/components/Selectors/SelectJobPostingUrgency";
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,6 +16,7 @@ import { Label } from "@/components/ui/label";
 import { useDepartments } from "@/lib/client/departments/hooks/useDepartments";
 import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPostingMutations";
 import { useTeams } from "@/lib/client/teams/hooks/useTeams";
+import type { JobPostingUrgency } from "@/lib/db/types";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -33,6 +35,7 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
   const [title, setTitle] = useState("");
   const [departmentId, setDepartmentId] = useState("");
   const [teamId, setTeamId] = useState("");
+  const [urgency, setUrgency] = useState<JobPostingUrgency>("normal");
   const departmentTeams = teams.filter(
     (team) => team.departmentId === departmentId,
   );
@@ -42,6 +45,7 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
     setTitle("");
     setDepartmentId("");
     setTeamId("");
+    setUrgency("normal");
   };
 
   const handleDepartmentChange = (value: string) => {
@@ -59,7 +63,11 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
     e.preventDefault();
     if (!title.trim() || !teamId || create.isPending) return;
     try {
-      const id = await create.mutateAsync({ title: title.trim(), teamId });
+      const id = await create.mutateAsync({
+        title: title.trim(),
+        teamId,
+        urgency,
+      });
       toast.success("Entwurf erstellt");
       reset();
       onOpenChange(false);
@@ -119,6 +127,14 @@ export function CreateJobPostingDialog({ open, onOpenChange }: Props) {
                 placeholder="Wonach suchst du?"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="posting-urgency">Dringlichkeit</Label>
+              <SelectJobPostingUrgency
+                id="posting-urgency"
+                value={urgency}
+                onValueChange={setUrgency}
               />
             </div>
             <DialogFooter>

--- a/app/components/Selectors/SelectJobPostingUrgency.tsx
+++ b/app/components/Selectors/SelectJobPostingUrgency.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { JobPostingUrgency } from "@/lib/db/types";
+import { JOB_POSTING_URGENCY_LABELS } from "@/lib/jobPostings/urgency";
+
+interface Props {
+  id: string;
+  value: JobPostingUrgency;
+  onValueChange: (urgency: JobPostingUrgency) => void;
+}
+
+export function SelectJobPostingUrgency({ id, value, onValueChange }: Props) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(urgency) => onValueChange(urgency as JobPostingUrgency)}
+    >
+      <SelectTrigger id={id} className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {Object.entries(JOB_POSTING_URGENCY_LABELS).map(([urgency, label]) => (
+          <SelectItem key={urgency} value={urgency}>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/app/lib/db/jobPosting.ts
+++ b/app/lib/db/jobPosting.ts
@@ -1,4 +1,5 @@
 export type JobPostingStatus = "draft" | "published" | "closed" | "archived";
+export type JobPostingUrgency = "normal" | "urgent";
 
 export interface JobPosting {
   _id: string;
@@ -6,6 +7,7 @@ export interface JobPosting {
   organizationId: string;
   teamId: string;
   status: JobPostingStatus;
+  urgency?: JobPostingUrgency;
   title: string;
   shortText?: string;
   description?: string;

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -1,6 +1,10 @@
 export type * from "./application";
 export type { JobFeedToken } from "./jobFeedToken";
-export type { JobPosting, JobPostingStatus } from "./jobPosting";
+export type {
+  JobPosting,
+  JobPostingStatus,
+  JobPostingUrgency,
+} from "./jobPosting";
 export type { Log } from "./log";
 export type { Organization } from "./organization";
 export type { Department, Team } from "./orgStructureTypes";

--- a/app/lib/jobPostings/form.ts
+++ b/app/lib/jobPostings/form.ts
@@ -1,9 +1,11 @@
-import type { JobPosting } from "@/lib/db/types";
+import type { JobPosting, JobPostingUrgency } from "@/lib/db/types";
 import { jobPostingApplicationQuestions } from "./applicationQuestions";
+import { jobPostingUrgency } from "./urgency";
 
 export interface JobPostingFormValues {
   title: string;
   teamId: string;
+  urgency: JobPostingUrgency;
   shortText: string;
   description: string;
   tasks: string;
@@ -20,6 +22,7 @@ export function toJobPostingForm(posting: JobPosting): JobPostingFormValues {
   return {
     title: posting.title,
     teamId: posting.teamId,
+    urgency: jobPostingUrgency(posting.urgency),
     shortText: posting.shortText ?? "",
     description: posting.description ?? "",
     tasks: posting.tasks ?? "",

--- a/app/lib/jobPostings/urgency.test.ts
+++ b/app/lib/jobPostings/urgency.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import { jobPostingUrgency } from "./urgency";
+
+test("treats legacy job postings without urgency as normal", () => {
+  expect(jobPostingUrgency()).toBe("normal");
+});
+
+test("keeps an explicitly stored urgency", () => {
+  expect(jobPostingUrgency("urgent")).toBe("urgent");
+});

--- a/app/lib/jobPostings/urgency.ts
+++ b/app/lib/jobPostings/urgency.ts
@@ -1,0 +1,12 @@
+import type { JobPostingUrgency } from "@/lib/db/types";
+
+export const JOB_POSTING_URGENCY_LABELS: Record<JobPostingUrgency, string> = {
+  normal: "Normal",
+  urgent: "Dringend",
+};
+
+export function jobPostingUrgency(
+  urgency?: JobPostingUrgency,
+): JobPostingUrgency {
+  return urgency ?? "normal";
+}

--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
 import { jobPostings, teams, users } from "../../db/collections";
+import type { JobPostingUrgency } from "../../db/types";
 import { newId } from "../../db/ids";
 import { UNAVAILABLE_MEMBER_STATUSES } from "../../members/status";
 import { addLog } from "../logs";
@@ -19,6 +20,7 @@ const DEFAULT_REQUIREMENTS = "<ul><li>Alter (&lt;25 Jahre)</li></ul>";
 const contentSchema = z.object({
   title: z.string().trim().min(1),
   teamId: z.string().trim().min(1),
+  urgency: z.enum(["normal", "urgent"]).default("normal"),
   shortText: optionalText,
   description: optionalText,
   tasks: optionalText,
@@ -32,11 +34,13 @@ const contentSchema = z.object({
 });
 
 type Content = z.infer<typeof contentSchema>;
+type ContentInput = z.input<typeof contentSchema>;
 
 function toDocumentFields(content: Content, contactUserIds: string[]) {
   return {
     title: content.title,
     teamId: content.teamId,
+    urgency: content.urgency,
     shortText: content.shortText ?? "",
     description: sanitizeRichText(content.description),
     tasks: sanitizeRichText(content.tasks),
@@ -59,12 +63,14 @@ function toDocumentFields(content: Content, contactUserIds: string[]) {
 export async function createJobPostingDraft(input: {
   title: string;
   teamId: string;
+  urgency?: JobPostingUrgency;
 }): Promise<string> {
   const user = await requirePermission(USER_PERMISSIONS.recruiting);
-  const { title, teamId } = z
+  const { title, teamId, urgency } = z
     .object({
       title: z.string().trim().min(1),
       teamId: z.string().trim().min(1),
+      urgency: z.enum(["normal", "urgent"]).default("normal"),
     })
     .parse(input);
   await requireActiveTeam(teamId, user.organizationId);
@@ -78,6 +84,7 @@ export async function createJobPostingDraft(input: {
     organizationId: user.organizationId,
     teamId,
     status: "draft",
+    urgency,
     title,
     shortText: DEFAULT_SHORT_TEXT,
     requirements: DEFAULT_REQUIREMENTS,
@@ -90,7 +97,7 @@ export async function createJobPostingDraft(input: {
 }
 
 export async function updateJobPosting(
-  input: { jobPostingId: string } & Content,
+  input: { jobPostingId: string } & ContentInput,
 ): Promise<void> {
   const user = await requirePermission(USER_PERMISSIONS.recruiting);
   const { jobPostingId, ...content } = z

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -110,6 +110,7 @@ test("createJobPostingDraft stores a draft scoped to the org without a departmen
     _id: id,
     title: "Vorstand",
     teamId: teamA,
+    urgency: "normal",
     shortText:
       "Baue mit uns die größte Community für junge (angehende) Gründer:innen im deutschsprachigen Raum auf.",
     requirements: "<ul><li>Alter (&lt;25 Jahre)</li></ul>",
@@ -120,6 +121,19 @@ test("createJobPostingDraft stores a draft scoped to the org without a departmen
     expect.objectContaining({ _id: id, title: "Vorstand", status: "draft" }),
     expect.objectContaining({ _id: userA, organizationId: orgA }),
   );
+});
+
+test("createJobPostingDraft stores urgent postings", async () => {
+  const id = await createJobPostingDraft({
+    title: "Dringende Unterstützung",
+    teamId: teamA,
+    urgency: "urgent",
+  });
+
+  expect(await getJobPostingById(id)).toMatchObject({
+    title: "Dringende Unterstützung",
+    urgency: "urgent",
+  });
 });
 
 test("createJobPostingDraft rejects an archived team", async () => {
@@ -185,6 +199,19 @@ test("updateJobPosting can edit content while published", async () => {
     }),
     expect.objectContaining({ _id: userA, organizationId: orgA }),
   );
+});
+
+test("updateJobPosting changes the urgency", async () => {
+  const id = await createJobPostingDraft({ title: "T", teamId: teamA });
+
+  await updateJobPosting({
+    jobPostingId: id,
+    title: "T",
+    teamId: teamA,
+    urgency: "urgent",
+  });
+
+  expect((await getJobPostingById(id)).urgency).toBe("urgent");
 });
 
 test("stores the exact application questions and forwards them to Tally", async () => {


### PR DESCRIPTION
## summary

- add normal and urgent priorities when creating or editing job postings
- persist urgency with a backwards-compatible normal default and highlight urgent rows with the existing purple accent

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/server/jobPostings/jobPostings.test.ts app/lib/jobPostings/urgency.test.ts`
- `pnpm build`
