### PR TITLE
feat(onboarding): ensure google accounts for new members

### DIFF
--- a/app/(protected)/settings/members/CreateMemberContactFields.tsx
+++ b/app/(protected)/settings/members/CreateMemberContactFields.tsx
@@ -17,7 +17,7 @@ export function CreateMemberContactFields({
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="manual-member-private-email">Private E-Mail</Label>
+        <Label htmlFor="manual-member-private-email">Private E-Mail*</Label>
         <Input
           id="manual-member-private-email"
           type="email"
@@ -25,6 +25,7 @@ export function CreateMemberContactFields({
           onChange={(event) => onPrivateEmailChange(event.target.value)}
           placeholder="name@beispiel.de"
           autoComplete="email"
+          required
         />
       </div>
       <div className="flex flex-col gap-2">

--- a/app/(protected)/settings/members/CreateMemberDialog.tsx
+++ b/app/(protected)/settings/members/CreateMemberDialog.tsx
@@ -65,7 +65,13 @@ export function CreateMemberDialog({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!name.trim() || !email.trim() || !teamId || create.isPending) {
+    if (
+      !name.trim() ||
+      !email.trim() ||
+      !privateEmail.trim() ||
+      !teamId ||
+      create.isPending
+    ) {
       return;
     }
 
@@ -73,7 +79,7 @@ export function CreateMemberDialog({
       const member = await create.mutateAsync({
         name: name.trim(),
         email: email.trim(),
-        privateEmail: privateEmail.trim() || undefined,
+        privateEmail: privateEmail.trim(),
         phone: phone.trim() || undefined,
         teamId,
         isTeamLead,
@@ -169,7 +175,11 @@ export function CreateMemberDialog({
               type="submit"
               variant="primary"
               disabled={
-                !name.trim() || !email.trim() || !teamId || create.isPending
+                !name.trim() ||
+                !email.trim() ||
+                !privateEmail.trim() ||
+                !teamId ||
+                create.isPending
               }
             >
               {create.isPending ? (

--- a/app/lib/server/applications/decision.test.ts
+++ b/app/lib/server/applications/decision.test.ts
@@ -107,6 +107,7 @@ test("sends the edited acceptance email before changing the status", async () =>
 
   expect(sendMail).toHaveBeenCalledWith(
     expect.objectContaining({
+      to: [{ email: "alex@example.com", name: "Alex Beispiel" }],
       subject: "Individuelle Zusage",
       params: expect.objectContaining({
         message: expect.stringContaining("temporary-password"),
@@ -182,6 +183,44 @@ test("blocks acceptance before external side effects without a member-platform s
   ).rejects.toThrow("Member-Plattform-Profil");
   expect(provisionWorkspaceUser).not.toHaveBeenCalled();
   expect(sendMail).not.toHaveBeenCalled();
+});
+
+test("does not send credentials when the onboarding profile cannot be linked", async () => {
+  await (
+    await users()
+  ).createIndex({ memberPlatformUserId: 1 }, { unique: true, sparse: true });
+  await (
+    await users()
+  ).insertOne({
+    _id: newId(),
+    _creationTime: Date.now(),
+    name: "Existing Profile",
+    email: "existing@youngfounders.network",
+    privateEmail: "existing@example.com",
+    memberPlatformUserId: "platform-alex",
+    organizationId,
+    role: "member",
+    memberStatus: "onboarding",
+    teamOnboardingStatus: "not_started",
+  });
+
+  await expect(
+    sendApplicationDecision({
+      applicationId,
+      decision: "accepted",
+      yfnEmail,
+      subject: "Zusage",
+      message: "Willkommen!",
+    }),
+  ).rejects.toThrow("nicht eindeutig");
+
+  expect(sendMail).not.toHaveBeenCalled();
+  expect(
+    await (await applications()).findOne({ _id: applicationId }),
+  ).toMatchObject({
+    status: "review",
+    workspaceProvisioningStatus: "provisioned",
+  });
 });
 
 test("sends a rejection with its dedicated template and then rejects", async () => {

--- a/app/lib/server/applications/decision.ts
+++ b/app/lib/server/applications/decision.ts
@@ -47,16 +47,6 @@ export async function sendApplicationDecision(
         })
       : { message: decision.message, workspaceUserId: undefined };
 
-  await sendDecisionEmail({
-    application,
-    decision: decision.decision,
-    jobTitle: posting.title,
-    message: prepared.message,
-    organizationId: user.organizationId,
-    subject: decision.subject,
-    workspaceUserId: prepared.workspaceUserId,
-  });
-
   let acceptedMember:
     | Awaited<ReturnType<typeof createAcceptedApplicantMember>>
     | undefined;
@@ -75,6 +65,15 @@ export async function sendApplicationDecision(
 
   let statusDetails: string;
   try {
+    await sendDecisionEmail({
+      application,
+      decision: decision.decision,
+      jobTitle: posting.title,
+      message: prepared.message,
+      organizationId: user.organizationId,
+      subject: decision.subject,
+      workspaceUserId: prepared.workspaceUserId,
+    });
     statusDetails = await persistDecision({
       application,
       decision,

--- a/app/lib/server/users/creation.ts
+++ b/app/lib/server/users/creation.ts
@@ -10,6 +10,7 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { addLog } from "../logs";
 import { requireActiveOrganizationTeam } from "./access";
 import { phoneSchema, privateEmailSchema } from "./contactDetails";
+import { provisionManualMemberWorkspace } from "./manualWorkspaceProvisioning";
 
 const MEMBER_EMAIL_CONFLICT_MESSAGE =
   "Für diese E-Mail-Adresse gibt es bereits ein Profil.";
@@ -29,7 +30,7 @@ const createMemberSchema = z.object({
       (email) => email.endsWith(`@${YFN_ORGANIZATION.domain}`),
       "Bitte gib eine gültige YFN-E-Mail-Adresse an.",
     ),
-  privateEmail: privateEmailSchema.optional(),
+  privateEmail: privateEmailSchema,
   phone: phoneSchema.optional(),
   teamId: z.string().trim().min(1),
   isTeamLead: z.boolean(),
@@ -61,9 +62,7 @@ export async function createMember(input: CreateMemberInput): Promise<User> {
     _creationTime: createdAt,
     name: memberInput.name,
     email: memberInput.email,
-    ...(memberInput.privateEmail
-      ? { privateEmail: memberInput.privateEmail }
-      : {}),
+    privateEmail: memberInput.privateEmail,
     ...(memberInput.phone ? { phone: memberInput.phone } : {}),
     organizationId: actor.organizationId,
     role: "member",
@@ -81,6 +80,33 @@ export async function createMember(input: CreateMemberInput): Promise<User> {
     if (isDuplicateKeyError(error)) {
       throw new Error(MEMBER_EMAIL_CONFLICT_MESSAGE);
     }
+    throw error;
+  }
+
+  try {
+    const workspaceAccount = await provisionManualMemberWorkspace({
+      name: memberInput.name,
+      primaryEmail: memberInput.email,
+      privateEmail: memberInput.privateEmail,
+    });
+    const result = await usersCollection.updateOne(
+      {
+        _id: createdMember._id,
+        organizationId: actor.organizationId,
+        googleWorkspaceUserId: { $exists: false },
+      },
+      { $set: { googleWorkspaceUserId: workspaceAccount.userId } },
+    );
+    if (result.modifiedCount !== 1) {
+      throw new Error("Google-Workspace-Konto konnte nicht verknüpft werden");
+    }
+    createdMember.googleWorkspaceUserId = workspaceAccount.userId;
+  } catch (error) {
+    await usersCollection.deleteOne({
+      _id: createdMember._id,
+      organizationId: actor.organizationId,
+      googleWorkspaceUserId: { $exists: false },
+    });
     throw error;
   }
 

--- a/app/lib/server/users/manualWorkspaceProvisioning.test.ts
+++ b/app/lib/server/users/manualWorkspaceProvisioning.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
+vi.mock("../../googleWorkspace/users", () => ({
+  provisionWorkspaceUser: vi.fn(),
+}));
+
+import { sendMail } from "../../email/brevo";
+import { BREVO_TEMPLATE_IDS } from "../../email/templates";
+import { provisionWorkspaceUser } from "../../googleWorkspace/users";
+import { provisionManualMemberWorkspace } from "./manualWorkspaceProvisioning";
+
+afterEach(() => vi.unstubAllEnvs());
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://ybase.example");
+  vi.mocked(provisionWorkspaceUser).mockResolvedValue({
+    userId: "google-user-1",
+    primaryEmail: "alex@youngfounders.network",
+    temporaryPassword: "temporary-password",
+  });
+  vi.mocked(sendMail).mockResolvedValue({
+    status: "sent",
+    messageId: "message-1",
+  });
+});
+
+test("creates a Workspace account and sends its credentials privately", async () => {
+  await expect(
+    provisionManualMemberWorkspace({
+      name: "Alex Beispiel",
+      primaryEmail: "alex@youngfounders.network",
+      privateEmail: "alex@example.com",
+    }),
+  ).resolves.toEqual({ userId: "google-user-1" });
+
+  expect(provisionWorkspaceUser).toHaveBeenCalledWith({
+    applicationId: "manual-member:alex@youngfounders.network",
+    primaryEmail: "alex@youngfounders.network",
+    recoveryEmail: "alex@example.com",
+    givenName: "Alex",
+    familyName: "Beispiel",
+  });
+  expect(sendMail).toHaveBeenCalledWith(
+    expect.objectContaining({
+      to: [{ email: "alex@example.com", name: "Alex Beispiel" }],
+      templateId: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
+      subject: "Deine Zugangsdaten für YFN",
+      params: expect.objectContaining({
+        message: expect.stringContaining("temporary-password"),
+      }),
+    }),
+  );
+});
+
+test.each([
+  { status: "skipped", reason: "disabled" } as const,
+  { status: "skipped", reason: "recipient-not-allowed" } as const,
+])("fails onboarding when credentials are not delivered", async (delivery) => {
+  vi.mocked(sendMail).mockResolvedValueOnce(delivery);
+
+  await expect(
+    provisionManualMemberWorkspace({
+      name: "Alex Beispiel",
+      primaryEmail: "alex@youngfounders.network",
+      privateEmail: "alex@example.com",
+    }),
+  ).rejects.toThrow("Zugangsdaten konnten nicht versendet werden");
+});
+
+test("validates the login URL before creating the account", async () => {
+  vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+  vi.stubEnv("AUTH_URL", "");
+
+  await expect(
+    provisionManualMemberWorkspace({
+      name: "Alex Beispiel",
+      primaryEmail: "alex@youngfounders.network",
+      privateEmail: "alex@example.com",
+    }),
+  ).rejects.toThrow("NEXT_PUBLIC_APP_URL");
+  expect(provisionWorkspaceUser).not.toHaveBeenCalled();
+});

--- a/app/lib/server/users/manualWorkspaceProvisioning.ts
+++ b/app/lib/server/users/manualWorkspaceProvisioning.ts
@@ -1,0 +1,68 @@
+import { appendWorkspaceAccessDetails } from "../../applications/decisionEmail";
+import { sendMail } from "../../email/brevo";
+import { BREVO_TEMPLATE_IDS } from "../../email/templates";
+import { appUrl } from "../../email/urls";
+import { provisionWorkspaceUser } from "../../googleWorkspace/users";
+import { YFN_ORGANIZATION } from "../../organization";
+
+interface ManualWorkspaceProvisioningInput {
+  name: string;
+  primaryEmail: string;
+  privateEmail: string;
+}
+
+export async function provisionManualMemberWorkspace(
+  input: ManualWorkspaceProvisioningInput,
+): Promise<{ userId: string }> {
+  const loginUrl = appUrl("/login");
+  const { givenName, familyName } = workspaceMemberName(
+    input.name,
+    input.primaryEmail,
+  );
+  const account = await provisionWorkspaceUser({
+    applicationId: manualWorkspaceProvisioningId(input.primaryEmail),
+    primaryEmail: input.primaryEmail,
+    recoveryEmail: input.privateEmail,
+    givenName,
+    familyName,
+  });
+  const message = appendWorkspaceAccessDetails({
+    message: `Hey ${givenName},\n\nwillkommen bei ${YFN_ORGANIZATION.name}. Dein Google-Workspace-Konto wurde für dein Onboarding eingerichtet.`,
+    primaryEmail: account.primaryEmail,
+    temporaryPassword: account.temporaryPassword,
+    loginUrl,
+  });
+  const delivery = await sendMail({
+    to: [{ email: input.privateEmail, name: input.name }],
+    templateId: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
+    subject: "Deine Zugangsdaten für YFN",
+    params: {
+      applicantName: input.name,
+      jobTitle: "Mitglied",
+      organizationName: YFN_ORGANIZATION.name,
+      message,
+    },
+    tags: ["ybase", "member", "manual-onboarding"],
+  });
+  if (delivery.status !== "sent") {
+    throw new Error("Zugangsdaten konnten nicht versendet werden");
+  }
+
+  return { userId: account.userId };
+}
+
+function manualWorkspaceProvisioningId(primaryEmail: string): string {
+  return `manual-member:${primaryEmail.trim().toLowerCase()}`;
+}
+
+function workspaceMemberName(
+  name: string,
+  primaryEmail: string,
+): { givenName: string; familyName: string } {
+  const fallback = primaryEmail.split("@")[0] || "Mitglied";
+  const parts = (name.trim() || fallback).split(/\s+/);
+  return {
+    givenName: parts[0],
+    familyName: parts.slice(1).join(" ") || parts[0],
+  };
+}

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -5,6 +5,9 @@ vi.mock("../../auth/session", () => ({
   requireRole: vi.fn(),
   requirePermission: vi.fn(),
 }));
+vi.mock("./manualWorkspaceProvisioning", () => ({
+  provisionManualMemberWorkspace: vi.fn(),
+}));
 
 import {
   requirePermission,
@@ -25,6 +28,7 @@ import { createMember } from "./creation";
 import { listMembers } from "./data";
 import { recordMemberInfraction } from "./infractions";
 import { setMemberStatus, setTeamOnboardingStatus } from "./lifecycleActions";
+import { provisionManualMemberWorkspace } from "./manualWorkspaceProvisioning";
 import { addUserToOrganization } from "./membership";
 import { updateBankDetails, updateMemberProfile } from "./profile";
 import { updateUserRole } from "./roles";
@@ -38,6 +42,10 @@ let memberB: string;
 setupTestDatabase();
 
 beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.mocked(provisionManualMemberWorkspace).mockResolvedValue({
+    userId: "google-manual-member",
+  });
   orgA = newId();
   orgB = newId();
   adminA = newId();
@@ -170,8 +178,14 @@ test("createMember starts a member in onboarding and writes a log", async () => 
     memberStatus: "onboarding",
     teamOnboardingStatus: "not_started",
     publicProfileSetupRequired: true,
+    googleWorkspaceUserId: "google-manual-member",
   });
   expect(typeof created?.registeredAt).toBe("number");
+  expect(provisionManualMemberWorkspace).toHaveBeenCalledWith({
+    name: "Manual Member",
+    primaryEmail: "manual@youngfounders.network",
+    privateEmail: "manual@example.com",
+  });
 
   const log = await (await logs()).findOne({ action: "member.created" });
   expect(log).toMatchObject({
@@ -187,6 +201,7 @@ test("createMember rejects invalid domains and duplicate profiles", async () => 
     createMember({
       name: "External Member",
       email: "member@example.org",
+      privateEmail: "external@example.org",
       teamId: "manual-team",
       isTeamLead: false,
     }),
@@ -195,6 +210,7 @@ test("createMember rejects invalid domains and duplicate profiles", async () => 
   await createMember({
     name: "Existing Member",
     email: "existing@youngfounders.network",
+    privateEmail: "existing@example.com",
     teamId: "manual-team",
     isTeamLead: false,
   });
@@ -202,6 +218,7 @@ test("createMember rejects invalid domains and duplicate profiles", async () => 
     createMember({
       name: "Existing Member",
       email: "EXISTING@YOUNGFOUNDERS.NETWORK",
+      privateEmail: "existing@example.com",
       teamId: "manual-team",
       isTeamLead: false,
     }),
@@ -215,10 +232,33 @@ test("createMember rejects leads for chapters", async () => {
     createMember({
       name: "Chapter Lead",
       email: "chapter@youngfounders.network",
+      privateEmail: "chapter@example.com",
       teamId: "manual-chapter",
       isTeamLead: true,
     }),
   ).rejects.toThrow("Chapter haben keine Lead-Position");
+});
+
+test("createMember rolls back the profile when Workspace setup fails", async () => {
+  await seedTeam("manual-team", orgA);
+  vi.mocked(provisionManualMemberWorkspace).mockRejectedValueOnce(
+    new Error("Zugangsdaten konnten nicht versendet werden"),
+  );
+
+  await expect(
+    createMember({
+      name: "Failed Member",
+      email: "failed@youngfounders.network",
+      privateEmail: "failed@example.com",
+      teamId: "manual-team",
+      isTeamLead: false,
+    }),
+  ).rejects.toThrow("Zugangsdaten konnten nicht versendet werden");
+
+  expect(
+    await (await users()).findOne({ email: "failed@youngfounders.network" }),
+  ).toBeNull();
+  expect(await (await logs()).findOne({ action: "member.created" })).toBeNull();
 });
 
 test("rejects invalid private contact details", async () => {


### PR DESCRIPTION
## summary

- provision Google Workspace accounts during manual onboarding and deliver temporary credentials to the required private email
- keep manual provisioning retry-safe and roll back incomplete local member profiles when account setup or delivery fails
- link application-based onboarding profiles before sending acceptance credentials

## validation

- `pnpm test` (591 tests passed)
- `pnpm vitest run app/lib/server/users/users.test.ts app/lib/server/users/manualWorkspaceProvisioning.test.ts app/lib/server/applications/decision.test.ts app/lib/server/applications/decisionProvisioning.test.ts app/lib/googleWorkspace/users.test.ts` (61 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm build` (passed with existing dependency-data warnings)
- changed-file Biome lint and Prettier check
- `pnpm lint` (passed with three existing warnings outside this diff)
- `pnpm lint:lines` (existing failure: `CreateJobPostingDialog.tsx` has 204 lines)
- `git diff --check origin/main...HEAD`
