### PR TITLE
feat(members): add legal membership management foundation

### DIFF
--- a/app/api/cron/memberships/route.test.ts
+++ b/app/api/cron/memberships/route.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/server/memberships/dailyJob", () => ({
+  processDailyMemberships: vi.fn(),
+}));
+
+import { processDailyMemberships } from "@/lib/server/memberships/dailyJob";
+import { POST } from "./route";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+test("rejects membership jobs without the cron secret", async () => {
+  vi.stubEnv("CRON_SECRET", "secret");
+  const response = await POST(
+    new Request("https://example.org/api/cron/memberships", {
+      method: "POST",
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  expect(processDailyMemberships).not.toHaveBeenCalled();
+});
+
+test("runs the daily membership job with the cron secret", async () => {
+  vi.stubEnv("CRON_SECRET", "secret");
+  vi.mocked(processDailyMemberships).mockResolvedValue({
+    ageOutsScheduled: 1,
+    membershipsEnded: 0,
+    accessRetries: 0,
+    failures: 0,
+  });
+  const response = await POST(
+    new Request("https://example.org/api/cron/memberships", {
+      method: "POST",
+      headers: { authorization: "Bearer secret" },
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({
+    data: {
+      ageOutsScheduled: 1,
+      membershipsEnded: 0,
+      accessRetries: 0,
+      failures: 0,
+    },
+  });
+});

--- a/app/api/cron/memberships/route.ts
+++ b/app/api/cron/memberships/route.ts
@@ -1,0 +1,15 @@
+import { processDailyMemberships } from "@/lib/server/memberships/dailyJob";
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return false;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  const result = await processDailyMemberships();
+  return Response.json({ data: result });
+}

--- a/app/lib/db/membership.ts
+++ b/app/lib/db/membership.ts
@@ -73,6 +73,11 @@ export interface Membership {
   endReason?: MembershipEndReason;
   endEvidenceStorageKey?: string;
   rightsSuspendedAt?: number;
+  handoverStartedAt?: number;
   handoverTasks: HandoverTask[];
+  userLifecycleSyncedAt?: number;
+  workspaceSuspendedAt?: number;
+  workspaceSuspensionPendingAt?: number;
+  workspaceSuspensionNotRequiredAt?: number;
   updatedAt: number;
 }

--- a/app/lib/db/membershipIndexes.ts
+++ b/app/lib/db/membershipIndexes.ts
@@ -19,6 +19,17 @@ export async function ensureMembershipIndexes(db: Db): Promise<void> {
     },
     { key: { organizationId: 1, legalStatus: 1, scheduledEndAt: 1 } },
     { key: { organizationId: 1, legalStatus: 1, dateOfBirth: 1 } },
+    { key: { isCurrent: 1, legalStatus: 1, scheduledEndAt: 1 } },
+    { key: { isCurrent: 1, legalStatus: 1, dateOfBirth: 1 } },
+    { key: { legalStatus: 1, userLifecycleSyncedAt: 1 } },
+    {
+      key: {
+        legalStatus: 1,
+        workspaceSuspendedAt: 1,
+        workspaceSuspensionNotRequiredAt: 1,
+      },
+    },
+    { key: { organizationId: 1, "handoverTasks.ownerUserId": 1 } },
   ]);
   await db.collection("membershipCases").createIndexes([
     { key: { organizationId: 1, membershipId: 1, _creationTime: -1 } },

--- a/app/lib/server/memberships/accessClosure.test.ts
+++ b/app/lib/server/memberships/accessClosure.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../googleWorkspace/membershipLifecycle", () => ({
+  suspendWorkspaceUser: vi.fn(),
+}));
+
+import { memberships, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Membership } from "../../db/types";
+import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { syncEndedMembershipAccess } from "./accessClosure";
+
+setupTestDatabase();
+
+beforeEach(() => vi.mocked(suspendWorkspaceUser).mockReset());
+
+test("does not suspend a replacement membership account during retries", async () => {
+  const now = Date.now();
+  const organizationId = newId();
+  const userId = newId();
+  const replacementMembershipId = newId();
+  const membership: Membership = {
+    _id: newId(),
+    _creationTime: now,
+    organizationId,
+    userId,
+    applicationId: newId(),
+    membershipNumber: newId(),
+    isCurrent: false,
+    legalStatus: "ended",
+    admittedAt: now - 1,
+    endedAt: now,
+    endReason: "resignation",
+    privateEmail: "member@example.org",
+    firstName: "Alex",
+    lastName: "Example",
+    dateOfBirth: "2005-01-01",
+    handoverTasks: [],
+    updatedAt: now,
+  };
+  await (await memberships()).insertOne(membership);
+  await (
+    await users()
+  ).insertOne({
+    _id: userId,
+    _creationTime: now,
+    organizationId,
+    membershipId: replacementMembershipId,
+    googleWorkspaceUserId: "google-user-1",
+    role: "member",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+  });
+
+  await syncEndedMembershipAccess(membership);
+
+  expect(suspendWorkspaceUser).not.toHaveBeenCalled();
+  expect(await (await users()).findOne({ _id: userId })).toMatchObject({
+    memberStatus: "active",
+    membershipId: replacementMembershipId,
+  });
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    workspaceSuspensionNotRequiredAt: expect.any(Number),
+  });
+});

