### PR TITLE
feat(team-directory): expose board member profile images

### DIFF
--- a/app/api/v1/team-directory/images/[userId]/route.test.ts
+++ b/app/api/v1/team-directory/images/[userId]/route.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findDepartment: vi.fn(),
+  findTeam: vi.fn(),
+  findUser: vi.fn(),
+  getObjectBuffer: vi.fn(),
+  validateProfileImage: vi.fn(),
+}));
+
+vi.mock("@/lib/db/collections", () => ({
+  departments: vi.fn(async () => ({ findOne: mocks.findDepartment })),
+  teams: vi.fn(async () => ({ findOne: mocks.findTeam })),
+  users: vi.fn(async () => ({ findOne: mocks.findUser })),
+}));
+vi.mock("@/lib/members/status", () => ({
+  PUBLIC_MEMBER_STATUSES: ["active", "offboarding_planned"],
+}));
+vi.mock("@/lib/s3/storage", () => ({
+  getObjectBuffer: mocks.getObjectBuffer,
+}));
+vi.mock("@/lib/server/profile/validation", () => ({
+  validateProfileImage: mocks.validateProfileImage,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ userId: "board-member" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("YFN_TEAM_DIRECTORY_ORGANIZATION_ID", "organization-id");
+  mocks.findUser.mockResolvedValue({
+    _id: "board-member",
+    boardMembership: { departmentId: "board-department", isChair: true },
+    profileImageStorageKey: "profile-image",
+  });
+  mocks.findDepartment.mockResolvedValue({
+    _id: "board-department",
+    isArchived: false,
+  });
+  mocks.getObjectBuffer.mockResolvedValue(Buffer.from([0xff, 0xd8, 0xff]));
+  mocks.validateProfileImage.mockReturnValue("image/jpeg");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test("serves the public profile image of a board member", async () => {
+  const response = await GET(
+    new Request("http://localhost/api/v1/team-directory/images/board-member"),
+    context,
+  );
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("image/jpeg");
+  expect(mocks.findTeam).not.toHaveBeenCalled();
+  expect(mocks.findDepartment).toHaveBeenCalledWith({
+    _id: "board-department",
+    organizationId: "organization-id",
+    isArchived: false,
+  });
+});
+
+test("hides board images assigned to an inactive department", async () => {
+  mocks.findDepartment.mockResolvedValue(null);
+
+  const response = await GET(
+    new Request("http://localhost/api/v1/team-directory/images/board-member"),
+    context,
+  );
+
+  expect(response.status).toBe(404);
+  expect(mocks.getObjectBuffer).not.toHaveBeenCalled();
+});

--- a/app/api/v1/team-directory/images/[userId]/route.ts
+++ b/app/api/v1/team-directory/images/[userId]/route.ts
@@ -25,24 +25,32 @@ export async function GET(_request: Request, context: RouteContext) {
     publicProfileCompletedAt: { $exists: true },
     profileImageStorageKey: { $exists: true },
   });
-  if (!member?.teamId || !member.profileImageStorageKey) {
+  if (!member?.profileImageStorageKey) {
     return new Response(null, { status: 404, headers: NOT_FOUND_HEADERS });
   }
 
-  const team = await (
-    await teams()
-  ).findOne({
-    _id: member.teamId,
-    organizationId,
-    isArchived: false,
-  });
-  if (!team) {
-    return new Response(null, { status: 404, headers: NOT_FOUND_HEADERS });
+  let departmentId = member.boardMembership?.departmentId;
+  if (!departmentId) {
+    if (!member.teamId) {
+      return new Response(null, { status: 404, headers: NOT_FOUND_HEADERS });
+    }
+    const team = await (
+      await teams()
+    ).findOne({
+      _id: member.teamId,
+      organizationId,
+      isArchived: false,
+    });
+    if (!team) {
+      return new Response(null, { status: 404, headers: NOT_FOUND_HEADERS });
+    }
+    departmentId = team.departmentId;
   }
+
   const department = await (
     await departments()
   ).findOne({
-    _id: team.departmentId,
+    _id: departmentId,
     organizationId,
     isArchived: false,
   });

--- a/app/lib/server/teamDirectory/feed.test.ts
+++ b/app/lib/server/teamDirectory/feed.test.ts
@@ -96,6 +96,8 @@ test("returns active members directly from their ybase profiles", async () => {
         isChair: true,
         secondaryRole: "Finanzen",
       },
+      profileImageStorageKey: "board-profile-image",
+      publicProfileCompletedAt: 100,
     }),
     member({
       _id: "member-board-without-secondary-role",
@@ -149,6 +151,7 @@ test("returns active members directly from their ybase profiles", async () => {
       role: "Operations",
       isChair: true,
       secondaryRole: "Finanzen",
+      imageUrl: `${publicOrigin}/api/v1/team-directory/images/member-board`,
     },
     {
       id: `ybase:${organizationId}:member:member-board-without-secondary-role`,

--- a/app/lib/server/teamDirectory/feed.ts
+++ b/app/lib/server/teamDirectory/feed.ts
@@ -74,6 +74,7 @@ export async function getTeamDirectory(
         const boardMember = boardMemberDto(
           member,
           organizationId,
+          publicOrigin,
           member.boardMembership
             ? activeDepartments.get(member.boardMembership.departmentId)
             : undefined,

--- a/app/lib/server/teamDirectory/memberMappers.ts
+++ b/app/lib/server/teamDirectory/memberMappers.ts
@@ -38,6 +38,17 @@ function memberId(organizationId: string, userId: string): string {
   return `ybase:${organizationId}:member:${userId}`;
 }
 
+function profileImage(
+  user: DirectoryUser,
+  publicOrigin: string,
+): { imageUrl?: string } {
+  return user.profileImageStorageKey && user.publicProfileCompletedAt
+    ? {
+        imageUrl: `${publicOrigin}/api/v1/team-directory/images/${encodeURIComponent(user._id)}`,
+      }
+    : {};
+}
+
 export function memberDto(
   user: DirectoryUser,
   organizationId: string,
@@ -49,17 +60,14 @@ export function memberDto(
     name: profileName(user),
     role: isLead ? "Lead" : "",
     isLead,
-    ...(user.profileImageStorageKey && user.publicProfileCompletedAt
-      ? {
-          imageUrl: `${publicOrigin}/api/v1/team-directory/images/${encodeURIComponent(user._id)}`,
-        }
-      : {}),
+    ...profileImage(user, publicOrigin),
   };
 }
 
 export function boardMemberDto(
   user: DirectoryUser,
   organizationId: string,
+  publicOrigin: string,
   department: Pick<Department, "_id" | "name"> | undefined,
 ): TeamDirectoryBoardMember | null {
   const boardMembership = user.boardMembership;
@@ -75,5 +83,6 @@ export function boardMemberDto(
     ...(boardMembership.secondaryRole
       ? { secondaryRole: boardMembership.secondaryRole }
       : {}),
+    ...profileImage(user, publicOrigin),
   };
 }

--- a/app/lib/server/teamDirectory/types.ts
+++ b/app/lib/server/teamDirectory/types.ts
@@ -13,6 +13,7 @@ export interface TeamDirectoryBoardMember {
   role: string;
   isChair: boolean;
   secondaryRole?: string;
+  imageUrl?: string;
 }
 
 export interface TeamDirectoryTeam {

--- a/docs/team-directory.md
+++ b/docs/team-directory.md
@@ -15,6 +15,9 @@ keinem Team innerhalb dieses Departments zugeordnet. Die optionale
 `secondaryRole` innerhalb der Vorstandszuordnung wird als Nebenrolle
 veröffentlicht.
 
+Für Team- und Vorstandsmitglieder wird `imageUrl` veröffentlicht, sobald ein
+Profilbild vorhanden und das öffentliche Profil vollständig ausgefüllt ist.
+
 Ein optionales `secondaryTeamId` veröffentlicht dieselbe Person zusätzlich als
 Mitglied eines zweiten Teams. `isTeamLead` markiert die Person im Hauptteam aus
 `teamId` als Lead, `isSecondaryTeamLead` unabhängig davon im weiteren Team aus
@@ -59,7 +62,8 @@ dargestellt.
         "name": "Ada Beispiel",
         "role": "Operations",
         "isChair": true,
-        "secondaryRole": "Finanzen"
+        "secondaryRole": "Finanzen",
+        "imageUrl": "https://ybase.example/api/v1/team-directory/images/user"
       }
     ],
     "departments": [


### PR DESCRIPTION
## summary

- expose profile image URLs for board members in the public team directory feed
- authorize stored board profile images through active department assignments
- document and test the extended feed contract and public image route

## validation

- `pnpm exec prettier --check app/lib/server/teamDirectory/memberMappers.ts app/lib/server/teamDirectory/types.ts app/lib/server/teamDirectory/feed.ts app/api/v1/team-directory/images/[userId]/route.ts app/lib/server/teamDirectory/feed.test.ts app/api/v1/team-directory/images/[userId]/route.test.ts docs/team-directory.md`
- `pnpm exec biome lint app/lib/server/teamDirectory/memberMappers.ts app/lib/server/teamDirectory/types.ts app/lib/server/teamDirectory/feed.ts app/api/v1/team-directory/images/[userId]/route.ts app/lib/server/teamDirectory/feed.test.ts app/api/v1/team-directory/images/[userId]/route.test.ts`
- `pnpm exec vitest run app/lib/server/teamDirectory/feed.test.ts app/api/v1/team-directory/images/[userId]/route.test.ts app/api/v1/team-directory/route.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test` (488 tests)