### PR TITLE
fix(recruiting): keep benefits out of tally forms

### DIFF
--- a/app/lib/server/jobPostings/tallyForm.test.ts
+++ b/app/lib/server/jobPostings/tallyForm.test.ts
@@ -269,8 +269,8 @@ test("syncs posting content and exact role questions into Tally", async () => {
   expect(serialized).toContain("Du entwickelst YBase weiter.");
   expect(serialized).toContain("Aufgaben");
   expect(serialized).toContain("Anforderungen");
-  expect(serialized).toContain("Benefits");
-  expect(serialized).toContain("Zugang zur YFN Community");
+  expect(serialized).not.toContain("Benefits");
+  expect(serialized).not.toContain("Zugang zur YFN Community");
   expect(serialized).toContain("Rahmenbedingungen");
   expect(serialized).toContain("Welche Architektur hast du zuletzt gestaltet?");
   expect(serialized).not.toContain("Spezifische Frage");

--- a/app/lib/tally/formTemplate.test.ts
+++ b/app/lib/tally/formTemplate.test.ts
@@ -163,6 +163,14 @@ test("syncs posting sections and exact application questions into the role secti
       block("FORM_TITLE"),
       roleHeading,
       {
+        ...block("HEADING_3", "HEADING_3", "old-benefits-heading"),
+        payload: { safeHTMLSchema: [["Benefits"]] },
+      },
+      {
+        ...block("TEXT", "TEXT", "old-benefits-text"),
+        payload: { safeHTMLSchema: [["Alte Benefits"]] },
+      },
+      {
         ...block("LABEL", "LABEL", "question-label"),
         payload: { safeHTMLSchema: [["Spezifische Frage 1"]] },
       },
@@ -178,7 +186,6 @@ test("syncs posting sections and exact application questions into the role secti
       description: "<p>Du entwickelst <strong>YBase</strong>.</p>",
       tasks: "<ul><li>Architektur gestalten</li><li>Team begleiten</li></ul>",
       requirements: "<p>Erfahrung mit TypeScript &amp; React</p>",
-      benefits: "<ul><li>Zugang zur YFN Community</li></ul>",
       timeCommitment: "5 Stunden pro Woche",
       location: "Berlin",
       isRemote: true,
@@ -195,8 +202,8 @@ test("syncs posting sections and exact application questions into the role secti
   expect(serialized).toContain("• Architektur gestalten");
   expect(serialized).toContain("Anforderungen");
   expect(serialized).toContain("Erfahrung mit TypeScript &amp; React");
-  expect(serialized).toContain("Benefits");
-  expect(serialized).toContain("• Zugang zur YFN Community");
+  expect(serialized).not.toContain("Benefits");
+  expect(serialized).not.toContain("Alte Benefits");
   expect(serialized).toContain("Rahmenbedingungen");
   expect(serialized).toContain("Arbeitsort: Berlin · Remote möglich");
   expect(serialized).toContain("Bewerbungsfrist: 31.08.2026");

--- a/app/lib/tally/jobPostingFormSections.ts
+++ b/app/lib/tally/jobPostingFormSections.ts
@@ -1,6 +1,5 @@
 import sanitizeHtml from "sanitize-html";
 import type { JobPosting } from "../db/types";
-import { DEFAULT_JOB_POSTING_BENEFITS } from "../jobPostings/benefits";
 
 export type JobPostingTallyContent = Pick<
   JobPosting,
@@ -9,7 +8,6 @@ export type JobPostingTallyContent = Pick<
   | "description"
   | "tasks"
   | "requirements"
-  | "benefits"
   | "timeCommitment"
   | "location"
   | "isRemote"
@@ -70,12 +68,6 @@ export function jobPostingSections(
     {
       heading: "Anforderungen",
       text: richTextToPlainText(posting.requirements),
-    },
-    {
-      heading: "Benefits",
-      text: richTextToPlainText(
-        posting.benefits ?? DEFAULT_JOB_POSTING_BENEFITS,
-      ),
     },
     { heading: "Rahmenbedingungen", text: framework },
   ].filter((section) => section.text);


### PR DESCRIPTION
## summary

- keep customizable job benefits in the member-platform job feed without copying them into Tally forms
- remove previously generated Benefits blocks on subsequent Tally syncs and cover the behavior with regression tests

## validation

- `pnpm exec vitest run app/lib/tally/formTemplate.test.ts app/lib/server/jobPostings/tallyForm.test.ts app/lib/server/jobFeed/feed.test.ts` (27 passed)
- `pnpm test` (585 passed)
- `pnpm exec biome lint app/lib/tally/jobPostingFormSections.ts app/lib/tally/formTemplate.test.ts app/lib/server/jobPostings/tallyForm.test.ts`
- `pnpm lint` (3 pre-existing warnings in unrelated files)
- `pnpm exec tsc --noEmit`