--- a/app/lib/server/memberships/accessClosure.ts
+++ b/app/lib/server/memberships/accessClosure.ts
@@ -1,0 +1,112 @@
+import type { UpdateFilter } from "mongodb";
+import { memberships, users } from "../../db/collections";
+import type { Membership, User } from "../../db/types";
+import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
+import { terminalMemberStatus } from "../../members/termination";
+
+export async function syncEndedMembershipAccess(
+  membership: Membership,
+): Promise<void> {
+  const user = await (
+    await users()
+  ).findOne({
+    _id: membership.userId,
+    organizationId: membership.organizationId,
+  });
+  if (!user || user.membershipId !== membership._id) {
+    await markAccessSyncNotRequired(membership._id);
+    return;
+  }
+
+  const status = terminalMemberStatus(membership.endReason ?? "resignation");
+  const endedAt = membership.endedAt ?? Date.now();
+  const update: UpdateFilter<User> = {
+    $set: {
+      memberStatus: status,
+      role: "member",
+      ...(status === "excluded"
+        ? { excludedAt: endedAt }
+        : { archivedAt: endedAt }),
+    },
+    $unset: {
+      teamId: "",
+      secondaryTeamId: "",
+      isTeamLead: "",
+      isSecondaryTeamLead: "",
+      boardMembership: "",
+      ...(status === "excluded" ? { archivedAt: "" } : { excludedAt: "" }),
+    },
+  };
+  const projected = await (
+    await users()
+  ).updateOne({ _id: user._id, membershipId: membership._id }, update);
+  if (projected.matchedCount !== 1) return;
+  await (
+    await memberships()
+  ).updateOne(
+    { _id: membership._id },
+    { $set: { userLifecycleSyncedAt: Date.now(), updatedAt: Date.now() } },
+  );
+  await syncWorkspaceSuspension(membership);
+}
+
+async function syncWorkspaceSuspension(membership: Membership): Promise<void> {
+  const user = await (
+    await users()
+  ).findOne({
+    _id: membership.userId,
+    organizationId: membership.organizationId,
+  });
+  const userKey =
+    user?.membershipId === membership._id
+      ? (user.googleWorkspaceUserId ?? user.email)
+      : undefined;
+  if (!userKey) {
+    await markAccessSyncNotRequired(membership._id);
+    return;
+  }
+  try {
+    await suspendWorkspaceUser(userKey);
+    await (
+      await memberships()
+    ).updateOne(
+      { _id: membership._id },
+      {
+        $set: { workspaceSuspendedAt: Date.now(), updatedAt: Date.now() },
+        $unset: {
+          workspaceSuspensionPendingAt: "",
+          workspaceSuspensionNotRequiredAt: "",
+        },
+      },
+    );
+  } catch {
+    await (
+      await memberships()
+    ).updateOne(
+      { _id: membership._id },
+      {
+        $set: {
+          workspaceSuspensionPendingAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+    );
+  }
+}
+
+async function markAccessSyncNotRequired(membershipId: string): Promise<void> {
+  const now = Date.now();
+  await (
+    await memberships()
+  ).updateOne(
+    { _id: membershipId },
+    {
+      $set: {
+        userLifecycleSyncedAt: now,
+        workspaceSuspensionNotRequiredAt: now,
+        updatedAt: now,
+      },
+      $unset: { workspaceSuspensionPendingAt: "" },
+    },
+  );
+}

--- a/app/lib/server/memberships/assignedHandover.test.ts
+++ b/app/lib/server/memberships/assignedHandover.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../auth/session", () => ({ requireUser: vi.fn() }));
+
+import { requireUser } from "../../auth/session";
+import { membershipEvents, memberships, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Membership } from "../../db/types";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import {
+  getOwnAssignedHandoverTasks,
+  setAssignedHandoverTaskCompleted,
+} from "./assignedHandover";
+
+setupTestDatabase();
+
+let actorId: string;
+let membership: Membership;
+let ownTaskId: string;
+let otherTaskId: string;
+
+beforeEach(async () => {
+  actorId = newId();
+  const organizationId = newId();
+  const memberId = newId();
+  ownTaskId = newId();
+  otherTaskId = newId();
+  const now = Date.now();
+  membership = {
+    _id: newId(),
+    _creationTime: now,
+    organizationId,
+    userId: memberId,
+    applicationId: newId(),
+    membershipNumber: newId(),
+    isCurrent: true,
+    legalStatus: "resigning",
+    admittedAt: now - 1,
+    privateEmail: "member@example.org",
+    firstName: "Alex",
+    lastName: "Example",
+    dateOfBirth: "2005-01-01",
+    handoverStartedAt: now,
+    handoverTasks: [
+      {
+        _id: ownTaskId,
+        category: "files",
+        title: "Dateien übergeben",
+        ownerUserId: actorId,
+      },
+      {
+        _id: otherTaskId,
+        category: "successor",
+        title: "Nachfolge klären",
+        ownerUserId: newId(),
+      },
+    ],
+    updatedAt: now,
+  };
+  await (await memberships()).insertOne(membership);
+  await (
+    await users()
+  ).insertOne({
+    _id: memberId,
+    _creationTime: now,
+    organizationId,
+    membershipId: membership._id,
+    name: "Alex Example",
+    role: "member",
+    memberStatus: "offboarding_planned",
+    teamOnboardingStatus: "completed",
+  });
+  vi.mocked(requireUser).mockResolvedValue(
+    createTestActor({ _id: actorId, organizationId }),
+  );
+});
+
+test("lists only handover tasks assigned to the current user", async () => {
+  await expect(getOwnAssignedHandoverTasks()).resolves.toEqual([
+    expect.objectContaining({
+      membershipId: membership._id,
+      taskId: ownTaskId,
+      memberName: "Alex Example",
+    }),
+  ]);
+});
+
+test("completes only an assigned task and records the event", async () => {
+  await setAssignedHandoverTaskCompleted({
+    membershipId: membership._id,
+    taskId: ownTaskId,
+    isCompleted: true,
+  });
+
+  const updated = await (await memberships()).findOne({ _id: membership._id });
+  expect(updated?.handoverTasks[0]).toMatchObject({
+    completedAt: expect.any(Number),
+    completedBy: actorId,
+  });
+  expect(
+    await (await membershipEvents()).findOne({ membershipId: membership._id }),
+  ).toMatchObject({
+    type: "handover.task_updated",
+    actorUserId: actorId,
+  });
+
+  await expect(
+    setAssignedHandoverTaskCompleted({
+      membershipId: membership._id,
+      taskId: otherTaskId,
+      isCompleted: true,
+    }),
+  ).rejects.toThrow("nicht gefunden");
+});

--- a/app/lib/server/memberships/assignedHandover.ts
+++ b/app/lib/server/memberships/assignedHandover.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { z } from "zod";
+import { requireUser } from "../../auth/session";
+import { memberships, users } from "../../db/collections";
+import { appendMembershipEvent } from "./events";
+
+export async function getOwnAssignedHandoverTasks() {
+  const actor = await requireUser();
+  const records = await (
+    await memberships()
+  )
+    .find({
+      organizationId: actor.organizationId,
+      handoverTasks: { $elemMatch: { ownerUserId: actor._id } },
+    })
+    .toArray();
+  const memberUsers = await (
+    await users()
+  )
+    .find({
+      _id: { $in: records.map(({ userId }) => userId) },
+      organizationId: actor.organizationId,
+    })
+    .project({ name: 1, email: 1 })
+    .toArray();
+  const names = new Map(
+    memberUsers.map((member) => [
+      member._id,
+      member.name ?? member.email ?? "Mitglied",
+    ]),
+  );
+  return records.flatMap((membership) =>
+    membership.handoverTasks
+      .filter(({ ownerUserId }) => ownerUserId === actor._id)
+      .map((task) => ({
+        membershipId: membership._id,
+        taskId: task._id,
+        memberName: names.get(membership.userId) ?? "Mitglied",
+        title: task.title,
+        scheduledEndAt: membership.scheduledEndAt,
+        completedAt: task.completedAt,
+      })),
+  );
+}
+
+export async function setAssignedHandoverTaskCompleted(input: {
+  membershipId: string;
+  taskId: string;
+  isCompleted: boolean;
+}): Promise<void> {
+  const parsed = z
+    .object({
+      membershipId: z.string().min(1),
+      taskId: z.string().min(1),
+      isCompleted: z.boolean(),
+    })
+    .parse(input);
+  const actor = await requireUser();
+  const now = Date.now();
+  const collection = await memberships();
+  const membership = await collection.findOne({
+    _id: parsed.membershipId,
+    organizationId: actor.organizationId,
+    handoverTasks: {
+      $elemMatch: { _id: parsed.taskId, ownerUserId: actor._id },
+    },
+  });
+  if (!membership) throw new Error("Aufgabe nicht gefunden.");
+  const task = membership.handoverTasks.find(
+    ({ _id }) => _id === parsed.taskId,
+  );
+  if (Boolean(task?.completedAt) === parsed.isCompleted) return;
+  const result = await collection.updateOne(
+    {
+      _id: parsed.membershipId,
+      organizationId: actor.organizationId,
+      handoverTasks: {
+        $elemMatch: { _id: parsed.taskId, ownerUserId: actor._id },
+      },
+    },
+    parsed.isCompleted
+      ? {
+          $set: {
+            "handoverTasks.$[task].completedAt": now,
+            "handoverTasks.$[task].completedBy": actor._id,
+            updatedAt: now,
+          },
+        }
+      : {
+          $unset: {
+            "handoverTasks.$[task].completedAt": "",
+            "handoverTasks.$[task].completedBy": "",
+          },
+          $set: { updatedAt: now },
+        },
+    {
+      arrayFilters: [
+        { "task._id": parsed.taskId, "task.ownerUserId": actor._id },
+      ],
+    },
+  );
+  if (result.modifiedCount !== 1) {
+    throw new Error("Die Aufgabe wurde zwischenzeitlich geändert.");
+  }
+  await appendMembershipEvent({
+    organizationId: actor.organizationId,
+    membershipId: membership._id,
+    userId: membership.userId,
+    actorUserId: actor._id,
+    actorType: "user",
+    type: "handover.task_updated",
+    details: { taskId: parsed.taskId, isCompleted: parsed.isCompleted },
+  });
+}
+
+export type AssignedHandoverTask = Awaited<
+  ReturnType<typeof getOwnAssignedHandoverTasks>
+>[number];

--- a/app/lib/server/memberships/dailyJob.test.ts
+++ b/app/lib/server/memberships/dailyJob.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../googleWorkspace/membershipLifecycle", () => ({
+  suspendWorkspaceUser: vi.fn(),
+}));
+
+import { membershipEvents, memberships, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Membership, User } from "../../db/types";
+import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
+import { ageLimitAt } from "../../members/legalDates";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { processDailyMemberships } from "./dailyJob";
+
+setupTestDatabase();
+
+beforeEach(() => {
+  vi.mocked(suspendWorkspaceUser).mockReset().mockResolvedValue(undefined);
+});
+
+async function seedMembership(
+  input: {
+    dateOfBirth?: string;
+    membership?: Partial<Membership>;
+    user?: Partial<User>;
+  } = {},
+): Promise<Membership> {
+  const now = Date.parse("2030-01-01T12:00:00Z");
+  const organizationId = newId();
+  const userId = newId();
+  const membership: Membership = {
+    _id: newId(),
+    _creationTime: now,
+    organizationId,
+    userId,
+    applicationId: newId(),
+    membershipNumber: newId(),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt: now,
+    privateEmail: "member@example.org",
+    firstName: "Alex",
+    lastName: "Example",
+    dateOfBirth: input.dateOfBirth ?? "2005-07-01",
+    handoverTasks: [],
+    updatedAt: now,
+    ...input.membership,
+  };
+  await (await memberships()).insertOne(membership);
+  await (
+    await users()
+  ).insertOne({
+    _id: userId,
+    _creationTime: now,
+    organizationId,
+    membershipId: membership._id,
+    email: "alex@youngfounders.network",
+    googleWorkspaceUserId: "google-user-1",
+    role: "member",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+    ...input.user,
+  });
+  return membership;
+}
+
+test("schedules age-out and creates the handover thirty days early", async () => {
+  const now = Date.parse("2030-06-01T10:00:00Z");
+  const membership = await seedMembership();
+
+  const result = await processDailyMemberships(now);
+
+  expect(result).toMatchObject({ ageOutsScheduled: 1, membershipsEnded: 0 });
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    legalStatus: "resigning",
+    scheduledEndAt: ageLimitAt("2005-07-01"),
+    scheduledEndReason: "age_limit",
+    handoverStartedAt: expect.any(Number),
+    handoverTasks: expect.arrayContaining([
+      expect.objectContaining({ category: "successor" }),
+      expect.objectContaining({ category: "external_accounts" }),
+    ]),
+  });
+  expect(
+    await (await users()).findOne({ _id: membership.userId }),
+  ).toMatchObject({
+    memberStatus: "offboarding_planned",
+  });
+  await (await membershipEvents()).deleteMany({ membershipId: membership._id });
+  await processDailyMemberships(now + 1_000);
+  expect(
+    await (
+      await membershipEvents()
+    ).distinct("type", { membershipId: membership._id }),
+  ).toEqual(
+    expect.arrayContaining(["handover.started", "membership.end_scheduled"]),
+  );
+});
+
+test("ends an age-limited membership and removes operational roles", async () => {
+  const membership = await seedMembership({
+    user: {
+      role: "admin",
+      teamId: "team-1",
+      isTeamLead: true,
+      boardMembership: { departmentId: "department-1", isChair: true },
+    },
+  });
+
+  const result = await processDailyMemberships(
+    Date.parse("2030-07-01T10:00:00Z"),
+  );
+
+  expect(result.membershipsEnded).toBe(1);
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    isCurrent: false,
+    legalStatus: "ended",
+    endReason: "age_limit",
+    workspaceSuspendedAt: expect.any(Number),
+  });
+  const user = await (await users()).findOne({ _id: membership.userId });
+  expect(user).toMatchObject({ memberStatus: "archived", role: "member" });
+  expect(user).not.toHaveProperty("teamId");
+  expect(user).not.toHaveProperty("boardMembership");
+  expect(suspendWorkspaceUser).toHaveBeenCalledWith("google-user-1");
+});
+
+test("retries a failed Workspace suspension without reopening membership", async () => {
+  vi.mocked(suspendWorkspaceUser).mockRejectedValue(new Error("offline"));
+  const membership = await seedMembership();
+  const now = Date.parse("2030-07-01T10:00:00Z");
+
+  await processDailyMemberships(now);
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    legalStatus: "ended",
+    workspaceSuspensionPendingAt: expect.any(Number),
+  });
+
+  vi.mocked(suspendWorkspaceUser).mockResolvedValue(undefined);
+  await processDailyMemberships(now + 60_000);
+  const updated = await (await memberships()).findOne({ _id: membership._id });
+  expect(updated).toMatchObject({ workspaceSuspendedAt: expect.any(Number) });
+  expect(updated).not.toHaveProperty("workspaceSuspensionPendingAt");
+});
+
+test("keeps an earlier resignation date ahead of age-out", async () => {
+  const resignationAt = Date.parse("2030-06-15T22:00:00Z");
+  const membership = await seedMembership({
+    membership: {
+      legalStatus: "resigning",
+      scheduledEndAt: resignationAt,
+      scheduledEndReason: "resignation",
+      resignationReceivedAt: Date.parse("2029-09-01T10:00:00Z"),
+    },
+  });
+
+  await processDailyMemberships(Date.parse("2030-06-01T10:00:00Z"));
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    scheduledEndAt: resignationAt,
+    scheduledEndReason: "resignation",
+  });
+
+  await (
+    await memberships()
+  ).updateOne({ _id: membership._id }, { $set: { legalStatus: "suspended" } });
+  await processDailyMemberships(Date.parse("2030-07-01T10:00:00Z"));
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    legalStatus: "ended",
+    endReason: "resignation",
+  });
+});
+
+test("applies the age limit while membership rights are suspended", async () => {
+  const membership = await seedMembership({
+    membership: { legalStatus: "suspended" },
+  });
+
+  await processDailyMemberships(Date.parse("2030-07-01T10:00:00Z"));
+
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    legalStatus: "ended",
+    endReason: "age_limit",
+  });
+});

