### PR TITLE
feat(members): separate excluded members from archive

### DIFF
--- a/app/(protected)/settings/members/MemberInfractionsSection.tsx
+++ b/app/(protected)/settings/members/MemberInfractionsSection.tsx
@@ -41,7 +41,7 @@ export function MemberInfractionsSection({ member }: { member: User }) {
       setIsOpen(false);
       toast.success(
         result.memberExcluded
-          ? "Mitglied ins Offboarding verschoben"
+          ? "Mitglied ausgeschlossen"
           : "Verstoß gespeichert",
       );
     } catch (error) {
@@ -114,8 +114,7 @@ export function MemberInfractionsSection({ member }: { member: User }) {
                 <ShieldAlert className="mt-0.5 size-5 shrink-0" />
                 <p>
                   Dies ist der zweite Verstoß. Nach dem Speichern wird das
-                  Mitglied sofort ins Offboarding verschoben und der Zugriff
-                  gesperrt.
+                  Mitglied sofort ausgeschlossen und der Zugriff gesperrt.
                 </p>
               </div>
             ) : null}

--- a/app/(protected)/settings/members/MembersClient.tsx
+++ b/app/(protected)/settings/members/MembersClient.tsx
@@ -124,6 +124,17 @@ export function MembersClient({
           {stage === "archived" ? (
             <h2 className="text-lg font-semibold">Archivierte Mitglieder</h2>
           ) : null}
+          {stage === "excluded" ? (
+            <div>
+              <h2 className="text-lg font-semibold">
+                Ausgeschlossene Personen
+              </h2>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Zentrale Liste aller Personen, die aus dem Team ausgeschlossen
+                wurden.
+              </p>
+            </div>
+          ) : null}
           <MembersToolbar
             filters={{ ...filters, status: memberStatuses }}
             departments={departments}

--- a/app/(protected)/settings/members/memberLabels.test.ts
+++ b/app/(protected)/settings/members/memberLabels.test.ts
@@ -8,6 +8,7 @@ describe("memberStatusOptions", () => {
       "offboarding_planned",
       "offboarding",
       "archived",
+      "excluded",
     ]);
   });
 
@@ -19,6 +20,7 @@ describe("memberStatusOptions", () => {
         "offboarding_planned",
         "offboarding",
         "archived",
+        "excluded",
       ],
     );
   });

--- a/app/(protected)/settings/members/memberLabels.ts
+++ b/app/(protected)/settings/members/memberLabels.ts
@@ -15,6 +15,7 @@ const MEMBER_STATUS_OPTIONS: Option<MemberStatus>[] = [
   { value: "offboarding_planned", label: "Offboarding vorgemerkt" },
   { value: "offboarding", label: "Offboarding" },
   { value: "archived", label: "Archiviert" },
+  { value: "excluded", label: "Ausgeschlossen" },
 ];
 
 export function memberStatusOptions(

--- a/app/(protected)/settings/members/memberStagePresentation.ts
+++ b/app/(protected)/settings/members/memberStagePresentation.ts
@@ -42,4 +42,9 @@ export const MEMBER_STAGE_EMPTY_TEXT: Partial<Record<MemberStage, EmptyText>> =
       title: "Keine archivierten Mitglieder",
       description: "Vollständig offboardete Mitglieder erscheinen hier.",
     },
+    excluded: {
+      title: "Keine ausgeschlossenen Personen",
+      description:
+        "Aus dem Team ausgeschlossene Personen erscheinen zentral in dieser Liste.",
+    },
   };

