### PR TITLE
feat(members): link confirmed member platform profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # MongoDB
 MONGODB_URI=mongodb://localhost:27017
 MONGODB_DB=ybase
+MEMBER_PLATFORM_MONGODB_DB=production
 
 # Auth.js
 AUTH_SECRET=

--- a/app/(protected)/MemberPlatformLinking.tsx
+++ b/app/(protected)/MemberPlatformLinking.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  ArrowLeft,
+  CircleHelp,
+  Link2,
+  Loader2,
+  LogOut,
+  Search,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useDeferredValue, useState, useTransition } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { signOutWithPostHog } from "@/lib/posthog-client";
+import { confirmMemberPlatformProfile } from "@/lib/server/memberPlatform/actions";
+import type { MemberPlatformLinkingData } from "@/lib/server/memberPlatform/linking";
+import { MemberPlatformProfileOption } from "./MemberPlatformProfileOption";
+
+export function MemberPlatformLinking({
+  data,
+}: {
+  data: MemberPlatformLinkingData;
+}) {
+  const router = useRouter();
+  const suggested = data.profiles.find(({ id }) => id === data.suggestedId);
+  const [isSearching, setIsSearching] = useState(!suggested);
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string>();
+  const [isPending, startTransition] = useTransition();
+  const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase("de"));
+  const matchingProfiles = data.profiles.filter(({ name }) =>
+    name.toLocaleLowerCase("de").includes(deferredQuery),
+  );
+  const selected = data.profiles.find(({ id }) => id === selectedId);
+
+  const confirm = (profileId: string) => {
+    startTransition(async () => {
+      try {
+        await confirmMemberPlatformProfile(profileId);
+        router.refresh();
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Das Profil konnte nicht verknüpft werden.",
+        );
+      }
+    });
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
+      <Card className="w-full max-w-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            {isSearching ? (
+              <Search aria-hidden="true" className="size-6" />
+            ) : (
+              <Link2 aria-hidden="true" className="size-6" />
+            )}
+          </div>
+          <CardTitle className="text-2xl">
+            {isSearching ? "Finde dein Member-Profil" : "Bist das du?"}
+          </CardTitle>
+          <CardDescription className="text-base leading-relaxed">
+            {isSearching
+              ? "Suche nach deinem Namen und wähle genau dein eigenes Profil aus."
+              : "Bestätige dein bestehendes Profil auf der Member-Plattform."}
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-5">
+          {!isSearching && suggested ? (
+            <>
+              <MemberPlatformProfileOption profile={suggested} />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Button
+                  variant="primary"
+                  disabled={isPending}
+                  onClick={() => confirm(suggested.id)}
+                >
+                  {isPending ? (
+                    <Loader2 aria-hidden="true" className="animate-spin" />
+                  ) : null}
+                  Ja, das bin ich
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={isPending}
+                  onClick={() => setIsSearching(true)}
+                >
+                  Anderes Profil wählen
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              {suggested ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsSearching(false)}
+                >
+                  <ArrowLeft aria-hidden="true" />
+                  Zurück zum Vorschlag
+                </Button>
+              ) : null}
+              <div className="relative">
+                <Search
+                  aria-hidden="true"
+                  className="absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  aria-label="Member-Profil suchen"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Vor- oder Nachname"
+                  className="pl-11"
+                  autoFocus
+                />
+              </div>
+
+              {matchingProfiles.length > 0 ? (
+                <ScrollArea className="h-64 pr-3">
+                  <div className="space-y-2">
+                    {matchingProfiles.map((profile) => (
+                      <MemberPlatformProfileOption
+                        key={profile.id}
+                        profile={profile}
+                        isSelected={profile.id === selectedId}
+                        onSelect={() => setSelectedId(profile.id)}
+                      />
+                    ))}
+                  </div>
+                </ScrollArea>
+              ) : (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  Kein passendes Profil gefunden.
+                </p>
+              )}
+
+              <Button
+                className="w-full"
+                variant="primary"
+                disabled={!selected || isPending}
+                onClick={() => selected && confirm(selected.id)}
+              >
+                {isPending ? (
+                  <Loader2 aria-hidden="true" className="animate-spin" />
+                ) : null}
+                Dieses Profil verknüpfen
+              </Button>
+            </>
+          )}
+
+          <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+            <p className="flex items-start gap-2">
+              <CircleHelp
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <span>
+                Du findest dein Profil nicht oder bist dir unsicher? Bitte wende
+                dich an People &amp; Culture, bevor du ein fremdes Profil
+                auswählst.
+              </span>
+            </p>
+          </div>
+
+          <Button
+            className="w-full"
+            variant="ghost"
+            disabled={isPending}
+            onClick={() => void signOutWithPostHog()}
+          >
+            <LogOut aria-hidden="true" />
+            Abmelden
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/(protected)/MemberPlatformProfileOption.tsx
+++ b/app/(protected)/MemberPlatformProfileOption.tsx
@@ -1,0 +1,54 @@
+import { Check } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { MemberPlatformLinkOption } from "@/lib/server/memberPlatform/linking";
+import { getInitials } from "@/lib/formatters/getInitials";
+
+interface Props {
+  profile: MemberPlatformLinkOption;
+  isSelected?: boolean;
+  onSelect?: () => void;
+}
+
+export function MemberPlatformProfileOption({
+  profile,
+  isSelected = false,
+  onSelect,
+}: Props) {
+  const content = (
+    <>
+      <Avatar className="size-11 border">
+        <AvatarImage src={profile.imageUrl} alt="" className="object-cover" />
+        <AvatarFallback className="text-sm font-semibold">
+          {getInitials(profile.name)}
+        </AvatarFallback>
+      </Avatar>
+      <span className="min-w-0 flex-1 truncate text-left font-medium">
+        {profile.name}
+      </span>
+      {isSelected ? (
+        <span className="flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+          <Check aria-hidden="true" className="size-3.5" />
+        </span>
+      ) : null}
+    </>
+  );
+
+  if (!onSelect) {
+    return (
+      <div className="flex items-center gap-3 rounded-md border-2 bg-muted/30 p-4">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      onClick={onSelect}
+      className="flex w-full items-center gap-3 rounded-md border-2 p-3 transition-colors hover:border-ring aria-pressed:border-primary aria-pressed:bg-primary/5"
+    >
+      {content}
+    </button>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -6,6 +6,8 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { auth } from "@/lib/auth";
 import { requireAuthenticatedUser } from "@/lib/auth/session";
 import { isUnavailableMemberStatus } from "@/lib/members/status";
+import { getMemberPlatformLinkingData } from "@/lib/server/memberPlatform/linking";
+import { MemberPlatformLinking } from "./MemberPlatformLinking";
 import { OnboardingNotice } from "./OnboardingNotice";
 import { OffboardedNotice } from "./OffboardedNotice";
 import { PublicProfileSetup } from "./PublicProfileSetup";
@@ -29,6 +31,16 @@ export default async function ProtectedLayout({
           member.googlePhotoIsDefault === false && Boolean(member.image)
         }
       />
+    );
+  } else if (
+    member.memberStatus === "onboarding" &&
+    !member.memberPlatformUserId
+  ) {
+    const linkingData = await getMemberPlatformLinkingData(member);
+    content = linkingData ? (
+      <MemberPlatformLinking data={linkingData} />
+    ) : (
+      <OnboardingNotice onboardingStatus={member.teamOnboardingStatus} />
     );
   } else if (member.memberStatus === "onboarding") {
     content = (

--- a/app/(protected)/settings/members/MemberContactFields.tsx
+++ b/app/(protected)/settings/members/MemberContactFields.tsx
@@ -1,34 +1,62 @@
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import type { MemberDrawerFormState } from "./useMemberDrawerForm";
+import { ExternalLink, Mail, Phone } from "lucide-react";
+import type { User } from "@/lib/db/types";
 
-export function MemberContactFields({ form }: { form: MemberDrawerFormState }) {
+const MEMBER_PLATFORM_URL = "https://member.youngfounders.network";
+
+export function MemberContactFields({ member }: { member: User }) {
+  const profileUrl = member.memberPlatformUserId
+    ? `${MEMBER_PLATFORM_URL}/member/${member.memberPlatformUserId}`
+    : undefined;
+
   return (
-    <fieldset className="space-y-3 rounded-md border p-4">
-      <legend className="px-1 text-sm font-medium">Private Kontaktdaten</legend>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="member-private-email">Private E-Mail</Label>
-        <Input
-          id="member-private-email"
-          type="email"
-          value={form.privateEmail}
-          onChange={(event) => form.setPrivateEmail(event.target.value)}
-          placeholder="name@beispiel.de"
-          autoComplete="email"
-        />
+    <section className="border-t pt-5" aria-labelledby="private-contact-title">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 id="private-contact-title" className="text-sm font-semibold">
+            Private Kontaktdaten
+          </h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {member.memberPlatformUserId
+              ? "Aus der Member-Plattform synchronisiert"
+              : "Noch nicht mit der Member-Plattform verknüpft"}
+          </p>
+        </div>
+        {profileUrl ? (
+          <a
+            href={profileUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1 text-xs underline-offset-4 hover:underline"
+          >
+            Profil
+            <ExternalLink aria-hidden="true" className="size-3" />
+          </a>
+        ) : null}
       </div>
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="member-phone">Telefonnummer</Label>
-        <Input
-          id="member-phone"
-          type="tel"
-          value={form.phone}
-          onChange={(event) => form.setPhone(event.target.value)}
-          placeholder="+49 170 1234567"
-          autoComplete="tel"
-          maxLength={40}
-        />
+
+      <div className="mt-3 grid gap-2 text-sm">
+        {member.privateEmail ? (
+          <a
+            href={`mailto:${member.privateEmail}`}
+            className="text-muted-foreground hover:text-foreground flex min-w-0 items-center gap-2 underline-offset-4 hover:underline"
+          >
+            <Mail aria-hidden="true" className="size-3.5 shrink-0" />
+            <span className="truncate">{member.privateEmail}</span>
+          </a>
+        ) : null}
+        {member.phone ? (
+          <a
+            href={`tel:${member.phone.replace(/\s/g, "")}`}
+            className="text-muted-foreground hover:text-foreground flex items-center gap-2 underline-offset-4 hover:underline"
+          >
+            <Phone aria-hidden="true" className="size-3.5 shrink-0" />
+            <span>{member.phone}</span>
+          </a>
+        ) : null}
+        {!member.privateEmail && !member.phone ? (
+          <p className="text-muted-foreground">Keine Kontaktdaten hinterlegt</p>
+        ) : null}
       </div>
-    </fieldset>
+    </section>
   );
 }

--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -56,7 +56,6 @@ export function MemberDrawerPanel({
       </div>
 
       <div className="flex flex-1 flex-col gap-4 px-6">
-        <MemberContactFields form={form} />
         <PublicOrganizationFields form={form} />
         <MemberStatusField
           status={form.status}
@@ -78,6 +77,7 @@ export function MemberDrawerPanel({
           }
         />
         <MemberInfractionsSection member={member} />
+        <MemberContactFields member={member} />
       </div>
 
       <SheetFooter className="mt-6 border-t px-6 pt-6 pb-6">

--- a/app/(protected)/settings/members/MemberRow.tsx
+++ b/app/(protected)/settings/members/MemberRow.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Mail, Smartphone } from "lucide-react";
 import { MemberStageBadge } from "@/components/Members/MemberStageBadge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { TableCell, TableRow } from "@/components/ui/table";
@@ -90,34 +89,6 @@ export function MemberRow({
       </TableCell>
       <TableCell className="text-muted-foreground">
         {member.email || "—"}
-      </TableCell>
-      <TableCell className="min-w-52">
-        {member.privateEmail || member.phone ? (
-          <div className="flex flex-col gap-1 text-sm">
-            {member.privateEmail ? (
-              <a
-                href={`mailto:${member.privateEmail}`}
-                className="text-muted-foreground flex items-center gap-1.5 hover:text-foreground hover:underline"
-                onClick={(event) => event.stopPropagation()}
-              >
-                <Mail aria-hidden="true" className="size-3.5 shrink-0" />
-                <span className="max-w-48 truncate">{member.privateEmail}</span>
-              </a>
-            ) : null}
-            {member.phone ? (
-              <a
-                href={`tel:${member.phone.replace(/\s/g, "")}`}
-                className="text-muted-foreground flex items-center gap-1.5 hover:text-foreground hover:underline"
-                onClick={(event) => event.stopPropagation()}
-              >
-                <Smartphone aria-hidden="true" className="size-3.5 shrink-0" />
-                <span>{member.phone}</span>
-              </a>
-            ) : null}
-          </div>
-        ) : (
-          "—"
-        )}
       </TableCell>
       <TableCell>
         <MemberStageBadge stage={memberStageForStatus(member.memberStatus)} />

--- a/app/(protected)/settings/members/MembersTableHeader.tsx
+++ b/app/(protected)/settings/members/MembersTableHeader.tsx
@@ -6,7 +6,6 @@ export function MembersTableHeader() {
       <TableRow>
         <TableHead className="pl-4">Name</TableHead>
         <TableHead>YFN-Mail</TableHead>
-        <TableHead>Privater Kontakt</TableHead>
         <TableHead>Status</TableHead>
         <TableHead>Department</TableHead>
         <TableHead>Team</TableHead>

--- a/app/(protected)/settings/members/MembersTableSkeleton.tsx
+++ b/app/(protected)/settings/members/MembersTableSkeleton.tsx
@@ -20,9 +20,6 @@ export function MembersTableSkeleton() {
                 <Skeleton className="h-4 w-44" />
               </TableCell>
               <TableCell>
-                <Skeleton className="h-9 w-44" />
-              </TableCell>
-              <TableCell>
                 <Skeleton className="h-7 w-24 rounded-full" />
               </TableCell>
               <TableCell>

--- a/app/(protected)/settings/members/useMemberDrawerForm.ts
+++ b/app/(protected)/settings/members/useMemberDrawerForm.ts
@@ -26,8 +26,6 @@ export function useMemberDrawerForm(
     setStatus: setStatusMutation,
     updateRole,
   } = useMemberMutations();
-  const [privateEmail, setPrivateEmail] = useState(member.privateEmail ?? "");
-  const [phone, setPhone] = useState(member.phone ?? "");
   const [teamId, setTeamId] = useState(member.teamId ?? "");
   const [secondaryTeamId, setSecondaryTeamId] = useState(
     member.secondaryTeamId ?? "",
@@ -67,22 +65,12 @@ export function useMemberDrawerForm(
       }
       const profile: {
         userId: string;
-        privateEmail?: string | null;
-        phone?: string | null;
         teamId?: string | null;
         secondaryTeamId?: string | null;
         isTeamLead?: boolean;
         isSecondaryTeamLead?: boolean;
         boardMembership?: BoardMembership | null;
       } = { userId: member._id };
-      const nextPrivateEmail = privateEmail.trim().toLowerCase();
-      if (nextPrivateEmail !== (member.privateEmail ?? "")) {
-        profile.privateEmail = nextPrivateEmail || null;
-      }
-      const nextPhone = phone.trim();
-      if (nextPhone !== (member.phone ?? "")) {
-        profile.phone = nextPhone || null;
-      }
       if (board.isBoardMember) {
         if (member.teamId) profile.teamId = null;
       } else if (teamId && teamId !== member.teamId) {
@@ -115,8 +103,6 @@ export function useMemberDrawerForm(
         profile.boardMembership = nextBoardMembership;
       }
       if (
-        profile.privateEmail !== undefined ||
-        profile.phone !== undefined ||
         profile.teamId !== undefined ||
         profile.secondaryTeamId !== undefined ||
         profile.isTeamLead !== undefined ||
@@ -151,10 +137,6 @@ export function useMemberDrawerForm(
   };
 
   return {
-    privateEmail,
-    setPrivateEmail,
-    phone,
-    setPhone,
     teamId,
     setTeamId,
     secondaryTeamId,

--- a/app/lib/auth/provisioning.ts
+++ b/app/lib/auth/provisioning.ts
@@ -2,6 +2,7 @@ import { organizations, projects, users } from "../db/collections";
 import { newId } from "../db/ids";
 import type { User } from "../db/types";
 import { YFN_ORGANIZATION } from "../organization";
+import { tryRefreshMemberPlatformProfile } from "../server/memberPlatform/sync";
 import { linkAcceptedApplication } from "./applicationLinking";
 
 type SignInProfile = {
@@ -111,7 +112,7 @@ export async function ensureAppUser(profile: SignInProfile): Promise<User> {
     user = { ...user, ...membership };
   }
 
-  return linkAcceptedApplication(user);
+  return tryRefreshMemberPlatformProfile(await linkAcceptedApplication(user));
 }
 
 export async function isLinkedWorkspaceUser(

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -14,6 +14,7 @@ export async function ensureIndexes(): Promise<void> {
     { key: { email: 1 }, unique: true, sparse: true },
     { key: { googleWorkspaceUserId: 1 }, unique: true, sparse: true },
     { key: { applicationId: 1 }, unique: true, sparse: true },
+    { key: { memberPlatformUserId: 1 }, sparse: true },
     { key: { organizationId: 1 } },
     {
       key: {

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -39,6 +39,8 @@ export interface User {
   privateEmail?: string;
   phone?: string;
   phoneVerificationTime?: number;
+  memberPlatformUserId?: string;
+  memberPlatformSyncedAt?: number;
   isAnonymous?: boolean;
   firstName?: string;
   lastName?: string;

--- a/app/lib/memberPlatform/suggestions.test.ts
+++ b/app/lib/memberPlatform/suggestions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+  normalizeEmail,
+  normalizeName,
+  normalizePhone,
+  suggestMemberPlatformProfile,
+} from "./suggestions";
+
+const profile = {
+  id: "member-1",
+  person: { firstName: "Zoë", lastName: "Beispiel" },
+  contact: { email: "zoe@example.com", phone: "+49 170 1234567" },
+  auth: { provider: "google", providerId: "google-1" },
+};
+
+describe("member platform profile suggestions", () => {
+  test("normalizes identifiers used for suggestions", () => {
+    expect(normalizeEmail(" Zoe@Example.COM ")).toBe("zoe@example.com");
+    expect(normalizePhone("0049 (170) 123-4567")).toBe("491701234567");
+    expect(normalizeName(" Zoë  Beispiel ")).toBe("zoe beispiel");
+  });
+
+  test("suggests the profile with the strongest identity evidence", () => {
+    const suggestion = suggestMemberPlatformProfile({
+      member: {
+        name: "Zoe Beispiel",
+        privateEmail: "zoe@example.com",
+      },
+      profiles: [profile, { ...profile, id: "member-2", contact: undefined }],
+    });
+
+    expect(suggestion?.id).toBe("member-1");
+  });
+
+  test("can suggest a unique exact name for user confirmation", () => {
+    const suggestion = suggestMemberPlatformProfile({
+      member: { name: "Zoe Beispiel" },
+      profiles: [profile],
+    });
+
+    expect(suggestion?.id).toBe("member-1");
+  });
+
+  test("does not treat another auth provider as the Workspace identity", () => {
+    const suggestion = suggestMemberPlatformProfile({
+      member: { googleWorkspaceUserId: "google-1" },
+      profiles: [
+        { ...profile, auth: { provider: "linkedin", providerId: "google-1" } },
+      ],
+    });
+
+    expect(suggestion).toBeUndefined();
+  });
+
+  test("does not choose between equally strong profiles", () => {
+    const suggestion = suggestMemberPlatformProfile({
+      member: { privateEmail: "zoe@example.com" },
+      profiles: [profile, { ...profile, id: "member-2" }],
+    });
+
+    expect(suggestion).toBeUndefined();
+  });
+});

--- a/app/lib/memberPlatform/suggestions.ts
+++ b/app/lib/memberPlatform/suggestions.ts
@@ -1,0 +1,114 @@
+const COLLATOR = new Intl.Collator("de", { sensitivity: "base" });
+
+export interface MemberPlatformProfile {
+  id: string;
+  deletedAt?: Date | null;
+  person?: { firstName?: string; lastName?: string };
+  contact?: { email?: string; phone?: string };
+  auth?: { provider?: string; providerId?: string };
+  images?: { profileImage?: string };
+}
+
+interface SuggestionSource {
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  privateEmail?: string;
+  phone?: string;
+  googleWorkspaceUserId?: string;
+}
+
+interface RankedProfile {
+  profile: MemberPlatformProfile;
+  score: number;
+}
+
+export function suggestMemberPlatformProfile({
+  member,
+  profiles,
+}: {
+  member: SuggestionSource;
+  profiles: MemberPlatformProfile[];
+}): MemberPlatformProfile | undefined {
+  const ranked = profiles
+    .map((profile) => ({
+      profile,
+      score: profileScore(member, profile),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(compareRankedProfiles);
+  const [best, second] = ranked;
+  if (!best || second?.score === best.score) return undefined;
+  return best.profile;
+}
+
+export function normalizeEmail(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+export function normalizePhone(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const digits = value.replace(/\D/g, "");
+  return digits.startsWith("00") ? digits.slice(2) : digits;
+}
+
+export function normalizeName(value: unknown): string {
+  return typeof value === "string"
+    ? value
+        .normalize("NFKD")
+        .replace(/\p{M}/gu, "")
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}]+/gu, " ")
+        .trim()
+    : "";
+}
+
+function compareRankedProfiles(
+  left: RankedProfile,
+  right: RankedProfile,
+): number {
+  return (
+    right.score - left.score ||
+    COLLATOR.compare(left.profile.id, right.profile.id)
+  );
+}
+
+function profileScore(
+  member: SuggestionSource,
+  profile: MemberPlatformProfile,
+): number {
+  let score = 0;
+  if (
+    member.googleWorkspaceUserId &&
+    profile.auth?.provider === "google" &&
+    member.googleWorkspaceUserId === profile.auth.providerId
+  ) {
+    score += 400;
+  }
+
+  const platformEmail = normalizeEmail(profile.contact?.email);
+  if (platformEmail && platformEmail === normalizeEmail(member.privateEmail)) {
+    score += 300;
+  }
+  if (platformEmail && platformEmail === normalizeEmail(member.email)) {
+    score += 250;
+  }
+
+  const platformPhone = normalizePhone(profile.contact?.phone);
+  if (platformPhone && platformPhone === normalizePhone(member.phone)) {
+    score += 200;
+  }
+
+  const memberName = normalizeName(
+    member.name ||
+      [member.firstName, member.lastName].filter(Boolean).join(" "),
+  );
+  const profileName = normalizeName(
+    [profile.person?.firstName, profile.person?.lastName]
+      .filter(Boolean)
+      .join(" "),
+  );
+  if (memberName && memberName === profileName) score += 100;
+  return score;
+}

--- a/app/lib/server/memberPlatform/actions.ts
+++ b/app/lib/server/memberPlatform/actions.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { z } from "zod";
+import { requireAuthenticatedUser } from "../../auth/session";
+import { users } from "../../db/collections";
+import {
+  findLinkableMemberPlatformProfile,
+  isEligibleForMemberPlatformLinking,
+} from "./linking";
+import { persistMemberPlatformProfile } from "./sync";
+
+const profileIdSchema = z.string().trim().min(1).max(120);
+
+export async function confirmMemberPlatformProfile(
+  profileId: string,
+): Promise<void> {
+  const selectedId = profileIdSchema.parse(profileId);
+  const member = await requireAuthenticatedUser();
+  if (member.memberPlatformUserId) return;
+  if (member.memberStatus !== "onboarding") {
+    throw new Error("Die Profilverknüpfung ist bereits abgeschlossen.");
+  }
+  if (!isEligibleForMemberPlatformLinking(member)) {
+    throw new Error(
+      "Die Profilverknüpfung ist für dieses Konto nicht verfügbar.",
+    );
+  }
+
+  const [profile, existingClaim] = await Promise.all([
+    findLinkableMemberPlatformProfile(selectedId),
+    (await users()).findOne(
+      {
+        _id: { $ne: member._id },
+        memberPlatformUserId: selectedId,
+      },
+      { projection: { _id: 1 } },
+    ),
+  ]);
+  if (existingClaim) {
+    throw new Error(
+      "Dieses Profil ist bereits verknüpft. Bitte wende dich an People & Culture.",
+    );
+  }
+
+  const updated = await persistMemberPlatformProfile(member, profile);
+  if (updated.memberPlatformUserId !== selectedId) {
+    throw new Error(
+      "Das Profil konnte nicht verknüpft werden. Bitte wende dich an People & Culture.",
+    );
+  }
+}

--- a/app/lib/server/memberPlatform/client.ts
+++ b/app/lib/server/memberPlatform/client.ts
@@ -1,0 +1,9 @@
+import type { Db } from "mongodb";
+import { getClient } from "../../db/client";
+
+export async function getMemberPlatformDb(): Promise<Db | null> {
+  const databaseName = process.env.MEMBER_PLATFORM_MONGODB_DB?.trim();
+  if (!databaseName) return null;
+
+  return (await getClient()).db(databaseName);
+}

--- a/app/lib/server/memberPlatform/linking.test.ts
+++ b/app/lib/server/memberPlatform/linking.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../auth/session", () => ({
+  requireAuthenticatedUser: vi.fn(),
+}));
+
+import { requireAuthenticatedUser } from "../../auth/session";
+import { getClient } from "../../db/client";
+import { users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { User } from "../../db/types";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { confirmMemberPlatformProfile } from "./actions";
+import { getMemberPlatformLinkingData } from "./linking";
+
+const PLATFORM_DATABASE = "member_platform_linking_test";
+const previousPlatformDatabase = process.env.MEMBER_PLATFORM_MONGODB_DB;
+
+setupTestDatabase();
+
+afterAll(() => {
+  if (previousPlatformDatabase === undefined) {
+    delete process.env.MEMBER_PLATFORM_MONGODB_DB;
+    return;
+  }
+  process.env.MEMBER_PLATFORM_MONGODB_DB = previousPlatformDatabase;
+});
+
+beforeEach(async () => {
+  process.env.MEMBER_PLATFORM_MONGODB_DB = PLATFORM_DATABASE;
+  await (await getClient()).db(PLATFORM_DATABASE).dropDatabase();
+  vi.mocked(requireAuthenticatedUser).mockReset();
+});
+
+test("suggests one profile and excludes profiles already linked in YBase", async () => {
+  const member = await insertMember({
+    name: "Zoë Beispiel",
+    privateEmail: "zoe@example.com",
+  });
+  await insertPlatformProfile("platform-1", "Zoë", "Beispiel");
+  await insertPlatformProfile("platform-2", "Andere", "Person");
+  await insertMember({ memberPlatformUserId: "platform-2" });
+
+  const data = await getMemberPlatformLinkingData(member);
+
+  expect(data).toEqual({
+    suggestedId: "platform-1",
+    profiles: [
+      {
+        id: "platform-1",
+        name: "Zoë Beispiel",
+        imageUrl: "https://example.com/profile.jpg",
+      },
+    ],
+  });
+});
+
+test("links exactly the profile confirmed by the member", async () => {
+  const member = await insertMember();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+  await insertPlatformProfile("platform-1", "Andere", "Person");
+
+  await confirmMemberPlatformProfile("platform-1");
+
+  await expect(
+    (await users()).findOne({ _id: member._id }),
+  ).resolves.toMatchObject({
+    memberPlatformUserId: "platform-1",
+    privateEmail: "private@example.com",
+    phone: "+49 170 1234567",
+    memberPlatformSyncedAt: expect.any(Number),
+  });
+});
+
+test("rejects a profile that another YBase member has already claimed", async () => {
+  const member = await insertMember();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+  await insertPlatformProfile("platform-1", "Andere", "Person");
+  await insertMember({ memberPlatformUserId: "platform-1" });
+
+  await expect(confirmMemberPlatformProfile("platform-1")).rejects.toThrow(
+    "bereits verknüpft",
+  );
+});
+
+test("does not expose or link profiles for accounts outside YFN", async () => {
+  const member = await insertMember({ email: "zoe@example.com" });
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+  await insertPlatformProfile("platform-1", "Zoë", "Beispiel");
+
+  await expect(getMemberPlatformLinkingData(member)).resolves.toBeNull();
+  await expect(confirmMemberPlatformProfile("platform-1")).rejects.toThrow(
+    "nicht verfügbar",
+  );
+});
+
+async function insertMember(overrides: Partial<User> = {}): Promise<User> {
+  const member: User = {
+    _id: newId(),
+    _creationTime: Date.now(),
+    name: "Zoë Beispiel",
+    email: "zoe@youngfounders.network",
+    memberStatus: "onboarding",
+    teamOnboardingStatus: "not_started",
+    ...overrides,
+  };
+  await (await users()).insertOne(member);
+  return member;
+}
+
+async function insertPlatformProfile(
+  id: string,
+  firstName: string,
+  lastName: string,
+): Promise<void> {
+  const database = (await getClient()).db(PLATFORM_DATABASE);
+  await Promise.all([
+    database.collection("users").insertOne({
+      id,
+      deletedAt: null,
+      person: { firstName, lastName },
+      contact: {
+        email: "private@example.com",
+        phone: "+49 170 1234567",
+      },
+      images: { profileImage: "https://example.com/profile.jpg" },
+    }),
+    database.collection("user-states").insertOne({
+      userId: id,
+      current: "ACCEPTED",
+    }),
+  ]);
+}

--- a/app/lib/server/memberPlatform/linking.ts
+++ b/app/lib/server/memberPlatform/linking.ts
@@ -1,0 +1,124 @@
+import {
+  type MemberPlatformProfile,
+  suggestMemberPlatformProfile,
+} from "../../memberPlatform/suggestions";
+import { users } from "../../db/collections";
+import type { User } from "../../db/types";
+import { YFN_ORGANIZATION } from "../../organization";
+import { getMemberPlatformDb } from "./client";
+
+const LINKABLE_MEMBER_STATES = ["ACCEPTED", "ALUMNI"];
+const COLLATOR = new Intl.Collator("de", { sensitivity: "base" });
+
+export interface MemberPlatformLinkOption {
+  id: string;
+  name: string;
+  imageUrl?: string;
+}
+
+export interface MemberPlatformLinkingData {
+  suggestedId?: string;
+  profiles: MemberPlatformLinkOption[];
+}
+
+export async function getMemberPlatformLinkingData(
+  member: User,
+): Promise<MemberPlatformLinkingData | null> {
+  if (!isEligibleForMemberPlatformLinking(member)) return null;
+  const platformDb = await getMemberPlatformDb();
+  if (!platformDb) return null;
+
+  const [profiles, states, claims] = await Promise.all([
+    platformDb
+      .collection<MemberPlatformProfile>("users")
+      .find({ deletedAt: null })
+      .project<MemberPlatformProfile>({
+        _id: 0,
+        id: 1,
+        person: 1,
+        contact: 1,
+        auth: 1,
+        images: 1,
+      })
+      .toArray(),
+    platformDb
+      .collection("user-states")
+      .find({ current: { $in: LINKABLE_MEMBER_STATES } })
+      .project<{ userId: string }>({ _id: 0, userId: 1 })
+      .toArray(),
+    (await users())
+      .find({ memberPlatformUserId: { $exists: true } })
+      .project<{ memberPlatformUserId: string }>({
+        _id: 0,
+        memberPlatformUserId: 1,
+      })
+      .toArray(),
+  ]);
+  const linkableIds = new Set(states.map(({ userId }) => userId));
+  const claimedIds = new Set(
+    claims.map(({ memberPlatformUserId }) => memberPlatformUserId),
+  );
+  const availableProfiles = profiles.filter(
+    ({ id }) => linkableIds.has(id) && !claimedIds.has(id),
+  );
+  const suggested = suggestMemberPlatformProfile({
+    member,
+    profiles: availableProfiles,
+  });
+  const options = availableProfiles
+    .map(toLinkOption)
+    .filter((option) => option.name)
+    .sort((left, right) => COLLATOR.compare(left.name, right.name));
+
+  return { suggestedId: suggested?.id, profiles: options };
+}
+
+export function isEligibleForMemberPlatformLinking(member: User): boolean {
+  return (
+    !member.memberPlatformUserId &&
+    member.memberStatus === "onboarding" &&
+    member.email
+      ?.trim()
+      .toLowerCase()
+      .endsWith(`@${YFN_ORGANIZATION.domain}`) === true
+  );
+}
+
+export async function findLinkableMemberPlatformProfile(
+  profileId: string,
+): Promise<MemberPlatformProfile> {
+  const platformDb = await getMemberPlatformDb();
+  if (!platformDb) {
+    throw new Error("Die Member-Plattform ist nicht konfiguriert.");
+  }
+
+  const [profile, state] = await Promise.all([
+    platformDb
+      .collection<MemberPlatformProfile>("users")
+      .findOne(
+        { id: profileId, deletedAt: null },
+        { projection: { _id: 0, id: 1, contact: 1 } },
+      ),
+    platformDb.collection("user-states").findOne({
+      userId: profileId,
+      current: { $in: LINKABLE_MEMBER_STATES },
+    }),
+  ]);
+  if (!profile || !state) {
+    throw new Error("Dieses Member-Profil ist nicht mehr verfügbar.");
+  }
+  return profile;
+}
+
+function toLinkOption(
+  profile: MemberPlatformProfile,
+): MemberPlatformLinkOption {
+  return {
+    id: profile.id,
+    name: [profile.person?.firstName, profile.person?.lastName]
+      .filter(Boolean)
+      .join(" ")
+      .trim(),
+    imageUrl: profile.images?.profileImage,
+  };
+}

--- a/app/lib/server/memberPlatform/sync.test.ts
+++ b/app/lib/server/memberPlatform/sync.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeEach, expect, test } from "vitest";
+import { getClient } from "../../db/client";
+import { users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { User } from "../../db/types";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { tryRefreshMemberPlatformProfile } from "./sync";
+
+const PLATFORM_DATABASE = "member_platform_test";
+const previousPlatformDatabase = process.env.MEMBER_PLATFORM_MONGODB_DB;
+
+setupTestDatabase();
+
+afterAll(() => {
+  if (previousPlatformDatabase === undefined) {
+    delete process.env.MEMBER_PLATFORM_MONGODB_DB;
+    return;
+  }
+  process.env.MEMBER_PLATFORM_MONGODB_DB = previousPlatformDatabase;
+});
+
+beforeEach(async () => {
+  process.env.MEMBER_PLATFORM_MONGODB_DB = PLATFORM_DATABASE;
+  await (await getClient()).db(PLATFORM_DATABASE).dropDatabase();
+});
+
+test("refreshes contact details for an existing confirmed link", async () => {
+  const member = await insertMember({
+    email: "zoe@youngfounders.network",
+    privateEmail: "old@example.com",
+    memberPlatformUserId: "platform-1",
+  });
+  await insertPlatformProfile({
+    id: "platform-1",
+    email: "zoe@example.com",
+    phone: "+49 170 1234567",
+  });
+
+  const synced = await tryRefreshMemberPlatformProfile(member);
+
+  expect(synced).toMatchObject({
+    memberPlatformUserId: "platform-1",
+    privateEmail: "zoe@example.com",
+    phone: "+49 170 1234567",
+    memberPlatformSyncedAt: expect.any(Number),
+  });
+  await expect(
+    (await users()).findOne({ _id: member._id }),
+  ).resolves.toMatchObject({
+    memberPlatformUserId: "platform-1",
+    phone: "+49 170 1234567",
+  });
+});
+
+test("does not link an unconfirmed profile automatically", async () => {
+  const member = await insertMember({
+    email: "new@youngfounders.network",
+    privateEmail: "shared@example.com",
+  });
+  await insertPlatformProfile({
+    id: "platform-1",
+    email: "shared@example.com",
+  });
+
+  const synced = await tryRefreshMemberPlatformProfile(member);
+
+  expect(synced.memberPlatformUserId).toBeUndefined();
+  expect(await (await users()).findOne({ _id: member._id })).not.toHaveProperty(
+    "memberPlatformUserId",
+  );
+});
+
+test("does not refresh linked accounts outside the YFN domain", async () => {
+  const member = await insertMember({
+    email: "zoe@example.org",
+    privateEmail: "old@example.com",
+    memberPlatformUserId: "platform-1",
+  });
+  await insertPlatformProfile({
+    id: "platform-1",
+    email: "zoe@example.com",
+  });
+
+  const synced = await tryRefreshMemberPlatformProfile(member);
+
+  expect(synced.privateEmail).toBe("old@example.com");
+});
+
+async function insertMember(overrides: Partial<User>): Promise<User> {
+  const member: User = {
+    _id: newId(),
+    _creationTime: Date.now(),
+    name: "Zoë Beispiel",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+    ...overrides,
+  };
+  await (await users()).insertOne(member);
+  return member;
+}
+
+async function insertPlatformProfile(input: {
+  id: string;
+  email: string;
+  phone?: string;
+}): Promise<void> {
+  const database = (await getClient()).db(PLATFORM_DATABASE);
+  await Promise.all([
+    database.collection("users").insertOne({
+      id: input.id,
+      deletedAt: null,
+      person: { firstName: "Zoë", lastName: "Beispiel" },
+      contact: { email: input.email, phone: input.phone },
+    }),
+    database.collection("user-states").insertOne({
+      userId: input.id,
+      current: "ACCEPTED",
+    }),
+  ]);
+}

--- a/app/lib/server/memberPlatform/sync.ts
+++ b/app/lib/server/memberPlatform/sync.ts
@@ -1,0 +1,79 @@
+import type { MemberPlatformProfile } from "../../memberPlatform/suggestions";
+import { users } from "../../db/collections";
+import type { User } from "../../db/types";
+import { YFN_ORGANIZATION } from "../../organization";
+import { getMemberPlatformDb } from "./client";
+
+export async function tryRefreshMemberPlatformProfile(
+  member: User,
+): Promise<User> {
+  try {
+    return await refreshMemberPlatformProfile(member);
+  } catch (error) {
+    console.error(
+      `Member-platform refresh failed for YBase user ${member._id}`,
+      error,
+    );
+    return member;
+  }
+}
+
+async function refreshMemberPlatformProfile(member: User): Promise<User> {
+  const email = member.email?.trim().toLowerCase();
+  if (!email?.endsWith(`@${YFN_ORGANIZATION.domain}`)) return member;
+  if (!member.memberPlatformUserId) return member;
+
+  const platformDb = await getMemberPlatformDb();
+  if (!platformDb) return member;
+
+  const profile = await platformDb
+    .collection<MemberPlatformProfile>("users")
+    .findOne(
+      { id: member.memberPlatformUserId, deletedAt: null },
+      { projection: { _id: 0, id: 1, contact: 1 } },
+    );
+  if (!profile) return member;
+  return persistMemberPlatformProfile(member, profile);
+}
+
+export async function persistMemberPlatformProfile(
+  member: User,
+  profile: MemberPlatformProfile,
+): Promise<User> {
+  const privateEmail = profile.contact?.email?.trim().toLowerCase();
+  const phone = profile.contact?.phone?.trim();
+  const syncedAt = Date.now();
+  const unset: Partial<Record<"privateEmail" | "phone", "">> = {
+    ...(privateEmail ? {} : { privateEmail: "" }),
+    ...(phone ? {} : { phone: "" }),
+  };
+  const result = await (
+    await users()
+  ).updateOne(
+    {
+      _id: member._id,
+      $or: [
+        { memberPlatformUserId: { $exists: false } },
+        { memberPlatformUserId: profile.id },
+      ],
+    },
+    {
+      $set: {
+        memberPlatformUserId: profile.id,
+        memberPlatformSyncedAt: syncedAt,
+        ...(privateEmail ? { privateEmail } : {}),
+        ...(phone ? { phone } : {}),
+      },
+      ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}),
+    },
+  );
+  if (result.matchedCount !== 1) return member;
+
+  return {
+    ...member,
+    memberPlatformUserId: profile.id,
+    memberPlatformSyncedAt: syncedAt,
+    privateEmail,
+    phone,
+  };
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -46,6 +46,8 @@ erDiagram
         string email
         string privateEmail
         string phone
+        string memberPlatformUserId
+        number memberPlatformSyncedAt
         string googleWorkspaceUserId
         string role
         string teamId


### PR DESCRIPTION
## Summary
Adds a user-confirmed onboarding flow that suggests, searches, and links the correct Member Platform profile, then refreshes its private contact data on sign-in.

Moves private contact details out of the members table into a subtle read-only drawer section with a direct Member Platform link.

Adds the cross-database configuration, profile matching safeguards, YFN eligibility checks, schema fields, and focused coverage.

## Validation
Passed Biome, TypeScript, 514 tests, and the production build; `pnpm lint:lines` still reports only the pre-existing 204-line `CreateJobPostingDialog.tsx` already present on `origin/main`.