--- a/app/lib/server/memberships/dailyJob.ts
+++ b/app/lib/server/memberships/dailyJob.ts
@@ -1,0 +1,108 @@
+import { memberships } from "../../db/collections";
+import type { Membership } from "../../db/types";
+import { ageLimitAt, calendarDaysUntil } from "../../members/legalDates";
+import { finalizeMembershipEnd, scheduleMembershipEnd } from "./termination";
+
+export interface MembershipJobResult {
+  ageOutsScheduled: number;
+  membershipsEnded: number;
+  accessRetries: number;
+  failures: number;
+}
+
+export async function processDailyMemberships(
+  now = Date.now(),
+): Promise<MembershipJobResult> {
+  const result: MembershipJobResult = {
+    ageOutsScheduled: 0,
+    membershipsEnded: 0,
+    accessRetries: 0,
+    failures: 0,
+  };
+  const collection = await memberships();
+  const dueMemberships = await collection
+    .find({
+      isCurrent: true,
+      legalStatus: { $in: ["resigning", "suspended"] },
+      scheduledEndAt: { $lte: now },
+      scheduledEndReason: { $in: ["resignation", "age_limit"] },
+    })
+    .toArray();
+  for (const membership of dueMemberships) {
+    try {
+      const isEnded = await finalizeMembershipEnd(
+        membership,
+        membership.scheduledEndReason ?? "resignation",
+        membership.scheduledEndAt ?? now,
+      );
+      if (isEnded) result.membershipsEnded += 1;
+    } catch {
+      result.failures += 1;
+    }
+  }
+
+  const ageOutCandidates = await collection
+    .find({
+      isCurrent: true,
+      legalStatus: { $in: ["active", "resigning", "suspended"] },
+    })
+    .toArray();
+  for (const membership of ageOutCandidates) {
+    try {
+      await processAgeOut(membership, now, result);
+    } catch {
+      result.failures += 1;
+    }
+  }
+
+  const retryCandidates = await collection
+    .find({
+      legalStatus: "ended",
+      $or: [
+        { userLifecycleSyncedAt: { $exists: false } },
+        {
+          workspaceSuspendedAt: { $exists: false },
+          workspaceSuspensionNotRequiredAt: { $exists: false },
+        },
+      ],
+    })
+    .toArray();
+  for (const membership of retryCandidates) {
+    try {
+      await finalizeMembershipEnd(
+        membership,
+        membership.endReason ?? "resignation",
+        membership.endedAt ?? now,
+      );
+      result.accessRetries += 1;
+    } catch {
+      result.failures += 1;
+    }
+  }
+  return result;
+}
+
+async function processAgeOut(
+  membership: Membership,
+  now: number,
+  result: MembershipJobResult,
+): Promise<void> {
+  const scheduledEndAt = ageLimitAt(membership.dateOfBirth);
+  if (scheduledEndAt <= now) {
+    const isEnded = await finalizeMembershipEnd(
+      membership,
+      "age_limit",
+      scheduledEndAt,
+    );
+    if (isEnded) result.membershipsEnded += 1;
+    return;
+  }
+  if (calendarDaysUntil(scheduledEndAt, now) > 30) return;
+  const isScheduled = await scheduleMembershipEnd({
+    membership,
+    reason: "age_limit",
+    scheduledEndAt,
+    recordedAt: now,
+  });
+  if (isScheduled) result.ageOutsScheduled += 1;
+}

