### PR TITLE
feat(recruiting): open job postings from list rows

### DIFF
--- a/app/(protected)/recruiting/RecruitingClient.tsx
+++ b/app/(protected)/recruiting/RecruitingClient.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { Megaphone, Plus } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import toast from "react-hot-toast";
 import { CreateJobPostingDialog } from "@/components/Dialogs/CreateJobPostingDialog";
 import { DeleteJobPostingDialog } from "@/components/JobPostings/DeleteJobPostingDialog";
 import { JobPostingActionsMenu } from "@/components/JobPostings/JobPostingActionsMenu";
@@ -20,12 +25,9 @@ import { useTeamDirectory } from "@/lib/client/teams/hooks/useTeamDirectory";
 import type { JobPosting } from "@/lib/db/types";
 import { jobPostingUrgency } from "@/lib/jobPostings/urgency";
 import { cn } from "@/lib/utils";
-import { Megaphone, Plus } from "lucide-react";
-import Link from "next/link";
-import { useState } from "react";
-import toast from "react-hot-toast";
 
 export function RecruitingClient() {
+  const router = useRouter();
   const { jobPostings, isLoading } = useJobPostings();
   const { lookup } = useTeamDirectory();
   const { archive, deletePosting } = useJobPostingMutations();
@@ -101,14 +103,17 @@ export function RecruitingClient() {
                     <TableRow
                       key={posting._id}
                       className={cn(
+                        "cursor-pointer",
                         isUrgent &&
                           "border-l-4 border-l-secondary bg-secondary/[0.06] hover:bg-secondary/10",
                       )}
+                      onClick={() => router.push(`/recruiting/${posting._id}`)}
                     >
                       <TableCell className="font-medium">
                         <Link
                           href={`/recruiting/${posting._id}`}
                           className="outline-none hover:underline focus-visible:underline"
+                          onClick={(event) => event.stopPropagation()}
                         >
                           {posting.title}
                         </Link>
@@ -118,7 +123,10 @@ export function RecruitingClient() {
                       <TableCell>
                         <JobPostingStatusBadge status={posting.status} />
                       </TableCell>
-                      <TableCell className="text-right">
+                      <TableCell
+                        className="text-right"
+                        onClick={(event) => event.stopPropagation()}
+                      >
                         <JobPostingActionsMenu
                           posting={posting}
                           disabled={

--- a/app/components/JobPostings/JobPostingActionsMenu.tsx
+++ b/app/components/JobPostings/JobPostingActionsMenu.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Archive, MoreVertical, Pencil, Trash2 } from "lucide-react";
-import Link from "next/link";
+import { Archive, MoreVertical, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -40,12 +39,6 @@ export function JobPostingActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={0} className={menu.content}>
-        <DropdownMenuItem className={menu.item} asChild>
-          <Link href={`/recruiting/${posting._id}`}>
-            <Pencil className="text-current" />
-            Bearbeiten
-          </Link>
-        </DropdownMenuItem>
         {canArchive ? (
           <DropdownMenuItem className={menu.item} onSelect={onArchive}>
             <Archive className="text-current" />


### PR DESCRIPTION
## summary

- open job postings by clicking anywhere on their list row while preserving the accessible title link
- keep archive and delete in the overflow menu and remove the redundant edit action

## validation

- `git diff --check`
- `pnpm exec biome lint app/(protected)/recruiting/RecruitingClient.tsx app/components/JobPostings/JobPostingActionsMenu.tsx`
- `pnpm lint` (passes with three existing warnings)
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm test -- app/lib/server/jobPostings app/lib/jobPostings`
- `pnpm vitest run` (75 files, 477 tests)
- `pnpm build`