### PR TITLE
fix(members): move member profile link into header

### DIFF
--- a/app/(protected)/settings/members/MemberContactFields.tsx
+++ b/app/(protected)/settings/members/MemberContactFields.tsx
@@ -1,40 +1,19 @@
-import { ExternalLink, Mail, Phone } from "lucide-react";
+import { Mail, Phone } from "lucide-react";
 import type { User } from "@/lib/db/types";
 
-const MEMBER_PLATFORM_URL = "https://member.youngfounders.network";
-
 export function MemberContactFields({ member }: { member: User }) {
-  const profileUrl = member.memberPlatformUserId
-    ? `${MEMBER_PLATFORM_URL}/member/${member.memberPlatformUserId}`
-    : undefined;
-
   return (
     <section className="border-t pt-5" aria-labelledby="private-contact-title">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h3 id="private-contact-title" className="text-sm font-semibold">
-            Private Kontaktdaten
-          </h3>
-          <p className="text-muted-foreground mt-1 text-xs">
-            {member.membershipId
-              ? "In der YBase-Mitgliedschaftsakte verwaltet"
-              : member.memberPlatformUserId
-                ? "Aus der Member-Plattform synchronisiert"
-                : "Noch nicht mit der Member-Plattform verknüpft"}
-          </p>
-        </div>
-        {profileUrl ? (
-          <a
-            href={profileUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1 text-xs underline-offset-4 hover:underline"
-          >
-            Profil
-            <ExternalLink aria-hidden="true" className="size-3" />
-          </a>
-        ) : null}
-      </div>
+      <h3 id="private-contact-title" className="text-sm font-semibold">
+        Private Kontaktdaten
+      </h3>
+      <p className="text-muted-foreground mt-1 text-xs">
+        {member.membershipId
+          ? "In der YBase-Mitgliedschaftsakte verwaltet"
+          : member.memberPlatformUserId
+            ? "Aus der Member-Plattform synchronisiert"
+            : "Noch nicht mit der Member-Plattform verknüpft"}
+      </p>
 
       <div className="mt-3 grid gap-2 text-sm">
         {member.privateEmail ? (

--- a/app/(protected)/settings/members/MemberDrawerPanel.tsx
+++ b/app/(protected)/settings/members/MemberDrawerPanel.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from "lucide-react";
+import { ExternalLink, Loader2 } from "lucide-react";
 import { MemberStageBadge } from "@/components/Members/MemberStageBadge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,8 @@ import { ROLE_OPTIONS } from "./memberLabels";
 import { PublicOrganizationFields } from "./PublicOrganizationFields";
 import type { MemberDrawerFormState } from "./useMemberDrawerForm";
 
+const MEMBER_PLATFORM_URL = "https://member.youngfounders.network";
+
 interface Props {
   member: User;
   displayName: string;
@@ -28,6 +30,10 @@ export function MemberDrawerPanel({
   form,
   onClose,
 }: Props) {
+  const memberPlatformProfileUrl = member.memberPlatformUserId
+    ? `${MEMBER_PLATFORM_URL}/member/${member.memberPlatformUserId}`
+    : undefined;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       <div className="flex flex-row items-center gap-5 px-6 pt-8 pb-6 text-left">
@@ -48,10 +54,20 @@ export function MemberDrawerPanel({
           <p className="text-muted-foreground max-w-full truncate text-base">
             {member.email || "Keine E-Mail hinterlegt"}
           </p>
-          <MemberStageBadge
-            className="mt-1"
-            stage={memberStageForStatus(form.status)}
-          />
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-2">
+            <MemberStageBadge stage={memberStageForStatus(form.status)} />
+            {memberPlatformProfileUrl ? (
+              <a
+                href={memberPlatformProfileUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex items-center gap-1 text-sm underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+              >
+                Member-Profil
+                <ExternalLink aria-hidden="true" className="size-3.5" />
+              </a>
+            ) : null}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## summary

- move the member platform profile link from private contact details into the member drawer header
- use an explicit label, external-link indicator, and keyboard focus state while simplifying the contact section markup

## validation

- pnpm exec prettier --check (changed files)
- pnpm exec biome lint (changed files)
- pnpm exec tsc --noEmit
- pnpm vitest run app/lib/server/memberPlatform/linking.test.ts app/lib/server/memberPlatform/sync.test.ts (10 passed)
- pnpm build — not run (repo-wide; change is limited to presentational components)