--- a/app/lib/server/memberships/death.test.ts
+++ b/app/lib/server/memberships/death.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
+vi.mock("../../googleWorkspace/membershipLifecycle", () => ({
+  suspendWorkspaceUser: vi.fn(),
+}));
+
+import { requirePermission } from "../../auth/session";
+import { membershipEvents, memberships, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Membership } from "../../db/types";
+import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
+import { createTestActor } from "../../test/fixtures";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { recordMemberDeath } from "./death";
+
+setupTestDatabase();
+
+let organizationId: string;
+let membership: Membership;
+
+beforeEach(async () => {
+  organizationId = newId();
+  const userId = newId();
+  const now = Date.now();
+  membership = {
+    _id: newId(),
+    _creationTime: now,
+    organizationId,
+    userId,
+    applicationId: newId(),
+    membershipNumber: newId(),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt: now - 30 * 24 * 60 * 60 * 1_000,
+    privateEmail: "member@example.org",
+    firstName: "Alex",
+    lastName: "Example",
+    dateOfBirth: "2005-01-01",
+    handoverTasks: [],
+    updatedAt: now,
+  };
+  await (await memberships()).insertOne(membership);
+  await (
+    await users()
+  ).insertOne({
+    _id: userId,
+    _creationTime: now,
+    organizationId,
+    membershipId: membership._id,
+    googleWorkspaceUserId: "google-user-1",
+    role: "member",
+    memberStatus: "active",
+    teamOnboardingStatus: "completed",
+  });
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({ organizationId }),
+  );
+  vi.mocked(suspendWorkspaceUser).mockReset().mockResolvedValue(undefined);
+});
+
+test("records death without member communication and closes access", async () => {
+  const eventDate = Date.now() - 24 * 60 * 60 * 1_000;
+
+  await recordMemberDeath({ membershipId: membership._id, eventDate });
+
+  expect(
+    await (await memberships()).findOne({ _id: membership._id }),
+  ).toMatchObject({
+    isCurrent: false,
+    legalStatus: "ended",
+    endReason: "death",
+    endedAt: eventDate,
+  });
+  expect(
+    await (await users()).findOne({ _id: membership.userId }),
+  ).toMatchObject({
+    memberStatus: "archived",
+  });
+  expect(
+    await (await membershipEvents()).findOne({ membershipId: membership._id }),
+  ).toMatchObject({
+    type: "membership.ended",
+    details: { reason: "death", effectiveAt: eventDate },
+  });
+  expect(suspendWorkspaceUser).toHaveBeenCalledWith("google-user-1");
+});
+
+test("cannot end a membership from another organization", async () => {
+  vi.mocked(requirePermission).mockResolvedValue(
+    createTestActor({ organizationId: newId() }),
+  );
+
+  await expect(
+    recordMemberDeath({
+      membershipId: membership._id,
+      eventDate: Date.now() - 24 * 60 * 60 * 1_000,
+    }),
+  ).rejects.toThrow("nicht gefunden");
+});

