### PR TITLE
fix(recruiting): clarify job description label

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingContentFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingContentFields.tsx
@@ -20,9 +20,9 @@ export function JobPostingContentFields({ values, onChange }: Props) {
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-2">
-        <Label>Beschreibung</Label>
+        <Label>Beschreibung der Stelle</Label>
         <RichTextEditor
-          ariaLabel="Beschreibung"
+          ariaLabel="Beschreibung der Stelle"
           value={values.description}
           onChange={(description) => onChange({ description })}
         />


### PR DESCRIPTION
## summary

- rename the job posting editor field to “Beschreibung der Stelle”
- keep the rich text editor's accessible label aligned with the visible label

## validation

- `pnpm exec prettier --check 'app/(protected)/recruiting/[id]/JobPostingContentFields.tsx'`
- `pnpm exec biome lint 'app/(protected)/recruiting/[id]/JobPostingContentFields.tsx'`
- `git diff --check`
- tests not run (copy-only change; repository guidance excludes trivial copy changes)