--- a/app/components/Members/MemberStageBadge.tsx
+++ b/app/components/Members/MemberStageBadge.tsx
@@ -17,6 +17,8 @@ const MEMBER_STAGE_BADGE_STYLES: Record<MemberStage, string> = {
     "border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-800 dark:bg-rose-950/60 dark:text-rose-200",
   archived:
     "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200",
+  excluded:
+    "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/60 dark:text-red-200",
 };
 
 export function MemberStageBadge({

--- a/app/lib/auth/session.test.ts
+++ b/app/lib/auth/session.test.ts
@@ -52,7 +52,7 @@ test("admin passes People & Culture and finance permission guards", async () => 
   await expect(requirePermission("manage_finance")).resolves.toBeDefined();
 });
 
-test.each(["offboarding", "archived", "offboarded"])(
+test.each(["offboarding", "archived", "excluded", "offboarded"])(
   "%s users lose access to protected data",
   async (memberStatus) => {
     mocks.findOne.mockResolvedValue({
@@ -62,14 +62,10 @@ test.each(["offboarding", "archived", "offboarded"])(
       memberStatus,
     });
 
-    await expect(requireUser()).rejects.toThrow(
-      "User is offboarding or archived",
-    );
-    await expect(requireRole("member")).rejects.toThrow(
-      "User is offboarding or archived",
-    );
+    await expect(requireUser()).rejects.toThrow("User is unavailable");
+    await expect(requireRole("member")).rejects.toThrow("User is unavailable");
     await expect(requirePermission("manage_members")).rejects.toThrow(
-      "User is offboarding or archived",
+      "User is unavailable",
     );
   },
 );

--- a/app/lib/auth/session.ts
+++ b/app/lib/auth/session.ts
@@ -24,7 +24,7 @@ export async function requireUser() {
   const user = await requireAuthenticatedUser();
   if (!user.organizationId) throw new Error("User has no organization");
   if (isUnavailableMemberStatus(user.memberStatus)) {
-    throw new Error("User is offboarding or archived");
+    throw new Error("User is unavailable");
   }
   if (user.memberStatus === "onboarding") {
     throw new Error("Member is awaiting approval");

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -5,6 +5,7 @@ export type MemberStatus =
   | "offboarding_planned"
   | "offboarding"
   | "archived"
+  | "excluded"
   | "offboarded";
 export type TeamOnboardingStatus = "not_started" | "in_progress" | "completed";
 export type ProfileImageSource = "google" | "upload";
@@ -61,6 +62,7 @@ export interface User {
   offboardingPlannedAt?: number;
   offboardingStartedAt?: number;
   archivedAt?: number;
+  excludedAt?: number;
   offboardedAt?: number;
   memberInfractions?: MemberInfraction[];
 }

--- a/app/lib/members/stages.test.ts
+++ b/app/lib/members/stages.test.ts
@@ -65,6 +65,7 @@ describe("member lifecycle stages", () => {
     member("planned-member", "offboarding_planned"),
     member("offboarding-member", "offboarding"),
     member("archived-member", "archived"),
+    member("excluded-member", "excluded"),
     member("legacy-offboarded-member", "offboarded"),
   ];
   test("validates stage query parameters", () => {
@@ -76,6 +77,7 @@ describe("member lifecycle stages", () => {
     );
     expect(memberStageForStatus("active")).toBe("active");
     expect(memberStageForStatus("offboarded")).toBe("archived");
+    expect(memberStageForStatus("excluded")).toBe("excluded");
   });
 
   test("groups application records by recruiting step", () => {
@@ -109,6 +111,9 @@ describe("member lifecycle stages", () => {
     expect(
       membersForStage(members, "archived").map((entry) => entry._id),
     ).toEqual(["archived-member", "legacy-offboarded-member"]);
+    expect(
+      membersForStage(members, "excluded").map((entry) => entry._id),
+    ).toEqual(["excluded-member"]);
   });
 
   test("counts records shown in every tab", () => {
@@ -120,6 +125,7 @@ describe("member lifecycle stages", () => {
       offboarding_planned: 1,
       offboarding: 1,
       archived: 2,
+      excluded: 1,
     });
   });
 });

--- a/app/lib/members/stages.ts
+++ b/app/lib/members/stages.ts
@@ -12,6 +12,7 @@ export const MEMBER_STAGE_OPTIONS = [
   { value: "offboarding_planned", label: "Offboarding vorgemerkt" },
   { value: "offboarding", label: "Offboarding" },
   { value: "archived", label: "Archiviert" },
+  { value: "excluded", label: "Ausgeschlossen" },
 ] as const;
 
 export type MemberStage = (typeof MEMBER_STAGE_OPTIONS)[number]["value"];
@@ -50,6 +51,7 @@ const MEMBER_STATUSES_BY_STAGE: Partial<
   offboarding_planned: ["offboarding_planned"],
   offboarding: ["offboarding"],
   archived: ["archived", "offboarded"],
+  excluded: ["excluded"],
 };
 
 export function memberStatusesForStage(

--- a/app/lib/members/status.test.ts
+++ b/app/lib/members/status.test.ts
@@ -13,7 +13,7 @@ describe("member status semantics", () => {
     expect(isUnavailableMemberStatus("offboarding_planned")).toBe(false);
   });
 
-  test.each(["offboarding", "archived", "offboarded"] as const)(
+  test.each(["offboarding", "archived", "excluded", "offboarded"] as const)(
     "treats %s members as unavailable",
     (status) => {
       expect(isUnavailableMemberStatus(status)).toBe(true);

--- a/app/lib/members/status.ts
+++ b/app/lib/members/status.ts
@@ -8,6 +8,7 @@ export const PUBLIC_MEMBER_STATUSES = [
 export const UNAVAILABLE_MEMBER_STATUSES = [
   "offboarding",
   "archived",
+  "excluded",
   "offboarded",
 ] as const satisfies readonly MemberStatus[];
 

--- a/app/lib/server/profile/actions.ts
+++ b/app/lib/server/profile/actions.ts
@@ -39,7 +39,7 @@ function requireEligibleUser<
 >(user: T): asserts user is T & { organizationId: string } {
   if (!user.organizationId) throw new Error("User has no organization");
   if (isUnavailableMemberStatus(user.memberStatus)) {
-    throw new Error("User is offboarding or archived");
+    throw new Error("User is unavailable");
   }
 }
 

--- a/app/lib/server/users/infractions.ts
+++ b/app/lib/server/users/infractions.ts
@@ -66,8 +66,8 @@ export async function recordMemberInfraction(input: RecordInfractionInput) {
     };
     if (memberExcluded) {
       update.$set = {
-        memberStatus: "offboarding",
-        offboardingStartedAt: infraction.createdAt,
+        memberStatus: "excluded",
+        excludedAt: infraction.createdAt,
       };
     }
 
@@ -87,7 +87,7 @@ export async function recordMemberInfraction(input: RecordInfractionInput) {
           currentUser._id,
           "member.status_change",
           target._id,
-          `${target.name ?? target.email}: ${target.memberStatus} → offboarding (zweiter Verstoß)`,
+          `${target.name ?? target.email}: ${target.memberStatus} → excluded (zweiter Verstoß)`,
         );
       }
       return { infractionCount, memberExcluded };

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -18,6 +18,7 @@ const memberStatusSchema = z.enum([
   "offboarding_planned",
   "offboarding",
   "archived",
+  "excluded",
   "offboarded",
 ]);
 const teamOnboardingSchema = z.enum([

--- a/app/lib/server/users/memberLifecycle.test.ts
+++ b/app/lib/server/users/memberLifecycle.test.ts
@@ -31,6 +31,13 @@ test("archiving a member records the completion timestamp", () => {
   });
 });
 
+test("excluding a member records a separate exclusion timestamp", () => {
+  expect(memberStatusPatch("active", "excluded", NOW)).toEqual({
+    memberStatus: "excluded",
+    excludedAt: NOW,
+  });
+});
+
 test("returning to onboarding only updates the status", () => {
   expect(memberStatusPatch("active", "onboarding", NOW)).toEqual({
     memberStatus: "onboarding",

--- a/app/lib/server/users/memberLifecycle.ts
+++ b/app/lib/server/users/memberLifecycle.ts
@@ -8,6 +8,7 @@ type MemberStatusPatch = Partial<
     | "offboardingPlannedAt"
     | "offboardingStartedAt"
     | "archivedAt"
+    | "excludedAt"
   >
 >;
 
@@ -26,6 +27,7 @@ export function memberStatusPatch(
   if (next === "offboarding_planned") patch.offboardingPlannedAt = now;
   if (next === "offboarding") patch.offboardingStartedAt = now;
   if (next === "archived" || next === "offboarded") patch.archivedAt = now;
+  if (next === "excluded") patch.excludedAt = now;
   return patch;
 }
 

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -370,6 +370,14 @@ test("setMemberStatus maps legacy offboarded writes to archived", async () => {
   expect(typeof updated?.archivedAt).toBe("number");
 });
 
+test("setMemberStatus records manual exclusions separately", async () => {
+  await setMemberStatus({ userId: memberA, status: "excluded" });
+  const updated = await (await users()).findOne({ _id: memberA });
+  expect(updated?.memberStatus).toBe("excluded");
+  expect(typeof updated?.excludedAt).toBe("number");
+  expect(updated?.archivedAt).toBeUndefined();
+});
+
 test("setMemberStatus cannot touch a user from another org", async () => {
   await expect(
     setMemberStatus({ userId: memberB, status: "archived" }),
@@ -422,8 +430,9 @@ test("recordMemberInfraction excludes the member atomically on the second infrac
   expect(result).toEqual({ infractionCount: 2, memberExcluded: true });
   const updated = await (await users()).findOne({ _id: memberA });
   expect(updated?.memberInfractions).toHaveLength(2);
-  expect(updated?.memberStatus).toBe("offboarding");
-  expect(typeof updated?.offboardingStartedAt).toBe("number");
+  expect(updated?.memberStatus).toBe("excluded");
+  expect(typeof updated?.excludedAt).toBe("number");
+  expect(updated?.offboardingStartedAt).toBeUndefined();
   const statusLog = await (
     await logs()
   ).findOne({ action: "member.status_change" });
@@ -451,7 +460,7 @@ test("recordMemberInfraction handles two simultaneous infractions safely", async
   ]);
   const updated = await (await users()).findOne({ _id: memberA });
   expect(updated?.memberInfractions).toHaveLength(2);
-  expect(updated?.memberStatus).toBe("offboarding");
+  expect(updated?.memberStatus).toBe("excluded");
 });
 
 test("setMemberStatus cannot reactivate a member after two infractions", async () => {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -59,6 +59,7 @@ erDiagram
         number offboardingPlannedAt
         number offboardingStartedAt
         number archivedAt
+        number excludedAt
         array memberInfractions "_id, reason, createdAt, createdBy"
     }
 


### PR DESCRIPTION
## summary

- add a separate excluded-member status, timestamp, badge, and central members list while keeping completed offboarding in the archive
- move second-infraction removals directly to excluded and keep excluded users unavailable across protected flows

## validation

- `git diff --name-only -z -- '*.ts' '*.tsx' | xargs -0 pnpm exec biome lint`
- `git diff --name-only -z | xargs -0 pnpm exec prettier --check`
- `pnpm exec vitest run app/lib/members/stages.test.ts app/lib/members/status.test.ts 'app/(protected)/settings/members/memberLabels.test.ts' app/lib/server/users/memberLifecycle.test.ts app/lib/server/users/users.test.ts app/lib/auth/session.test.ts`
- `pnpm build` (passes with a `sanitize-html`/`postcss` externalization warning)