--- a/app/lib/server/memberships/death.ts
+++ b/app/lib/server/memberships/death.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { z } from "zod";
+import { requirePermission } from "../../auth/session";
+import { memberships } from "../../db/collections";
+import { finalizeMembershipEnd } from "./termination";
+
+export async function recordMemberDeath(input: {
+  membershipId: string;
+  eventDate: number;
+}): Promise<void> {
+  const parsed = z
+    .object({
+      membershipId: z.string().min(1),
+      eventDate: z.number().int().positive().max(Date.now()),
+    })
+    .parse(input);
+  const actor = await requirePermission("manage_members");
+  const membership = await (
+    await memberships()
+  ).findOne({
+    _id: parsed.membershipId,
+    organizationId: actor.organizationId,
+    isCurrent: true,
+  });
+  if (!membership) throw new Error("Aktive Mitgliedschaft nicht gefunden.");
+  if (parsed.eventDate < membership.admittedAt) {
+    throw new Error("Das Ereignisdatum liegt vor Beginn der Mitgliedschaft.");
+  }
+  await finalizeMembershipEnd(membership, "death", parsed.eventDate, actor._id);
+}

--- a/app/lib/server/memberships/handover.ts
+++ b/app/lib/server/memberships/handover.ts
@@ -1,0 +1,148 @@
+import { memberships, users } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { HandoverTask, Membership, User } from "../../db/types";
+import { appendMembershipEvent } from "./events";
+
+const HANDOVER_TASKS: Array<Pick<HandoverTask, "category" | "title">> = [
+  { category: "successor", title: "Nachfolge und Handover-Owner festlegen" },
+  {
+    category: "responsibilities",
+    title: "Laufende Verantwortungen übergeben",
+  },
+  { category: "files", title: "Dateien und Dokumentation übergeben" },
+  { category: "shared_access", title: "Geteilte Zugänge übertragen" },
+  {
+    category: "reimbursements",
+    title: "Offene Erstattungen und Auslagen klären",
+  },
+  {
+    category: "external_accounts",
+    title: "Externe Toolkonten schließen oder übertragen",
+  },
+];
+
+export async function ensureMembershipHandover(
+  membership: Membership,
+  startedAt: number,
+  actorUserId?: string,
+): Promise<boolean> {
+  const member = await (
+    await users()
+  ).findOne({
+    _id: membership.userId,
+    organizationId: membership.organizationId,
+    membershipId: membership._id,
+  });
+  if (!member) return false;
+
+  const [lead, coordinator] = await Promise.all([
+    findHandoverLead(member, membership.organizationId),
+    (await users()).findOne({
+      organizationId: membership.organizationId,
+      role: { $in: ["people_culture", "admin"] },
+      memberStatus: { $in: ["active", "offboarding_planned"] },
+    }),
+  ]);
+  const tasks = HANDOVER_TASKS.map((task) => ({
+    ...task,
+    _id: newId(),
+    ownerUserId: taskOwner(
+      task.category,
+      member._id,
+      lead?._id,
+      coordinator?._id,
+    ),
+  }));
+  const result = await (
+    await memberships()
+  ).updateOne(
+    {
+      _id: membership._id,
+      organizationId: membership.organizationId,
+      isCurrent: true,
+      legalStatus: { $in: ["active", "resigning"] },
+      handoverStartedAt: { $exists: false },
+    },
+    {
+      $set: {
+        handoverStartedAt: startedAt,
+        handoverTasks: tasks,
+        updatedAt: startedAt,
+      },
+    },
+  );
+  const stored =
+    result.modifiedCount === 1
+      ? { handoverStartedAt: startedAt, handoverTasks: tasks }
+      : await (
+          await memberships()
+        ).findOne(
+          {
+            _id: membership._id,
+            organizationId: membership.organizationId,
+            legalStatus: { $in: ["active", "resigning"] },
+            handoverStartedAt: { $exists: true },
+          },
+          { projection: { handoverStartedAt: 1, handoverTasks: 1 } },
+        );
+  if (!stored?.handoverStartedAt) return false;
+
+  await (
+    await users()
+  ).updateOne(
+    {
+      _id: member._id,
+      membershipId: membership._id,
+      memberStatus: { $in: ["onboarding", "active"] },
+    },
+    {
+      $set: {
+        memberStatus: "offboarding_planned",
+        offboardingPlannedAt: startedAt,
+      },
+    },
+  );
+  await appendMembershipEvent({
+    organizationId: membership.organizationId,
+    membershipId: membership._id,
+    userId: membership.userId,
+    actorUserId,
+    actorType: actorUserId ? "user" : "system",
+    type: "handover.started",
+    idempotencyKey: `handover:${membership._id}:started`,
+    occurredAt: stored.handoverStartedAt,
+    details: { taskCount: stored.handoverTasks.length },
+  });
+  return result.modifiedCount === 1;
+}
+
+async function findHandoverLead(
+  member: User,
+  organizationId: string,
+): Promise<User | null> {
+  const teamIds = [member.teamId, member.secondaryTeamId].filter(
+    (teamId): teamId is string => Boolean(teamId),
+  );
+  if (teamIds.length === 0) return null;
+  return (await users()).findOne({
+    organizationId,
+    memberStatus: { $in: ["active", "offboarding_planned"] },
+    $or: [
+      { teamId: { $in: teamIds }, isTeamLead: true },
+      { secondaryTeamId: { $in: teamIds }, isSecondaryTeamLead: true },
+    ],
+  });
+}
+
+function taskOwner(
+  category: HandoverTask["category"],
+  memberId: string,
+  leadId?: string,
+  coordinatorId?: string,
+): string | undefined {
+  if (category === "successor" || category === "shared_access") {
+    return leadId ?? coordinatorId;
+  }
+  if (category === "reimbursements") return coordinatorId;
+  return memberId;
+}

