### PR TITLE
feat(members): add legal membership management foundation

### DIFF
--- a/app/(protected)/MemberPlatformLinking.tsx
+++ b/app/(protected)/MemberPlatformLinking.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import {
-  ArrowLeft,
-  CircleHelp,
-  Link2,
-  Loader2,
-  LogOut,
-  Search,
-} from "lucide-react";
+import { CircleHelp, Link2, Loader2, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useDeferredValue, useState, useTransition } from "react";
+import { useTransition } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,8 +12,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { signOutWithPostHog } from "@/lib/posthog-client";
 import { confirmMemberPlatformProfile } from "@/lib/server/memberPlatform/actions";
 import type { MemberPlatformLinkingData } from "@/lib/server/memberPlatform/linking";
@@ -32,16 +23,8 @@ export function MemberPlatformLinking({
   data: MemberPlatformLinkingData;
 }) {
   const router = useRouter();
-  const suggested = data.profiles.find(({ id }) => id === data.suggestedId);
-  const [isSearching, setIsSearching] = useState(!suggested);
-  const [query, setQuery] = useState("");
-  const [selectedId, setSelectedId] = useState<string>();
+  const profile = data.profile;
   const [isPending, startTransition] = useTransition();
-  const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase("de"));
-  const matchingProfiles = data.profiles.filter(({ name }) =>
-    name.toLocaleLowerCase("de").includes(deferredQuery),
-  );
-  const selected = data.profiles.find(({ id }) => id === selectedId);
 
   const confirm = (profileId: string) => {
     startTransition(async () => {
@@ -63,105 +46,38 @@ export function MemberPlatformLinking({
       <Card className="w-full max-w-xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-            {isSearching ? (
-              <Search aria-hidden="true" className="size-6" />
-            ) : (
-              <Link2 aria-hidden="true" className="size-6" />
-            )}
+            <Link2 aria-hidden="true" className="size-6" />
           </div>
           <CardTitle className="text-2xl">
-            {isSearching ? "Finde dein Member-Profil" : "Bist das du?"}
+            {profile
+              ? "Bist das du?"
+              : "Profil konnte nicht sicher zugeordnet werden"}
           </CardTitle>
           <CardDescription className="text-base leading-relaxed">
-            {isSearching
-              ? "Suche nach deinem Namen und wähle genau dein eigenes Profil aus."
-              : "Bestätige dein bestehendes Profil auf der Member-Plattform."}
+            {profile
+              ? "Bestätige dein bestehendes Profil auf der Member-Plattform."
+              : "People & Culture muss die Zuordnung prüfen, bevor dein Onboarding weitergehen kann."}
           </CardDescription>
         </CardHeader>
 
         <CardContent className="space-y-5">
-          {!isSearching && suggested ? (
+          {profile ? (
             <>
-              <MemberPlatformProfileOption profile={suggested} />
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Button
-                  variant="primary"
-                  disabled={isPending}
-                  onClick={() => confirm(suggested.id)}
-                >
-                  {isPending ? (
-                    <Loader2 aria-hidden="true" className="animate-spin" />
-                  ) : null}
-                  Ja, das bin ich
-                </Button>
-                <Button
-                  variant="outline"
-                  disabled={isPending}
-                  onClick={() => setIsSearching(true)}
-                >
-                  Anderes Profil wählen
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              {suggested ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsSearching(false)}
-                >
-                  <ArrowLeft aria-hidden="true" />
-                  Zurück zum Vorschlag
-                </Button>
-              ) : null}
-              <div className="relative">
-                <Search
-                  aria-hidden="true"
-                  className="absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  aria-label="Member-Profil suchen"
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Vor- oder Nachname"
-                  className="pl-11"
-                  autoFocus
-                />
-              </div>
-
-              {matchingProfiles.length > 0 ? (
-                <ScrollArea className="h-64 pr-3">
-                  <div className="space-y-2">
-                    {matchingProfiles.map((profile) => (
-                      <MemberPlatformProfileOption
-                        key={profile.id}
-                        profile={profile}
-                        isSelected={profile.id === selectedId}
-                        onSelect={() => setSelectedId(profile.id)}
-                      />
-                    ))}
-                  </div>
-                </ScrollArea>
-              ) : (
-                <p className="py-8 text-center text-sm text-muted-foreground">
-                  Kein passendes Profil gefunden.
-                </p>
-              )}
-
+              <MemberPlatformProfileOption profile={profile} />
               <Button
                 className="w-full"
                 variant="primary"
-                disabled={!selected || isPending}
-                onClick={() => selected && confirm(selected.id)}
+                disabled={isPending}
+                aria-busy={isPending}
+                onClick={() => confirm(profile.id)}
               >
                 {isPending ? (
                   <Loader2 aria-hidden="true" className="animate-spin" />
                 ) : null}
-                Dieses Profil verknüpfen
+                Ja, das bin ich
               </Button>
             </>
-          )}
+          ) : null}
 
           <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
             <p className="flex items-start gap-2">
@@ -170,9 +86,8 @@ export function MemberPlatformLinking({
                 className="mt-0.5 size-4 shrink-0"
               />
               <span>
-                Du findest dein Profil nicht oder bist dir unsicher? Bitte wende
-                dich an People &amp; Culture, bevor du ein fremdes Profil
-                auswählst.
+                Ist das nicht dein Profil oder fehlt der Vorschlag? Bitte wende
+                dich an People &amp; Culture.
               </span>
             </p>
           </div>

--- a/app/(protected)/MemberPlatformProfileOption.tsx
+++ b/app/(protected)/MemberPlatformProfileOption.tsx
@@ -1,21 +1,14 @@
-import { Check } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import type { MemberPlatformLinkOption } from "@/lib/server/memberPlatform/linking";
 import { getInitials } from "@/lib/formatters/getInitials";
-
-interface Props {
-  profile: MemberPlatformLinkOption;
-  isSelected?: boolean;
-  onSelect?: () => void;
-}
+import type { MemberPlatformLinkOption } from "@/lib/server/memberPlatform/linking";
 
 export function MemberPlatformProfileOption({
   profile,
-  isSelected = false,
-  onSelect,
-}: Props) {
-  const content = (
-    <>
+}: {
+  profile: MemberPlatformLinkOption;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border-2 bg-muted/30 p-4">
       <Avatar className="size-11 border">
         <AvatarImage src={profile.imageUrl} alt="" className="object-cover" />
         <AvatarFallback className="text-sm font-semibold">
@@ -25,30 +18,6 @@ export function MemberPlatformProfileOption({
       <span className="min-w-0 flex-1 truncate text-left font-medium">
         {profile.name}
       </span>
-      {isSelected ? (
-        <span className="flex size-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
-          <Check aria-hidden="true" className="size-3.5" />
-        </span>
-      ) : null}
-    </>
-  );
-
-  if (!onSelect) {
-    return (
-      <div className="flex items-center gap-3 rounded-md border-2 bg-muted/30 p-4">
-        {content}
-      </div>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      aria-pressed={isSelected}
-      onClick={onSelect}
-      className="flex w-full items-center gap-3 rounded-md border-2 p-3 transition-colors hover:border-ring aria-pressed:border-primary aria-pressed:bg-primary/5"
-    >
-      {content}
-    </button>
+    </div>
   );
 }

--- a/app/(protected)/settings/members/MemberContactFields.tsx
+++ b/app/(protected)/settings/members/MemberContactFields.tsx
@@ -16,9 +16,11 @@ export function MemberContactFields({ member }: { member: User }) {
             Private Kontaktdaten
           </h3>
           <p className="text-muted-foreground mt-1 text-xs">
-            {member.memberPlatformUserId
-              ? "Aus der Member-Plattform synchronisiert"
-              : "Noch nicht mit der Member-Plattform verknüpft"}
+            {member.membershipId
+              ? "In der YBase-Mitgliedschaftsakte verwaltet"
+              : member.memberPlatformUserId
+                ? "Aus der Member-Plattform synchronisiert"
+                : "Noch nicht mit der Member-Plattform verknüpft"}
           </p>
         </div>
         {profileUrl ? (

--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -57,12 +57,14 @@ export function MemberDrawerPanel({
 
       <div className="flex flex-1 flex-col gap-4 px-6">
         <PublicOrganizationFields form={form} />
-        <MemberStatusField
-          status={form.status}
-          onboarding={member.teamOnboardingStatus}
-          infractionCount={member.memberInfractions?.length ?? 0}
-          onChange={form.setStatus}
-        />
+        {!member.membershipId ? (
+          <MemberStatusField
+            status={form.status}
+            onboarding={member.teamOnboardingStatus}
+            infractionCount={member.memberInfractions?.length ?? 0}
+            onChange={form.setStatus}
+          />
+        ) : null}
         <LabeledSelect
           id="member-role"
           label="Berechtigungen"
@@ -76,7 +78,9 @@ export function MemberDrawerPanel({
               : "Rollen können nur von Admins geändert werden."
           }
         />
-        <MemberInfractionsSection member={member} />
+        {!member.membershipId ? (
+          <MemberInfractionsSection member={member} />
+        ) : null}
         <MemberContactFields member={member} />
       </div>
 

--- a/app/(protected)/settings/members/filterMembers.ts
+++ b/app/(protected)/settings/members/filterMembers.ts
@@ -1,4 +1,5 @@
 import type { MemberStatus, Team, User } from "@/lib/db/types";
+import { normalizeMemberStatus } from "../../../lib/members/status";
 
 export const ALL = "all";
 
@@ -46,7 +47,9 @@ export function filterMembers(
     ? filters.status
     : [filters.status];
   return members.filter((member) => {
-    if (!statuses.includes(member.memberStatus)) return false;
+    if (!statuses.includes(normalizeMemberStatus(member.memberStatus))) {
+      return false;
+    }
     if (
       filters.departmentId !== ALL &&
       !departmentIdsOf(member, teamsById).includes(filters.departmentId)

--- a/app/lib/db/application.ts
+++ b/app/lib/db/application.ts
@@ -1,3 +1,10 @@
+import type { LegalDelivery } from "./legalDelivery";
+import type {
+  AdmissionAppealDecision,
+  AdmissionDecision,
+  GuardianConsent,
+} from "./membershipAdmission";
+
 export type ApplicationStatus =
   | "received"
   | "review"
@@ -21,7 +28,14 @@ export interface ApplicationField {
   value: ApplicationFieldValue;
 }
 
-export type ApplicationHistoryType = "status_changed" | "management_updated";
+export type ApplicationHistoryType =
+  | "status_changed"
+  | "management_updated"
+  | "guardian_consent_recorded"
+  | "admission_decision_recorded"
+  | "rejection_delivered"
+  | "appeal_received"
+  | "appeal_decision_recorded";
 
 export type WorkspaceProvisioningStatus =
   | "pending"
@@ -78,6 +92,7 @@ export interface Application {
   applicantEmail: string;
   applicantEmailNormalized: string;
   applicantPhone?: string;
+  dateOfBirth?: string;
   fields: ApplicationField[];
   files: ApplicationFile[];
   tallyEventId: string;
@@ -99,6 +114,14 @@ export interface Application {
   onboardingStartedBy?: string;
   onboardingCompletedAt?: number;
   onboardingCompletedBy?: string;
+  guardianConsent?: GuardianConsent;
+  admissionDecision?: AdmissionDecision;
+  rejectionDelivery?: LegalDelivery;
+  appealTokenHash?: string;
+  appealExpiresAt?: number;
+  appealedAt?: number;
+  appealStatement?: string;
+  appealDecision?: AdmissionAppealDecision;
   cleanupEligibleAt?: number;
   submittedAt: number;
   withdrawnAt?: number;
@@ -119,6 +142,14 @@ export type ApplicationWithFiles = Omit<
   | "withdrawalTokenHash"
   | "yfnEmailNormalized"
   | "workspaceUserId"
+  | "guardianConsent"
+  | "admissionDecision"
+  | "rejectionDelivery"
+  | "appealTokenHash"
+  | "appealExpiresAt"
+  | "appealedAt"
+  | "appealStatement"
+  | "appealDecision"
   | "onboardingCompletedBy"
   | "onboardingStartedBy"
   | "cleanupEligibleAt"

--- a/app/lib/db/collections.ts
+++ b/app/lib/db/collections.ts
@@ -5,6 +5,11 @@ import type {
   JobFeedToken,
   JobPosting,
   Log,
+  DocumentExecution,
+  DocumentVersion,
+  Membership,
+  MembershipCase,
+  MembershipEvent,
   Organization,
   Project,
   Receipt,
@@ -87,4 +92,24 @@ export async function signatureTokens() {
 
 export async function uploadOwnerships() {
   return (await getDb()).collection<UploadOwnership>("uploadOwnerships");
+}
+
+export async function memberships() {
+  return (await getDb()).collection<Membership>("memberships");
+}
+
+export async function membershipCases() {
+  return (await getDb()).collection<MembershipCase>("membershipCases");
+}
+
+export async function documentVersions() {
+  return (await getDb()).collection<DocumentVersion>("documentVersions");
+}
+
+export async function documentExecutions() {
+  return (await getDb()).collection<DocumentExecution>("documentExecutions");
+}
+
+export async function membershipEvents() {
+  return (await getDb()).collection<MembershipEvent>("membershipEvents");
 }

--- a/app/lib/db/indexes.ts
+++ b/app/lib/db/indexes.ts
@@ -1,4 +1,5 @@
 import { getDb } from "./client";
+import { ensureMembershipIndexes } from "./membershipIndexes";
 
 export async function ensureIndexes(): Promise<void> {
   const db = await getDb();
@@ -14,7 +15,8 @@ export async function ensureIndexes(): Promise<void> {
     { key: { email: 1 }, unique: true, sparse: true },
     { key: { googleWorkspaceUserId: 1 }, unique: true, sparse: true },
     { key: { applicationId: 1 }, unique: true, sparse: true },
-    { key: { memberPlatformUserId: 1 }, sparse: true },
+    { key: { memberPlatformUserId: 1 }, unique: true, sparse: true },
+    { key: { membershipId: 1 }, unique: true, sparse: true },
     { key: { organizationId: 1 } },
     {
       key: {
@@ -72,6 +74,8 @@ export async function ensureIndexes(): Promise<void> {
       { key: { tallySubmissionId: 1 }, unique: true },
       { key: { tallyResponseId: 1 }, unique: true },
       { key: { withdrawalTokenHash: 1 }, unique: true, sparse: true },
+      { key: { appealTokenHash: 1 }, unique: true, sparse: true },
+      { key: { "rejectionDelivery.messageId": 1 }, unique: true, sparse: true },
       { key: { yfnEmailNormalized: 1 }, unique: true, sparse: true },
       { key: { jobPostingId: 1, applicantEmailNormalized: 1 }, unique: true },
     ]);
@@ -126,4 +130,5 @@ export async function ensureIndexes(): Promise<void> {
       { key: { contextType: 1, contextId: 1 } },
       { key: { claimedByType: 1, claimedById: 1 }, sparse: true },
     ]);
+  await ensureMembershipIndexes(db);
 }

--- a/app/lib/db/legalDelivery.ts
+++ b/app/lib/db/legalDelivery.ts
@@ -1,0 +1,8 @@
+export interface LegalDelivery {
+  channel: "email" | "letter";
+  recipient: string;
+  messageId?: string;
+  sentAt?: number;
+  deliveredAt?: number;
+  evidenceStorageKey?: string;
+}

--- a/app/lib/db/membership.ts
+++ b/app/lib/db/membership.ts
@@ -1,0 +1,78 @@
+export type MembershipLegalStatus =
+  | "active"
+  | "resigning"
+  | "suspended"
+  | "ended";
+
+export type MembershipEndReason =
+  | "resignation"
+  | "exclusion"
+  | "age_limit"
+  | "death";
+
+export interface PostalAddress {
+  street: string;
+  postalCode: string;
+  city: string;
+  country: string;
+}
+
+export interface GuardianConsentEvidence {
+  representativeName: string;
+  representativeEmail: string;
+  signedAt: number;
+  signatureStorageKey?: string;
+  completedPdfStorageKey?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface HandoverTask {
+  _id: string;
+  category:
+    | "successor"
+    | "responsibilities"
+    | "files"
+    | "shared_access"
+    | "reimbursements"
+    | "external_accounts";
+  title: string;
+  ownerUserId?: string;
+  completedAt?: number;
+  completedBy?: string;
+}
+
+export interface Membership {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  userId: string;
+  applicationId: string;
+  membershipNumber: string;
+  isCurrent: boolean;
+  legalStatus: MembershipLegalStatus;
+  admittedAt: number;
+  admissionEvidenceStorageKey?: string;
+  guardianConsent?: GuardianConsentEvidence;
+  privateEmail: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  phone?: string;
+  address?: PostalAddress;
+  memberPlatformUserId?: string;
+  profileConfirmedAt?: number;
+  purposesConfirmedAt?: number;
+  resignationReceivedAt?: number;
+  scheduledEndAt?: number;
+  scheduledEndReason?: Extract<
+    MembershipEndReason,
+    "resignation" | "age_limit"
+  >;
+  endedAt?: number;
+  endReason?: MembershipEndReason;
+  endEvidenceStorageKey?: string;
+  rightsSuspendedAt?: number;
+  handoverTasks: HandoverTask[];
+  updatedAt: number;
+}

--- a/app/lib/db/membershipAdmission.ts
+++ b/app/lib/db/membershipAdmission.ts
@@ -1,0 +1,32 @@
+export interface GuardianConsent {
+  representativeName: string;
+  representativeEmail: string;
+  tokenHash: string;
+  expiresAt: number;
+  lastSentAt?: number;
+  signingStartedAt?: number;
+  signedAt?: number;
+  signatureStorageKey?: string;
+  completedPdfStorageKey?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface AdmissionDecision {
+  result: "admitted" | "rejected";
+  decidedAt: number;
+  decidedBy: string;
+  authority: "board_member" | "delegate";
+  authorityEvidenceStorageKey?: string;
+  reason?: string;
+  recordedAt: number;
+  recordedBy: string;
+}
+
+export interface AdmissionAppealDecision {
+  result: "admitted" | "rejected";
+  decidedAt: number;
+  recordedAt: number;
+  recordedBy: string;
+  evidenceStorageKey?: string;
+}

--- a/app/lib/db/membershipCase.ts
+++ b/app/lib/db/membershipCase.ts
@@ -1,0 +1,36 @@
+import type { LegalDelivery } from "./legalDelivery";
+
+export type MembershipCaseType = "warning" | "exclusion";
+
+export type MembershipCaseStatus =
+  | "open"
+  | "delivery_pending"
+  | "objection_pending"
+  | "closed";
+
+export type ExclusionDecision = "excluded" | "dismissed";
+
+export type ObjectionOutcome = "confirmed" | "overturned";
+
+export interface MembershipCase {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  membershipId: string;
+  userId: string;
+  type: MembershipCaseType;
+  status: MembershipCaseStatus;
+  reason: string;
+  warningSequence?: number;
+  decision?: ExclusionDecision;
+  decidedAt?: number;
+  decisionDelivery?: LegalDelivery;
+  objectionTokenHash?: string;
+  objectionExpiresAt?: number;
+  objectedAt?: number;
+  objectionText?: string;
+  objectionOutcome?: ObjectionOutcome;
+  objectionDecidedAt?: number;
+  closedAt?: number;
+  updatedAt: number;
+}

--- a/app/lib/db/membershipDocument.ts
+++ b/app/lib/db/membershipDocument.ts
@@ -1,0 +1,49 @@
+export type MembershipDocumentKind =
+  | "bylaws"
+  | "code_of_conduct"
+  | "privacy_notice"
+  | "usage_rights"
+  | "optional_consent";
+
+export type DocumentExecutionType =
+  | "signature"
+  | "acknowledgement"
+  | "optional_consent";
+
+export interface DocumentVersion {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  kind: MembershipDocumentKind;
+  title: string;
+  versionLabel: string;
+  sourceUrl: string;
+  snapshotStorageKey: string;
+  sha256: string;
+  publishedAt: number;
+  publishedBy: string;
+  targetTeamIds: string[];
+  targetDepartmentIds: string[];
+  executionType: DocumentExecutionType;
+  isActive: boolean;
+}
+
+export interface DocumentExecution {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  documentVersionId: string;
+  documentHash: string;
+  membershipId: string;
+  userId: string;
+  status: "assigned" | "completed" | "revoked";
+  assignedAt: number;
+  processingStartedAt?: number;
+  completedAt?: number;
+  signatureStorageKey?: string;
+  completedPdfStorageKey?: string;
+  paperEvidenceStorageKey?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  revokedAt?: number;
+}

--- a/app/lib/db/membershipEvent.ts
+++ b/app/lib/db/membershipEvent.ts
@@ -1,0 +1,14 @@
+export interface MembershipEvent {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  membershipId: string;
+  caseId?: string;
+  userId: string;
+  actorUserId?: string;
+  actorType: "user" | "system" | "public_link" | "integration";
+  type: string;
+  idempotencyKey?: string;
+  occurredAt: number;
+  details: Record<string, string | number | boolean | null>;
+}

--- a/app/lib/db/membershipIndexes.test.ts
+++ b/app/lib/db/membershipIndexes.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, expect, test } from "vitest";
+import { setupTestDatabase } from "../test/setupTestDatabase";
+import {
+  documentExecutions,
+  membershipEvents,
+  memberships,
+  users,
+} from "./collections";
+import { newId } from "./ids";
+import { ensureIndexes } from "./indexes";
+import type { Membership } from "./types";
+
+setupTestDatabase();
+
+beforeEach(async () => {
+  await ensureIndexes();
+});
+
+function membership(
+  organizationId: string,
+  userId: string,
+  overrides: Partial<Membership> = {},
+): Membership {
+  const now = Date.now();
+  return {
+    _id: newId(),
+    _creationTime: now,
+    organizationId,
+    userId,
+    applicationId: newId(),
+    membershipNumber: newId(),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt: now,
+    privateEmail: `${newId()}@example.org`,
+    firstName: "Alex",
+    lastName: "Example",
+    dateOfBirth: "2005-01-01",
+    handoverTasks: [],
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+test("allows a new membership episode after an earlier membership ended", async () => {
+  const organizationId = newId();
+  const userId = newId();
+  const memberPlatformUserId = newId();
+  const collection = await memberships();
+  await collection.insertOne(
+    membership(organizationId, userId, {
+      legalStatus: "ended",
+      isCurrent: false,
+      endedAt: Date.now(),
+      endReason: "resignation",
+      memberPlatformUserId,
+    }),
+  );
+  await collection.insertOne(
+    membership(organizationId, userId, { memberPlatformUserId }),
+  );
+
+  await expect(
+    collection.insertOne(
+      membership(organizationId, userId, {
+        memberPlatformUserId: newId(),
+      }),
+    ),
+  ).rejects.toMatchObject({ code: 11_000 });
+  await expect(
+    collection.insertOne(
+      membership(organizationId, newId(), { memberPlatformUserId }),
+    ),
+  ).rejects.toMatchObject({ code: 11_000 });
+});
+
+test("allows renewed optional consent without overwriting its history", async () => {
+  const now = Date.now();
+  const organizationId = newId();
+  const membershipId = newId();
+  const documentVersionId = newId();
+  const userId = newId();
+  const collection = await documentExecutions();
+  await collection.insertMany([
+    {
+      _id: newId(),
+      _creationTime: now,
+      organizationId,
+      documentVersionId,
+      documentHash: "first",
+      membershipId,
+      userId,
+      status: "revoked",
+      assignedAt: now,
+      completedAt: now + 1,
+      revokedAt: now + 2,
+    },
+    {
+      _id: newId(),
+      _creationTime: now + 3,
+      organizationId,
+      documentVersionId,
+      documentHash: "second",
+      membershipId,
+      userId,
+      status: "completed",
+      assignedAt: now + 3,
+      completedAt: now + 4,
+    },
+  ]);
+
+  expect(await collection.countDocuments({ membershipId })).toBe(2);
+});
+
+test("scopes event idempotency keys to an organization", async () => {
+  const now = Date.now();
+  const idempotencyKey = newId();
+  const collection = await membershipEvents();
+  const event = {
+    _creationTime: now,
+    membershipId: newId(),
+    userId: newId(),
+    actorType: "system" as const,
+    type: "membership.tested",
+    idempotencyKey,
+    occurredAt: now,
+    details: {},
+  };
+  await collection.insertOne({
+    ...event,
+    _id: newId(),
+    organizationId: "organization-a",
+  });
+  await collection.insertOne({
+    ...event,
+    _id: newId(),
+    organizationId: "organization-b",
+  });
+
+  await expect(
+    collection.insertOne({
+      ...event,
+      _id: newId(),
+      organizationId: "organization-a",
+    }),
+  ).rejects.toMatchObject({ code: 11_000 });
+});
+
+test("prevents two users from claiming the same member-platform profile", async () => {
+  const memberPlatformUserId = newId();
+  const now = Date.now();
+  const collection = await users();
+  await collection.insertOne({
+    _id: newId(),
+    _creationTime: now,
+    memberPlatformUserId,
+    memberStatus: "onboarding",
+    teamOnboardingStatus: "not_started",
+  });
+
+  await expect(
+    collection.insertOne({
+      _id: newId(),
+      _creationTime: now,
+      memberPlatformUserId,
+      memberStatus: "onboarding",
+      teamOnboardingStatus: "not_started",
+    }),
+  ).rejects.toMatchObject({ code: 11_000 });
+});

--- a/app/lib/db/membershipIndexes.ts
+++ b/app/lib/db/membershipIndexes.ts
@@ -1,0 +1,58 @@
+import type { Db } from "mongodb";
+
+export async function ensureMembershipIndexes(db: Db): Promise<void> {
+  await db.collection("memberships").createIndexes([
+    {
+      key: { organizationId: 1, userId: 1 },
+      unique: true,
+      partialFilterExpression: { isCurrent: true },
+    },
+    { key: { organizationId: 1, membershipNumber: 1 }, unique: true },
+    { key: { applicationId: 1 }, unique: true },
+    {
+      key: { memberPlatformUserId: 1 },
+      unique: true,
+      partialFilterExpression: {
+        memberPlatformUserId: { $type: "string" },
+        isCurrent: true,
+      },
+    },
+    { key: { organizationId: 1, legalStatus: 1, scheduledEndAt: 1 } },
+    { key: { organizationId: 1, legalStatus: 1, dateOfBirth: 1 } },
+  ]);
+  await db.collection("membershipCases").createIndexes([
+    { key: { organizationId: 1, membershipId: 1, _creationTime: -1 } },
+    { key: { organizationId: 1, type: 1, status: 1 } },
+    { key: { objectionTokenHash: 1 }, unique: true, sparse: true },
+    { key: { "decisionDelivery.messageId": 1 }, unique: true, sparse: true },
+    {
+      key: { membershipId: 1, type: 1, warningSequence: 1 },
+      unique: true,
+      partialFilterExpression: { warningSequence: { $exists: true } },
+    },
+  ]);
+  await db.collection("documentVersions").createIndexes([
+    { key: { organizationId: 1, kind: 1, isActive: 1 } },
+    {
+      key: { organizationId: 1, kind: 1, versionLabel: 1 },
+      unique: true,
+    },
+    { key: { sha256: 1 } },
+  ]);
+  await db
+    .collection("documentExecutions")
+    .createIndexes([
+      { key: { documentVersionId: 1, membershipId: 1, assignedAt: -1 } },
+      { key: { organizationId: 1, membershipId: 1, status: 1 } },
+    ]);
+  await db.collection("membershipEvents").createIndexes([
+    { key: { organizationId: 1, occurredAt: -1 } },
+    { key: { organizationId: 1, membershipId: 1, occurredAt: 1 } },
+    { key: { organizationId: 1, caseId: 1, occurredAt: 1 } },
+    {
+      key: { organizationId: 1, idempotencyKey: 1 },
+      unique: true,
+      partialFilterExpression: { idempotencyKey: { $type: "string" } },
+    },
+  ]);
+}

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -1,4 +1,5 @@
 export type * from "./application";
+export type * from "./legalDelivery";
 export type { JobFeedToken } from "./jobFeedToken";
 export type {
   JobPosting,
@@ -19,11 +20,17 @@ export type {
 export type { CostType, MealAllowance, MealAllowanceLine } from "./travelTypes";
 export type { SignatureToken } from "./signature";
 export type { UploadContextType, UploadOwnership } from "./upload";
+export type * from "./membership";
+export type * from "./membershipAdmission";
+export type * from "./membershipCase";
+export type * from "./membershipDocument";
+export type * from "./membershipEvent";
 export type {
   BoardMembership,
   MemberInfraction,
   MemberStatus,
   ProfileImageSource,
+  StoredMemberStatus,
   TeamOnboardingStatus,
   User,
   UserRole,

--- a/app/lib/db/user.ts
+++ b/app/lib/db/user.ts
@@ -5,8 +5,8 @@ export type MemberStatus =
   | "offboarding_planned"
   | "offboarding"
   | "archived"
-  | "excluded"
-  | "offboarded";
+  | "excluded";
+export type StoredMemberStatus = MemberStatus | "offboarded";
 export type TeamOnboardingStatus = "not_started" | "in_progress" | "completed";
 export type ProfileImageSource = "google" | "upload";
 
@@ -56,7 +56,8 @@ export interface User {
   isSecondaryTeamLead?: boolean;
   boardMembership?: BoardMembership;
   applicationId?: string;
-  memberStatus: MemberStatus;
+  membershipId?: string;
+  memberStatus: StoredMemberStatus;
   teamOnboardingStatus: TeamOnboardingStatus;
   registeredAt?: number;
   onboardedAt?: number;

--- a/app/lib/members/legalDates.test.ts
+++ b/app/lib/members/legalDates.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import {
+  ageLimitAt,
+  ageOnDate,
+  assertAdmissionAge,
+  berlinMidnight,
+  calendarDaysUntil,
+  oneMonthObjectionExpiresAt,
+  resignationEndAt,
+} from "./legalDates";
+
+describe("membership legal dates in Europe/Berlin", () => {
+  test.each([
+    ["2010-03-01", "2026-02-28", 15],
+    ["2010-03-01", "2026-03-01", 16],
+    ["2001-03-01", "2026-02-28", 24],
+    ["2001-03-01", "2026-03-01", 25],
+  ])("calculates age for %s on %s", (birth, date, expected) => {
+    expect(ageOnDate(birth, berlinMidnight(iso(date)))).toBe(expected);
+  });
+
+  test("accepts only ages 16 through 24 at the decision", () => {
+    const decision = berlinMidnight(iso("2026-03-01"));
+    expect(() => assertAdmissionAge("2010-03-01", decision)).not.toThrow();
+    expect(() => assertAdmissionAge("2011-03-01", decision)).toThrow();
+    expect(() => assertAdmissionAge("2001-03-01", decision)).toThrow();
+  });
+
+  test("normalizes a leap-day age-out to March 1 in non-leap years", () => {
+    expect(new Date(ageLimitAt("2004-02-29")).toISOString()).toBe(
+      "2029-02-28T23:00:00.000Z",
+    );
+  });
+
+  test.each([
+    ["2026-09-30", "2026-12-31T23:00:00.000Z"],
+    ["2026-10-01", "2027-12-31T23:00:00.000Z"],
+  ])("computes resignation deadline from %s", (received, expected) => {
+    expect(
+      new Date(resignationEndAt(berlinMidnight(iso(received)))).toISOString(),
+    ).toBe(expected);
+  });
+
+  test("moves a one-month deadline from a weekend to the next business day", () => {
+    const delivered = berlinMidnight(iso("2026-01-31"));
+    expect(new Date(oneMonthObjectionExpiresAt(delivered)).toISOString()).toBe(
+      "2026-03-02T23:00:00.000Z",
+    );
+  });
+
+  test("moves a one-month deadline from a Berlin holiday", () => {
+    const delivered = berlinMidnight(iso("2026-03-06"));
+    expect(new Date(oneMonthObjectionExpiresAt(delivered)).toISOString()).toBe(
+      "2026-04-07T22:00:00.000Z",
+    );
+  });
+
+  test("counts calendar days across the daylight-saving change", () => {
+    const from = berlinMidnight(iso("2026-03-20"));
+    const target = berlinMidnight(iso("2026-04-19"));
+    expect(calendarDaysUntil(target, from)).toBe(30);
+  });
+});
+
+function iso(value: string) {
+  const [year, month, day] = value.split("-").map(Number);
+  return { year, month, day };
+}

--- a/app/lib/members/legalDates.ts
+++ b/app/lib/members/legalDates.ts
@@ -1,0 +1,198 @@
+const BERLIN_TIME_ZONE = "Europe/Berlin";
+
+type DateParts = { year: number; month: number; day: number };
+
+function parseIsoDate(value: string): DateParts {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) throw new Error("Datum muss im Format JJJJ-MM-TT vorliegen.");
+  const parts = {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+  const normalized = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  if (
+    normalized.getUTCFullYear() !== parts.year ||
+    normalized.getUTCMonth() !== parts.month - 1 ||
+    normalized.getUTCDate() !== parts.day
+  ) {
+    throw new Error("Ungültiges Kalenderdatum.");
+  }
+  return parts;
+}
+
+function berlinParts(timestamp: number): DateParts {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BERLIN_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(timestamp);
+  const value = (type: string) =>
+    Number(parts.find((part) => part.type === type)?.value);
+  return { year: value("year"), month: value("month"), day: value("day") };
+}
+
+function addDays(parts: DateParts, days: number): DateParts {
+  const date = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day + days),
+  );
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+function easterSunday(year: number): DateParts {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const value = h + l - 7 * m + 114;
+  return {
+    year,
+    month: Math.floor(value / 31),
+    day: (value % 31) + 1,
+  };
+}
+
+function sameDate(left: DateParts, right: DateParts): boolean {
+  return (
+    left.year === right.year &&
+    left.month === right.month &&
+    left.day === right.day
+  );
+}
+
+function isBerlinPublicHoliday(parts: DateParts): boolean {
+  const fixedHolidays = [
+    { year: parts.year, month: 1, day: 1 },
+    { year: parts.year, month: 3, day: 8 },
+    { year: parts.year, month: 5, day: 1 },
+    { year: parts.year, month: 10, day: 3 },
+    { year: parts.year, month: 12, day: 25 },
+    { year: parts.year, month: 12, day: 26 },
+  ];
+  const easter = easterSunday(parts.year);
+  const movableHolidays = [
+    addDays(easter, -2),
+    addDays(easter, 1),
+    addDays(easter, 39),
+    addDays(easter, 50),
+  ];
+  return [...fixedHolidays, ...movableHolidays].some((holiday) =>
+    sameDate(parts, holiday),
+  );
+}
+
+function isBerlinBusinessDay(parts: DateParts): boolean {
+  const weekday = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day),
+  ).getUTCDay();
+  return weekday !== 0 && weekday !== 6 && !isBerlinPublicHoliday(parts);
+}
+
+export function berlinMidnight(parts: DateParts): number {
+  const target = Date.UTC(parts.year, parts.month - 1, parts.day);
+  let guess = target;
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    const rendered = new Intl.DateTimeFormat("en-CA", {
+      timeZone: BERLIN_TIME_ZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(guess);
+    const part = (type: string) =>
+      Number(rendered.find((item) => item.type === type)?.value);
+    const represented = Date.UTC(
+      part("year"),
+      part("month") - 1,
+      part("day"),
+      part("hour"),
+    );
+    guess += target - represented;
+  }
+  return guess;
+}
+
+export function ageOnDate(dateOfBirth: string, timestamp: number): number {
+  const birth = parseIsoDate(dateOfBirth);
+  const current = berlinParts(timestamp);
+  let age = current.year - birth.year;
+  if (
+    current.month < birth.month ||
+    (current.month === birth.month && current.day < birth.day)
+  ) {
+    age -= 1;
+  }
+  return age;
+}
+
+export function assertAdmissionAge(
+  dateOfBirth: string,
+  decidedAt: number,
+): void {
+  const age = ageOnDate(dateOfBirth, decidedAt);
+  if (age < 16 || age >= 25) {
+    throw new Error(
+      "Bei der Aufnahmeentscheidung muss die Person mindestens 16 und noch nicht 25 Jahre alt sein.",
+    );
+  }
+}
+
+export function ageLimitAt(dateOfBirth: string): number {
+  const birth = parseIsoDate(dateOfBirth);
+  const targetYear = birth.year + 25;
+  const normalized = new Date(Date.UTC(targetYear, birth.month - 1, birth.day));
+  return berlinMidnight({
+    year: normalized.getUTCFullYear(),
+    month: normalized.getUTCMonth() + 1,
+    day: normalized.getUTCDate(),
+  });
+}
+
+export function resignationEndAt(receivedAt: number): number {
+  const received = berlinParts(receivedAt);
+  const inTime =
+    received.month < 9 || (received.month === 9 && received.day <= 30);
+  return berlinMidnight({
+    year: received.year + (inTime ? 1 : 2),
+    month: 1,
+    day: 1,
+  });
+}
+
+export function oneMonthObjectionExpiresAt(deliveredAt: number): number {
+  const source = berlinParts(deliveredAt);
+  const nextMonth = source.month === 12 ? 1 : source.month + 1;
+  const nextYear = source.month === 12 ? source.year + 1 : source.year;
+  const lastDay = new Date(Date.UTC(nextYear, nextMonth, 0)).getUTCDate();
+  const lastValidDay = Math.min(source.day, lastDay);
+  let deadline = { year: nextYear, month: nextMonth, day: lastValidDay };
+  while (!isBerlinBusinessDay(deadline)) {
+    deadline = addDays(deadline, 1);
+  }
+  return berlinMidnight(addDays(deadline, 1));
+}
+
+export function calendarDaysUntil(
+  targetTimestamp: number,
+  fromTimestamp: number,
+): number {
+  const target = berlinParts(targetTimestamp);
+  const from = berlinParts(fromTimestamp);
+  const targetUtc = Date.UTC(target.year, target.month - 1, target.day);
+  const fromUtc = Date.UTC(from.year, from.month - 1, from.day);
+  return Math.round((targetUtc - fromUtc) / (24 * 60 * 60 * 1_000));
+}

--- a/app/lib/members/stages.ts
+++ b/app/lib/members/stages.ts
@@ -2,7 +2,13 @@ import {
   getApplicationDisplayStatus,
   type ApplicationDisplayStatus,
 } from "../applications/status";
-import type { ApplicationWithFiles, MemberStatus, User } from "../db/types";
+import type {
+  ApplicationWithFiles,
+  MemberStatus,
+  StoredMemberStatus,
+  User,
+} from "../db/types";
+import { normalizeMemberStatus } from "./status";
 
 export const MEMBER_STAGE_OPTIONS = [
   { value: "application", label: "Bewerbung" },
@@ -31,8 +37,8 @@ export function memberStageLabel(stage: MemberStage): string {
   );
 }
 
-export function memberStageForStatus(status: MemberStatus): MemberStage {
-  return status === "offboarded" ? "archived" : status;
+export function memberStageForStatus(status: StoredMemberStatus): MemberStage {
+  return normalizeMemberStatus(status);
 }
 
 const APPLICATION_STAGE_STATUSES: Record<
@@ -50,7 +56,7 @@ const MEMBER_STATUSES_BY_STAGE: Partial<
   active: ["active"],
   offboarding_planned: ["offboarding_planned"],
   offboarding: ["offboarding"],
-  archived: ["archived", "offboarded"],
+  archived: ["archived"],
   excluded: ["excluded"],
 };
 
@@ -76,7 +82,9 @@ export function applicationsForStage(
 
 export function membersForStage(members: User[], stage: MemberStage): User[] {
   const statuses = memberStatusesForStage(stage);
-  return members.filter((member) => statuses.includes(member.memberStatus));
+  return members.filter((member) =>
+    statuses.includes(normalizeMemberStatus(member.memberStatus)),
+  );
 }
 
 export function memberStageCounts(

--- a/app/lib/members/status.ts
+++ b/app/lib/members/status.ts
@@ -1,4 +1,4 @@
-import type { MemberStatus } from "../db/types";
+import type { MemberStatus, StoredMemberStatus } from "../db/types";
 
 export const PUBLIC_MEMBER_STATUSES = [
   "active",
@@ -10,16 +10,20 @@ export const UNAVAILABLE_MEMBER_STATUSES = [
   "archived",
   "excluded",
   "offboarded",
-] as const satisfies readonly MemberStatus[];
+] as const satisfies readonly StoredMemberStatus[];
 
-export function normalizeMemberStatus(status: MemberStatus): MemberStatus {
+export function normalizeMemberStatus(
+  status: StoredMemberStatus,
+): MemberStatus {
   return status === "offboarded" ? "archived" : status;
 }
 
-export function isPublicMemberStatus(status: MemberStatus): boolean {
-  return PUBLIC_MEMBER_STATUSES.some((value) => value === status);
+export function isPublicMemberStatus(status: StoredMemberStatus): boolean {
+  return PUBLIC_MEMBER_STATUSES.some(
+    (value) => value === normalizeMemberStatus(status),
+  );
 }
 
-export function isUnavailableMemberStatus(status: MemberStatus): boolean {
+export function isUnavailableMemberStatus(status: StoredMemberStatus): boolean {
   return UNAVAILABLE_MEMBER_STATUSES.some((value) => value === status);
 }

--- a/app/lib/members/termination.test.ts
+++ b/app/lib/members/termination.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { terminalMemberStatus } from "./termination";
+
+describe("terminal member status", () => {
+  test.each(["resignation", "age_limit", "death"] as const)(
+    "archives a membership ended by %s",
+    (endReason) => {
+      expect(terminalMemberStatus(endReason)).toBe("archived");
+    },
+  );
+
+  test("reserves excluded for a formal exclusion", () => {
+    expect(terminalMemberStatus("exclusion")).toBe("excluded");
+  });
+});

--- a/app/lib/members/termination.ts
+++ b/app/lib/members/termination.ts
@@ -1,0 +1,12 @@
+import type { MemberStatus, MembershipEndReason } from "../db/types";
+
+export type TerminalMemberStatus = Extract<
+  MemberStatus,
+  "archived" | "excluded"
+>;
+
+export function terminalMemberStatus(
+  endReason: MembershipEndReason,
+): TerminalMemberStatus {
+  return endReason === "exclusion" ? "excluded" : "archived";
+}

--- a/app/lib/server/applications/applications.test.ts
+++ b/app/lib/server/applications/applications.test.ts
@@ -130,6 +130,33 @@ test("loads one application without internal identifiers", async () => {
         withdrawalTokenHash: "secret-withdrawal-hash",
         onboardingStartedBy: actorId,
         onboardingCompletedBy: actorId,
+        guardianConsent: {
+          representativeName: "Erika Beispiel",
+          representativeEmail: "erika@example.com",
+          tokenHash: "secret-guardian-hash",
+          expiresAt: Date.now() + 86_400_000,
+        },
+        admissionDecision: {
+          result: "admitted",
+          decidedAt: Date.now(),
+          decidedBy: actorId,
+          authority: "board_member",
+          recordedAt: Date.now(),
+          recordedBy: actorId,
+        },
+        rejectionDelivery: {
+          channel: "email",
+          recipient: "alex@example.com",
+          messageId: "secret-message-id",
+        },
+        appealTokenHash: "secret-appeal-hash",
+        appealStatement: "Interner Beschwerdetext",
+        appealDecision: {
+          result: "rejected",
+          decidedAt: Date.now(),
+          recordedAt: Date.now(),
+          recordedBy: actorId,
+        },
         fields: [
           {
             key: "phone-in-fields",
@@ -155,6 +182,12 @@ test("loads one application without internal identifiers", async () => {
   expect(application).not.toHaveProperty("tallyResponseId");
   expect(application).not.toHaveProperty("tallyFormId");
   expect(application).not.toHaveProperty("withdrawalTokenHash");
+  expect(application).not.toHaveProperty("guardianConsent");
+  expect(application).not.toHaveProperty("admissionDecision");
+  expect(application).not.toHaveProperty("rejectionDelivery");
+  expect(application).not.toHaveProperty("appealTokenHash");
+  expect(application).not.toHaveProperty("appealStatement");
+  expect(application).not.toHaveProperty("appealDecision");
   expect(application).not.toHaveProperty("onboardingStartedBy");
   expect(application).not.toHaveProperty("onboardingCompletedBy");
 });

--- a/app/lib/server/applications/management.ts
+++ b/app/lib/server/applications/management.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
 import { applications, jobPostings, users } from "../../db/collections";
-import type { Application, ApplicationWithFiles } from "../../db/types";
+import type { ApplicationWithFiles } from "../../db/types";
 import { UNAVAILABLE_MEMBER_STATUSES } from "../../members/status";
 import { addLog } from "../logs";
 import {
@@ -13,36 +13,7 @@ import {
   requireRecruitingJobPosting,
 } from "./access";
 import { createApplicationHistoryEntry } from "./history";
-
-function toApplicationView(
-  application: Application,
-  jobPostingTitle: string,
-): ApplicationWithFiles {
-  const {
-    applicantEmailNormalized: _applicantEmailNormalized,
-    files,
-    tallyEventId: _tallyEventId,
-    tallySubmissionId: _tallySubmissionId,
-    tallyResponseId: _tallyResponseId,
-    tallyFormId: _tallyFormId,
-    withdrawalTokenHash: _withdrawalTokenHash,
-    yfnEmailNormalized: _yfnEmailNormalized,
-    workspaceUserId: _workspaceUserId,
-    onboardingStartedBy: _onboardingStartedBy,
-    onboardingCompletedBy: _onboardingCompletedBy,
-    cleanupEligibleAt: _cleanupEligibleAt,
-    ownerIds,
-    ...visibleApplication
-  } = application;
-  return {
-    ...visibleApplication,
-    jobPostingTitle,
-    ownerIds: ownerIds ?? [],
-    files: files.map(
-      ({ sourceUrl: _sourceUrl, storageKey: _storageKey, ...file }) => file,
-    ),
-  };
-}
+import { toApplicationView } from "./view";
 
 export async function getApplications(): Promise<ApplicationWithFiles[]> {
   const user = await requirePermission(USER_PERMISSIONS.recruiting);

--- a/app/lib/server/applications/view.ts
+++ b/app/lib/server/applications/view.ts
@@ -1,0 +1,39 @@
+import type { Application, ApplicationWithFiles } from "../../db/types";
+
+export function toApplicationView(
+  application: Application,
+  jobPostingTitle: string,
+): ApplicationWithFiles {
+  const {
+    applicantEmailNormalized: _applicantEmailNormalized,
+    files,
+    tallyEventId: _tallyEventId,
+    tallySubmissionId: _tallySubmissionId,
+    tallyResponseId: _tallyResponseId,
+    tallyFormId: _tallyFormId,
+    withdrawalTokenHash: _withdrawalTokenHash,
+    yfnEmailNormalized: _yfnEmailNormalized,
+    workspaceUserId: _workspaceUserId,
+    guardianConsent: _guardianConsent,
+    admissionDecision: _admissionDecision,
+    rejectionDelivery: _rejectionDelivery,
+    appealTokenHash: _appealTokenHash,
+    appealExpiresAt: _appealExpiresAt,
+    appealedAt: _appealedAt,
+    appealStatement: _appealStatement,
+    appealDecision: _appealDecision,
+    onboardingStartedBy: _onboardingStartedBy,
+    onboardingCompletedBy: _onboardingCompletedBy,
+    cleanupEligibleAt: _cleanupEligibleAt,
+    ownerIds,
+    ...visibleApplication
+  } = application;
+  return {
+    ...visibleApplication,
+    jobPostingTitle,
+    ownerIds: ownerIds ?? [],
+    files: files.map(
+      ({ sourceUrl: _sourceUrl, storageKey: _storageKey, ...file }) => file,
+    ),
+  };
+}

--- a/app/lib/server/memberPlatform/actions.ts
+++ b/app/lib/server/memberPlatform/actions.ts
@@ -5,6 +5,7 @@ import { requireAuthenticatedUser } from "../../auth/session";
 import { users } from "../../db/collections";
 import {
   findLinkableMemberPlatformProfile,
+  getMemberPlatformLinkingData,
   isEligibleForMemberPlatformLinking,
 } from "./linking";
 import { persistMemberPlatformProfile } from "./sync";
@@ -26,8 +27,8 @@ export async function confirmMemberPlatformProfile(
     );
   }
 
-  const [profile, existingClaim] = await Promise.all([
-    findLinkableMemberPlatformProfile(selectedId),
+  const [linkingData, existingClaim] = await Promise.all([
+    getMemberPlatformLinkingData(member),
     (await users()).findOne(
       {
         _id: { $ne: member._id },
@@ -41,6 +42,12 @@ export async function confirmMemberPlatformProfile(
       "Dieses Profil ist bereits verknüpft. Bitte wende dich an People & Culture.",
     );
   }
+  if (linkingData?.profile?.id !== selectedId) {
+    throw new Error(
+      "Dieses Profil kann nicht sicher zugeordnet werden. Bitte wende dich an People & Culture.",
+    );
+  }
+  const profile = await findLinkableMemberPlatformProfile(selectedId);
 
   const updated = await persistMemberPlatformProfile(member, profile);
   if (updated.memberPlatformUserId !== selectedId) {

--- a/app/lib/server/memberPlatform/linking.test.ts
+++ b/app/lib/server/memberPlatform/linking.test.ts
@@ -44,21 +44,18 @@ test("suggests one profile and excludes profiles already linked in YBase", async
   const data = await getMemberPlatformLinkingData(member);
 
   expect(data).toEqual({
-    suggestedId: "platform-1",
-    profiles: [
-      {
-        id: "platform-1",
-        name: "Zoë Beispiel",
-        imageUrl: "https://example.com/profile.jpg",
-      },
-    ],
+    profile: {
+      id: "platform-1",
+      name: "Zoë Beispiel",
+      imageUrl: "https://example.com/profile.jpg",
+    },
   });
 });
 
 test("links exactly the profile confirmed by the member", async () => {
   const member = await insertMember();
   vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
-  await insertPlatformProfile("platform-1", "Andere", "Person");
+  await insertPlatformProfile("platform-1", "Zoë", "Beispiel");
 
   await confirmMemberPlatformProfile("platform-1");
 
@@ -70,6 +67,30 @@ test("links exactly the profile confirmed by the member", async () => {
     phone: "+49 170 1234567",
     memberPlatformSyncedAt: expect.any(Number),
   });
+});
+
+test("does not expose or confirm profiles without a unique match", async () => {
+  const member = await insertMember();
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+  await insertPlatformProfile("platform-1", "Andere", "Person");
+
+  await expect(getMemberPlatformLinkingData(member)).resolves.toEqual({
+    profile: undefined,
+  });
+  await expect(confirmMemberPlatformProfile("platform-1")).rejects.toThrow(
+    "nicht sicher zugeordnet",
+  );
+});
+
+test("leaves profile import to the membership workflow for managed members", async () => {
+  const member = await insertMember({ membershipId: newId() });
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(member);
+  await insertPlatformProfile("platform-1", "Zoë", "Beispiel");
+
+  await expect(getMemberPlatformLinkingData(member)).resolves.toBeNull();
+  await expect(confirmMemberPlatformProfile("platform-1")).rejects.toThrow(
+    "nicht verfügbar",
+  );
 });
 
 test("rejects a profile that another YBase member has already claimed", async () => {

--- a/app/lib/server/memberPlatform/linking.ts
+++ b/app/lib/server/memberPlatform/linking.ts
@@ -8,7 +8,6 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { getMemberPlatformDb } from "./client";
 
 const LINKABLE_MEMBER_STATES = ["ACCEPTED", "ALUMNI"];
-const COLLATOR = new Intl.Collator("de", { sensitivity: "base" });
 
 export interface MemberPlatformLinkOption {
   id: string;
@@ -17,8 +16,7 @@ export interface MemberPlatformLinkOption {
 }
 
 export interface MemberPlatformLinkingData {
-  suggestedId?: string;
-  profiles: MemberPlatformLinkOption[];
+  profile?: MemberPlatformLinkOption;
 }
 
 export async function getMemberPlatformLinkingData(
@@ -65,17 +63,14 @@ export async function getMemberPlatformLinkingData(
     member,
     profiles: availableProfiles,
   });
-  const options = availableProfiles
-    .map(toLinkOption)
-    .filter((option) => option.name)
-    .sort((left, right) => COLLATOR.compare(left.name, right.name));
-
-  return { suggestedId: suggested?.id, profiles: options };
+  const option = suggested ? toLinkOption(suggested) : undefined;
+  return { profile: option?.name ? option : undefined };
 }
 
 export function isEligibleForMemberPlatformLinking(member: User): boolean {
   return (
     !member.memberPlatformUserId &&
+    !member.membershipId &&
     member.memberStatus === "onboarding" &&
     member.email
       ?.trim()

--- a/app/lib/server/memberPlatform/sync.test.ts
+++ b/app/lib/server/memberPlatform/sync.test.ts
@@ -86,6 +86,26 @@ test("does not refresh linked accounts outside the YFN domain", async () => {
   expect(synced.privateEmail).toBe("old@example.com");
 });
 
+test("does not overwrite YBase-owned membership contact data", async () => {
+  const member = await insertMember({
+    email: "zoe@youngfounders.network",
+    privateEmail: "ybase@example.com",
+    memberPlatformUserId: "platform-1",
+    membershipId: newId(),
+  });
+  await insertPlatformProfile({
+    id: "platform-1",
+    email: "platform@example.com",
+  });
+
+  const synced = await tryRefreshMemberPlatformProfile(member);
+
+  expect(synced.privateEmail).toBe("ybase@example.com");
+  await expect(
+    (await users()).findOne({ _id: member._id }),
+  ).resolves.toMatchObject({ privateEmail: "ybase@example.com" });
+});
+
 async function insertMember(overrides: Partial<User>): Promise<User> {
   const member: User = {
     _id: newId(),

--- a/app/lib/server/memberPlatform/sync.ts
+++ b/app/lib/server/memberPlatform/sync.ts
@@ -19,6 +19,7 @@ export async function tryRefreshMemberPlatformProfile(
 }
 
 async function refreshMemberPlatformProfile(member: User): Promise<User> {
+  if (member.membershipId) return member;
   const email = member.email?.trim().toLowerCase();
   if (!email?.endsWith(`@${YFN_ORGANIZATION.domain}`)) return member;
   if (!member.memberPlatformUserId) return member;
@@ -40,6 +41,7 @@ export async function persistMemberPlatformProfile(
   member: User,
   profile: MemberPlatformProfile,
 ): Promise<User> {
+  if (member.membershipId) return member;
   const privateEmail = profile.contact?.email?.trim().toLowerCase();
   const phone = profile.contact?.phone?.trim();
   const syncedAt = Date.now();
@@ -52,6 +54,7 @@ export async function persistMemberPlatformProfile(
   ).updateOne(
     {
       _id: member._id,
+      membershipId: { $exists: false },
       $or: [
         { memberPlatformUserId: { $exists: false } },
         { memberPlatformUserId: profile.id },

--- a/app/lib/server/memberships/events.ts
+++ b/app/lib/server/memberships/events.ts
@@ -1,0 +1,26 @@
+import { membershipEvents } from "../../db/collections";
+import { isDuplicateKeyError } from "../../db/errors";
+import { newId } from "../../db/ids";
+import type { MembershipEvent } from "../../db/types";
+
+type EventInput = Omit<
+  MembershipEvent,
+  "_id" | "_creationTime" | "occurredAt"
+> & { occurredAt?: number };
+
+export async function appendMembershipEvent(input: EventInput): Promise<void> {
+  const now = input.occurredAt ?? Date.now();
+  try {
+    await (
+      await membershipEvents()
+    ).insertOne({
+      ...input,
+      _id: newId(),
+      _creationTime: now,
+      occurredAt: now,
+    });
+  } catch (error) {
+    if (input.idempotencyKey && isDuplicateKeyError(error)) return;
+    throw error;
+  }
+}

--- a/app/lib/server/profile/actions.ts
+++ b/app/lib/server/profile/actions.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { requireAuthenticatedUser } from "../../auth/session";
 import { users } from "../../db/collections";
-import type { MemberStatus } from "../../db/types";
+import type { StoredMemberStatus } from "../../db/types";
 import { isUnavailableMemberStatus } from "../../members/status";
 import { profileImageUploadDirectory } from "../../s3/keys";
 import {
@@ -34,7 +34,7 @@ const completeSchema = z.object({
 function requireEligibleUser<
   T extends {
     organizationId?: string;
-    memberStatus: MemberStatus;
+    memberStatus: StoredMemberStatus;
   },
 >(user: T): asserts user is T & { organizationId: string } {
   if (!user.organizationId) throw new Error("User has no organization");

--- a/app/lib/server/users/infractions.ts
+++ b/app/lib/server/users/infractions.ts
@@ -23,6 +23,11 @@ const recordInfractionSchema = z.object({
 type RecordInfractionInput = z.infer<typeof recordInfractionSchema>;
 
 function validateTarget(target: User): number {
+  if (target.membershipId) {
+    throw new Error(
+      "Verwarnungen für dieses Mitglied werden in der geschützten Fallakte verwaltet.",
+    );
+  }
   if (!ELIGIBLE_STATUSES.some((status) => status === target.memberStatus)) {
     throw new Error(
       "Verstöße können nur bei aktiven oder vorgemerkten Mitgliedern hinterlegt werden.",

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -19,7 +19,6 @@ const memberStatusSchema = z.enum([
   "offboarding",
   "archived",
   "excluded",
-  "offboarded",
 ]);
 const teamOnboardingSchema = z.enum([
   "not_started",
@@ -31,11 +30,15 @@ export async function setMemberStatus(input: {
   userId: string;
   status: MemberStatus;
 }): Promise<void> {
-  const { userId, status: parsedStatus } = z
+  const { userId, status } = z
     .object({ userId: z.string(), status: memberStatusSchema })
     .parse(input);
-  const status = parsedStatus === "offboarded" ? "archived" : parsedStatus;
   const { currentUser, target } = await loadManagedMember(userId);
+  if (target.membershipId) {
+    throw new Error(
+      "Der Status dieses Mitglieds wird durch den Mitgliedschaftsvorgang gesteuert.",
+    );
+  }
   if (status === "active" && (target.memberInfractions?.length ?? 0) >= 2) {
     throw new Error(
       "Ein Mitglied mit zwei Verstößen kann nicht erneut aktiviert werden.",

--- a/app/lib/server/users/memberLifecycle.ts
+++ b/app/lib/server/users/memberLifecycle.ts
@@ -1,4 +1,9 @@
-import type { MemberStatus, TeamOnboardingStatus, User } from "../../db/types";
+import type {
+  MemberStatus,
+  StoredMemberStatus,
+  TeamOnboardingStatus,
+  User,
+} from "../../db/types";
 
 type MemberStatusPatch = Partial<
   Pick<
@@ -17,7 +22,7 @@ type TeamOnboardingPatch = Partial<
 >;
 
 export function memberStatusPatch(
-  current: MemberStatus,
+  current: StoredMemberStatus,
   next: MemberStatus,
   now: number,
 ): MemberStatusPatch {
@@ -26,7 +31,7 @@ export function memberStatusPatch(
   if (next === "active") patch.onboardedAt = now;
   if (next === "offboarding_planned") patch.offboardingPlannedAt = now;
   if (next === "offboarding") patch.offboardingStartedAt = now;
-  if (next === "archived" || next === "offboarded") patch.archivedAt = now;
+  if (next === "archived") patch.archivedAt = now;
   if (next === "excluded") patch.excludedAt = now;
   return patch;
 }

--- a/app/lib/server/users/profile.ts
+++ b/app/lib/server/users/profile.ts
@@ -63,6 +63,14 @@ export async function updateMemberProfile(input: {
     })
     .parse(input);
   const { currentUser, target } = await loadManagedMember(userId);
+  if (
+    target.membershipId &&
+    (privateEmail !== undefined || phone !== undefined)
+  ) {
+    throw new Error(
+      "Private Kontaktdaten dieses Mitglieds werden in der Mitgliedschaftsakte verwaltet.",
+    );
+  }
   const hasBoardAssignment =
     boardMembership !== null &&
     (boardMembership !== undefined || target.boardMembership !== undefined);

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -363,11 +363,16 @@ test("setMemberStatus records every offboarding phase", async () => {
   expect(typeof updated?.archivedAt).toBe("number");
 });
 
-test("setMemberStatus maps legacy offboarded writes to archived", async () => {
-  await setMemberStatus({ userId: memberA, status: "offboarded" });
+test("setMemberStatus rejects legacy offboarded writes", async () => {
+  await expect(
+    setMemberStatus({
+      userId: memberA,
+      status: "offboarded" as never,
+    }),
+  ).rejects.toThrow();
   const updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.memberStatus).toBe("archived");
-  expect(typeof updated?.archivedAt).toBe("number");
+  expect(updated?.memberStatus).toBe("onboarding");
+  expect(updated?.archivedAt).toBeUndefined();
 });
 
 test("setMemberStatus records manual exclusions separately", async () => {
@@ -376,6 +381,20 @@ test("setMemberStatus records manual exclusions separately", async () => {
   expect(updated?.memberStatus).toBe("excluded");
   expect(typeof updated?.excludedAt).toBe("number");
   expect(updated?.archivedAt).toBeUndefined();
+});
+
+test("setMemberStatus cannot bypass a managed membership workflow", async () => {
+  await (
+    await users()
+  ).updateOne({ _id: memberA }, { $set: { membershipId: newId() } });
+
+  await expect(
+    setMemberStatus({ userId: memberA, status: "excluded" }),
+  ).rejects.toThrow("durch den Mitgliedschaftsvorgang gesteuert");
+
+  const unchanged = await (await users()).findOne({ _id: memberA });
+  expect(unchanged?.memberStatus).toBe("onboarding");
+  expect(unchanged?.excludedAt).toBeUndefined();
 });
 
 test("setMemberStatus cannot touch a user from another org", async () => {
@@ -411,6 +430,31 @@ test("recordMemberInfraction stores the first infraction with an audit log", asy
     entityId: memberA,
     organizationId: orgA,
   });
+});
+
+test("recordMemberInfraction uses the case workflow for managed memberships", async () => {
+  await (
+    await users()
+  ).updateOne(
+    { _id: memberA },
+    {
+      $set: {
+        membershipId: newId(),
+        memberStatus: "active",
+      },
+    },
+  );
+
+  await expect(
+    recordMemberInfraction({
+      userId: memberA,
+      reason: "Dokumentierter Verstoß.",
+    }),
+  ).rejects.toThrow("geschützten Fallakte");
+
+  const unchanged = await (await users()).findOne({ _id: memberA });
+  expect(unchanged?.memberInfractions).toBeUndefined();
+  expect(unchanged?.memberStatus).toBe("active");
 });
 
 test("recordMemberInfraction excludes the member atomically on the second infraction", async () => {
@@ -552,6 +596,25 @@ test("updateMemberProfile assigns a team and its lead role", async () => {
   const updated = await (await users()).findOne({ _id: memberA });
   expect(updated?.teamId).toBe("team-1");
   expect(updated?.isTeamLead).toBe(true);
+});
+
+test("updateMemberProfile protects legal contact data without blocking team changes", async () => {
+  await seedTeam("team-1", orgA);
+  await (
+    await users()
+  ).updateOne({ _id: memberA }, { $set: { membershipId: newId() } });
+
+  await expect(
+    updateMemberProfile({
+      userId: memberA,
+      privateEmail: "new@example.org",
+    }),
+  ).rejects.toThrow("Mitgliedschaftsakte");
+
+  await updateMemberProfile({ userId: memberA, teamId: "team-1" });
+  const updated = await (await users()).findOne({ _id: memberA });
+  expect(updated?.privateEmail).toBeUndefined();
+  expect(updated?.teamId).toBe("team-1");
 });
 
 test("updateMemberProfile assigns a different optional second team", async () => {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -12,6 +12,13 @@ erDiagram
     organizations ||--o{ volunteerAllowance : has
     organizations ||--o{ logs : has
     organizations ||--o{ applications : has
+    organizations ||--o{ memberships : has
+    applications ||--o| memberships : admits
+    users ||--o{ memberships : holds
+    memberships ||--o{ membershipCases : has
+    memberships ||--o{ documentExecutions : requires
+    documentVersions ||--o{ documentExecutions : executed_as
+    memberships ||--o{ membershipEvents : records
     jobPostings ||--o{ applications : receives
     organizations ||--o| jobFeedTokens : authenticates
     organizations ||--o{ reimbursementInvites : grants
@@ -56,6 +63,7 @@ erDiagram
         boolean isSecondaryTeamLead
         object boardMembership "departmentId, isChair"
         string applicationId
+        string membershipId
         string memberStatus
         string teamOnboardingStatus
         number offboardingPlannedAt
@@ -63,6 +71,75 @@ erDiagram
         number archivedAt
         number excludedAt
         array memberInfractions "_id, reason, createdAt, createdBy"
+    }
+
+    memberships {
+        string _id
+        string organizationId
+        string userId
+        string applicationId
+        string membershipNumber
+        boolean isCurrent
+        string legalStatus
+        number admittedAt
+        string memberPlatformUserId
+        string dateOfBirth
+        string privateEmail
+        number scheduledEndAt
+        string scheduledEndReason
+        number endedAt
+        string endReason
+        array handoverTasks
+    }
+
+    membershipCases {
+        string _id
+        string organizationId
+        string membershipId
+        string type
+        string status
+        string reason
+        string decision "excluded or dismissed"
+        number decidedAt
+        object decisionDelivery
+        number objectionExpiresAt
+        number objectedAt
+        string objectionText
+        string objectionOutcome "confirmed or overturned"
+        number objectionDecidedAt
+    }
+
+    documentVersions {
+        string _id
+        string organizationId
+        string kind
+        string versionLabel
+        string sourceUrl
+        string snapshotStorageKey
+        string sha256
+        array targetTeamIds
+        array targetDepartmentIds
+    }
+
+    documentExecutions {
+        string _id
+        string documentVersionId
+        string membershipId
+        string userId
+        string documentHash
+        string status
+        number completedAt
+    }
+
+    membershipEvents {
+        string _id
+        string organizationId
+        string membershipId
+        string caseId
+        string type
+        number occurredAt
+        string actorType
+        string idempotencyKey
     }
 
     teams {
@@ -135,6 +212,12 @@ erDiagram
         string workspaceUserId
         string workspaceProvisioningStatus
         number workspaceProvisionedAt
+        string dateOfBirth
+        object guardianConsent
+        object admissionDecision "result, decidedAt, decidedBy, authority, recordedAt, recordedBy"
+        object rejectionDelivery
+        number appealExpiresAt
+        object appealDecision "result, decidedAt, recordedAt, recordedBy, evidenceStorageKey"
         string onboardingUserId
         number onboardingLinkedAt
         number onboardingCompletedAt
@@ -158,10 +241,50 @@ server-only. Imported objects use deterministic storage keys; each file records
 its status, attempt count, error and final object key.
 
 Accepted applications hold the normalized YFN email and Google Workspace
-provisioning state. No temporary password is persisted. The first matching
-Google login links the application to the onboarding user, copies team and
-position from the job posting, and sets `cleanupEligibleAt` for the retention
-workflow. Link conflicts stay on the application for correction by P&C.
+provisioning state. The same application also records the formal admission
+decision, any required guardian consent, rejection delivery and appeal. This
+keeps the pre-membership procedure in the existing recruiting record instead of
+creating a second application model. No temporary password is persisted. The
+first matching Google login links the application to the onboarding user,
+copies team and position from the job posting, and sets `cleanupEligibleAt` for
+the retention workflow. Link conflicts stay on the application for correction
+by P&C.
+
+For new ordinary YFN members, `memberships` is the legal source of truth.
+A membership is created at the recorded admission time and contains the durable
+admission evidence and required guardian consent. Details about who made and
+recorded the decision remain on the application and in its history instead of
+being duplicated on the membership.
+Onboarding then uses the existing `users.memberStatus`: `onboarding` while the
+member confirms personal data and completes required acknowledgements, then
+`active`. The member platform performs its own profile claim; YBase stores only
+the resulting external profile ID and imported membership data. All document
+executions reference the membership directly. Individual tasks determine
+progress without introducing a second aggregate operational status. Current
+board authorization continues to use `users.boardMembership`; there is no
+parallel mandate collection. The internal `memberships.legalStatus` supports
+legal workflows but is not displayed as a parallel lifecycle:
+
+The existing YBase profile linker remains available only to legacy users
+without `membershipId` and exposes at most one unambiguous suggestion. Once a
+membership is managed in YBase, login refreshes no longer overwrite its private
+contact data from the member platform.
+
+- `active`: membership continues without a pending legal termination.
+- `resigning`: a resignation was received and the membership continues until
+  `scheduledEndAt`; it is not awaiting approval.
+- `suspended`: the exclusion decision was delivered and all membership rights
+  are suspended during the internal remedy process under § 5.4.
+- `ended`: membership no longer exists; `endReason` records why.
+
+After the official offboarding workflow, `archived` is the terminal status for
+ordinary departures and `excluded` is reserved for a final formal exclusion.
+The legacy value `offboarded` is migration-only and must not be written by new
+membership workflows. `membershipEvents` is append-only; sensitive case content
+remains in `membershipCases` and is intentionally absent from the general
+`logs` collection. `membershipCases` is limited to warnings and exclusion
+proceedings. Resignation, age limit and death are termination facts on the
+membership itself; the handover checklist is attached to that membership.
 
 The authoritative field definitions live in
 [`app/lib/db/types.ts`](../app/lib/db/types.ts), while indexes are defined in


### PR DESCRIPTION
## summary

- Add statute-aligned membership, document, case, delivery, and immutable event records with indexes and legal date helpers.
- Keep the existing member lifecycle as a compatibility projection while protecting YBase-managed legal status, contact data, and warning workflows.
- Restrict legacy member-platform linking to one unambiguous profile and prevent later syncs from overwriting YBase-owned membership data.

## validation

- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed TypeScript files>`
- `pnpm lint:lines` *(known pre-existing failure: `CreateJobPostingDialog.tsx` is reported as 204 lines on `main`)*