--- a/app/lib/server/memberships/termination.ts
+++ b/app/lib/server/memberships/termination.ts
@@ -1,0 +1,146 @@
+import { memberships } from "../../db/collections";
+import type { Membership, MembershipEndReason } from "../../db/types";
+import { syncEndedMembershipAccess } from "./accessClosure";
+import { appendMembershipEvent } from "./events";
+import { ensureMembershipHandover } from "./handover";
+
+type ScheduledEndReason = Extract<
+  MembershipEndReason,
+  "resignation" | "age_limit"
+>;
+
+export async function scheduleMembershipEnd(input: {
+  membership: Membership;
+  reason: ScheduledEndReason;
+  scheduledEndAt: number;
+  actorUserId?: string;
+  resignationReceivedAt?: number;
+  recordedAt?: number;
+}): Promise<boolean> {
+  const { membership, reason, scheduledEndAt } = input;
+  const recordedAt = input.recordedAt ?? Date.now();
+  if (
+    !membership.isCurrent ||
+    !["active", "resigning"].includes(membership.legalStatus)
+  ) {
+    return false;
+  }
+  const currentEndAt = membership.scheduledEndAt;
+  const shouldReplace =
+    currentEndAt === undefined ||
+    scheduledEndAt < currentEndAt ||
+    (scheduledEndAt === currentEndAt &&
+      reason === "age_limit" &&
+      membership.scheduledEndReason !== "age_limit");
+  const isAlreadyScheduled =
+    currentEndAt === scheduledEndAt && membership.scheduledEndReason === reason;
+  if (!shouldReplace && !isAlreadyScheduled) return false;
+
+  let isChanged = false;
+  if (!isAlreadyScheduled || membership.legalStatus !== "resigning") {
+    const result = await (
+      await memberships()
+    ).updateOne(
+      {
+        _id: membership._id,
+        organizationId: membership.organizationId,
+        isCurrent: true,
+        legalStatus: membership.legalStatus,
+        ...(currentEndAt === undefined
+          ? { scheduledEndAt: { $exists: false } }
+          : { scheduledEndAt: currentEndAt }),
+      },
+      {
+        $set: {
+          legalStatus: "resigning",
+          scheduledEndAt,
+          scheduledEndReason: reason,
+          ...(reason === "resignation" && input.resignationReceivedAt
+            ? { resignationReceivedAt: input.resignationReceivedAt }
+            : {}),
+          updatedAt: recordedAt,
+        },
+      },
+    );
+    isChanged = result.modifiedCount === 1;
+  }
+
+  if (!isChanged && !isAlreadyScheduled) return false;
+  await appendMembershipEvent({
+    organizationId: membership.organizationId,
+    membershipId: membership._id,
+    userId: membership.userId,
+    actorUserId: input.actorUserId,
+    actorType: input.actorUserId ? "user" : "system",
+    type: "membership.end_scheduled",
+    idempotencyKey: `membership:${membership._id}:scheduled:${reason}:${scheduledEndAt}`,
+    occurredAt: recordedAt,
+    details: { reason, scheduledEndAt },
+  });
+  await ensureMembershipHandover(
+    membership,
+    Math.min(recordedAt, scheduledEndAt),
+    input.actorUserId,
+  );
+  return isChanged;
+}
+
+export async function finalizeMembershipEnd(
+  membership: Membership,
+  reason: MembershipEndReason,
+  effectiveAt: number,
+  actorUserId?: string,
+): Promise<boolean> {
+  const result = await (
+    await memberships()
+  ).updateOne(
+    {
+      _id: membership._id,
+      organizationId: membership.organizationId,
+      isCurrent: true,
+      legalStatus: { $ne: "ended" },
+    },
+    {
+      $set: {
+        legalStatus: "ended",
+        isCurrent: false,
+        endedAt: effectiveAt,
+        endReason: reason,
+        updatedAt: Date.now(),
+      },
+    },
+  );
+  const ended =
+    result.modifiedCount === 1
+      ? {
+          ...membership,
+          legalStatus: "ended" as const,
+          isCurrent: false,
+          endedAt: effectiveAt,
+          endReason: reason,
+        }
+      : await (
+          await memberships()
+        ).findOne({
+          _id: membership._id,
+          organizationId: membership.organizationId,
+          legalStatus: "ended",
+        });
+  if (!ended) return false;
+
+  const recordedReason = ended.endReason ?? reason;
+  const recordedEndAt = ended.endedAt ?? effectiveAt;
+  await appendMembershipEvent({
+    organizationId: ended.organizationId,
+    membershipId: ended._id,
+    userId: ended.userId,
+    actorUserId,
+    actorType: actorUserId ? "user" : "system",
+    type: "membership.ended",
+    idempotencyKey: `membership:${ended._id}:ended`,
+    occurredAt: recordedEndAt,
+    details: { reason: recordedReason, effectiveAt: recordedEndAt },
+  });
+  await syncEndedMembershipAccess(ended);
+  return result.modifiedCount === 1;
+}


### PR DESCRIPTION
## summary

- Add statute-aligned membership, document, case, delivery, and immutable event records with indexes and legal date helpers.
- Keep the existing member lifecycle as a compatibility projection while protecting YBase-managed legal status, contact data, and warning workflows.
- Restrict legacy member-platform linking to one unambiguous profile and prevent later syncs from overwriting YBase-owned membership data.

## validation

- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed TypeScript files>`
- `pnpm lint:lines` *(known pre-existing failure: `CreateJobPostingDialog.tsx` is reported as 204 lines on `main`)*
