### PR TITLE
feat(email): notify user lifecycle states

### DIFF
--- a/app/lib/email/templates.test.ts
+++ b/app/lib/email/templates.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { BREVO_TEMPLATE_IDS, USER_STATE_EMAIL_TEMPLATES } from "./templates";
+
+describe("user-state Brevo templates", () => {
+  it("uses the central static Brevo template catalog", () => {
+    expect(USER_STATE_EMAIL_TEMPLATES.member_activated.templateId).toBe(
+      BREVO_TEMPLATE_IDS.MEMBER_ACTIVATED,
+    );
+    expect(USER_STATE_EMAIL_TEMPLATES.workspace_account_ready.templateId).toBe(
+      BREVO_TEMPLATE_IDS.WORKSPACE_ACCOUNT_READY,
+    );
+  });
+
+  it("keeps every user-state event tagged", () => {
+    for (const template of Object.values(USER_STATE_EMAIL_TEMPLATES)) {
+      expect(template.tag).toMatch(/\S/);
+    }
+  });
+});

--- a/app/lib/email/templates.ts
+++ b/app/lib/email/templates.ts
@@ -9,4 +9,67 @@ export const BREVO_TEMPLATE_IDS = {
   APPLICATION_ACCEPTED: 151,
   APPLICATION_REJECTED: 152,
   MEMBERSHIP_GUARDIAN_CONSENT: 153,
+
+  MEMBER_ONBOARDING_STARTED: undefined,
+  MEMBER_ACTIVATED: undefined,
+  TEAM_ONBOARDING_STARTED: undefined,
+  TEAM_ONBOARDING_COMPLETED: undefined,
+  MEMBER_OFFBOARDING_PLANNED: undefined,
+  MEMBER_OFFBOARDING_STARTED: undefined,
+  MEMBER_ARCHIVED: undefined,
+  MEMBER_EXCLUDED: undefined,
+  WORKSPACE_ACCOUNT_READY: undefined,
 } as const;
+
+export type UserStateEmailEvent =
+  | "member_onboarding_started"
+  | "member_activated"
+  | "team_onboarding_started"
+  | "team_onboarding_completed"
+  | "member_offboarding_planned"
+  | "member_offboarding_started"
+  | "member_archived"
+  | "member_excluded"
+  | "workspace_account_ready";
+
+export const USER_STATE_EMAIL_TEMPLATES = {
+  member_onboarding_started: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_ONBOARDING_STARTED,
+    tag: "member-onboarding-started",
+  },
+  member_activated: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_ACTIVATED,
+    tag: "member-activated",
+  },
+  team_onboarding_started: {
+    templateId: BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_STARTED,
+    tag: "team-onboarding-started",
+  },
+  team_onboarding_completed: {
+    templateId: BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_COMPLETED,
+    tag: "team-onboarding-completed",
+  },
+  member_offboarding_planned: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_OFFBOARDING_PLANNED,
+    tag: "member-offboarding-planned",
+  },
+  member_offboarding_started: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_OFFBOARDING_STARTED,
+    tag: "member-offboarding-started",
+  },
+  member_archived: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_ARCHIVED,
+    tag: "member-archived",
+  },
+  member_excluded: {
+    templateId: BREVO_TEMPLATE_IDS.MEMBER_EXCLUDED,
+    tag: "member-excluded",
+  },
+  workspace_account_ready: {
+    templateId: BREVO_TEMPLATE_IDS.WORKSPACE_ACCOUNT_READY,
+    tag: "workspace-account-ready",
+  },
+} as const satisfies Record<
+  UserStateEmailEvent,
+  { templateId: number | undefined; tag: string }
+>;

--- a/app/lib/server/applications/decision.ts
+++ b/app/lib/server/applications/decision.ts
@@ -45,7 +45,11 @@ export async function sendApplicationDecision(
           message: decision.message,
           yfnEmail: decision.yfnEmail,
         })
-      : { message: decision.message, workspaceUserId: undefined };
+      : {
+          message: decision.message,
+          workspaceAccess: undefined,
+          workspaceUserId: undefined,
+        };
 
   await sendDecisionEmail({
     application,
@@ -55,6 +59,7 @@ export async function sendApplicationDecision(
     organizationId: user.organizationId,
     subject: decision.subject,
     workspaceUserId: prepared.workspaceUserId,
+    workspaceAccess: prepared.workspaceAccess,
   });
 
   let acceptedMember:

--- a/app/lib/server/applications/decisionDelivery.ts
+++ b/app/lib/server/applications/decisionDelivery.ts
@@ -5,6 +5,7 @@ import { sendMail } from "../../email/brevo";
 import { BREVO_TEMPLATE_IDS } from "../../email/templates";
 import { provisionWorkspaceUser } from "../../googleWorkspace/users";
 import { YFN_ORGANIZATION } from "../../organization";
+import { sendWorkspaceAccountReadyEmail } from "../users/email";
 import {
   recordWorkspaceDeliveryFailure,
   recordWorkspaceProvisioned,
@@ -19,12 +20,22 @@ const templateIds = {
   rejected: BREVO_TEMPLATE_IDS.APPLICATION_REJECTED,
 };
 
+export type WorkspaceAccessDetails = {
+  primaryEmail: string;
+  temporaryPassword: string;
+  loginUrl: string;
+};
+
 export async function prepareAcceptance(input: {
   application: Application;
   organizationId: string;
   message: string;
   yfnEmail: string;
-}): Promise<{ message: string; workspaceUserId: string }> {
+}): Promise<{
+  message: string;
+  workspaceUserId: string;
+  workspaceAccess: WorkspaceAccessDetails;
+}> {
   const loginUrl = ybaseLoginUrl();
   const reservation = await reserveWorkspaceProvisioning({
     application: input.application,
@@ -45,14 +56,20 @@ export async function prepareAcceptance(input: {
       organizationId: input.organizationId,
       workspaceUserId: account.userId,
     });
+    const workspaceAccess: WorkspaceAccessDetails = {
+      primaryEmail: account.primaryEmail,
+      temporaryPassword: account.temporaryPassword,
+      loginUrl,
+    };
     return {
       workspaceUserId: account.userId,
       message: appendWorkspaceAccessDetails({
         message: input.message,
-        primaryEmail: account.primaryEmail,
-        temporaryPassword: account.temporaryPassword,
+        primaryEmail: workspaceAccess.primaryEmail,
+        temporaryPassword: workspaceAccess.temporaryPassword,
         loginUrl,
       }),
+      workspaceAccess,
     };
   } catch (error) {
     await recordWorkspaceProvisioningFailure({
@@ -72,6 +89,7 @@ export async function sendDecisionEmail(input: {
   organizationId: string;
   subject: string;
   workspaceUserId?: string;
+  workspaceAccess?: WorkspaceAccessDetails;
 }): Promise<void> {
   let delivery: Awaited<ReturnType<typeof sendMail>>;
   try {
@@ -100,6 +118,16 @@ export async function sendDecisionEmail(input: {
   if (delivery.status !== "sent") {
     await recordDeliveryFailure(input);
     throw new Error("E-Mail konnte nicht versendet werden");
+  }
+
+  if (input.decision === "accepted" && input.workspaceAccess) {
+    await sendWorkspaceAccountReadyEmail({
+      recoveryEmail: input.application.applicantEmail,
+      applicantName: input.application.applicantName,
+      workspaceEmail: input.workspaceAccess.primaryEmail,
+      temporaryPassword: input.workspaceAccess.temporaryPassword,
+      loginUrl: input.workspaceAccess.loginUrl,
+    });
   }
 }
 

--- a/app/lib/server/memberships/accessClosure.ts
+++ b/app/lib/server/memberships/accessClosure.ts
@@ -3,6 +3,7 @@ import { memberships, users } from "../../db/collections";
 import type { Membership, User } from "../../db/types";
 import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
 import { terminalMemberStatus } from "../../members/termination";
+import { notifyMemberStatusChange } from "../users/email";
 
 export async function syncEndedMembershipAccess(
   membership: Membership,
@@ -41,6 +42,11 @@ export async function syncEndedMembershipAccess(
     await users()
   ).updateOne({ _id: user._id, membershipId: membership._id }, update);
   if (projected.matchedCount !== 1) return;
+  await notifyMemberStatusChange({
+    user,
+    previous: user.memberStatus,
+    next: status,
+  });
   await (
     await memberships()
   ).updateOne(

--- a/app/lib/server/memberships/handover.ts
+++ b/app/lib/server/memberships/handover.ts
@@ -1,6 +1,7 @@
 import { memberships, users } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { HandoverTask, Membership, User } from "../../db/types";
+import { notifyMemberStatusChange } from "../users/email";
 import { appendMembershipEvent } from "./events";
 
 const HANDOVER_TASKS: Array<Pick<HandoverTask, "category" | "title">> = [
@@ -87,7 +88,7 @@ export async function ensureMembershipHandover(
         );
   if (!stored?.handoverStartedAt) return false;
 
-  await (
+  const statusUpdate = await (
     await users()
   ).updateOne(
     {
@@ -102,6 +103,13 @@ export async function ensureMembershipHandover(
       },
     },
   );
+  if (statusUpdate.modifiedCount === 1) {
+    await notifyMemberStatusChange({
+      user: member,
+      previous: member.memberStatus,
+      next: "offboarding_planned",
+    });
+  }
   await appendMembershipEvent({
     organizationId: membership.organizationId,
     membershipId: membership._id,

--- a/app/lib/server/reimbursementInvites/redemption.ts
+++ b/app/lib/server/reimbursementInvites/redemption.ts
@@ -7,6 +7,7 @@ import {
 } from "../../members/status";
 import { YFN_ORGANIZATION } from "../../organization";
 import { addLog } from "../logs";
+import { notifyMemberStatusChange } from "../users/email";
 import {
   hashReimbursementInviteToken,
   isReimbursementInviteToken,
@@ -71,4 +72,9 @@ export async function redeemReimbursementInvite(token: string): Promise<void> {
     invite._id,
     email,
   );
+  await notifyMemberStatusChange({
+    user,
+    previous: user.memberStatus,
+    next: "active",
+  });
 }

--- a/app/lib/server/users/creation.ts
+++ b/app/lib/server/users/creation.ts
@@ -10,6 +10,7 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { addLog } from "../logs";
 import { requireActiveOrganizationTeam } from "./access";
 import { phoneSchema, privateEmailSchema } from "./contactDetails";
+import { sendUserStateEmail } from "./email";
 
 const MEMBER_EMAIL_CONFLICT_MESSAGE =
   "Für diese E-Mail-Adresse gibt es bereits ein Profil.";
@@ -91,6 +92,10 @@ export async function createMember(input: CreateMemberInput): Promise<User> {
     createdMember._id,
     `${memberInput.name} (${memberInput.email})`,
   );
+  await sendUserStateEmail({
+    user: createdMember,
+    event: "member_onboarding_started",
+  });
 
   return createdMember;
 }

--- a/app/lib/server/users/email.test.ts
+++ b/app/lib/server/users/email.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
+
+import { sendMail } from "../../email/brevo";
+import {
+  notifyMemberStatusChange,
+  notifyTeamOnboardingChange,
+  sendUserStateEmail,
+  sendWorkspaceAccountReadyEmail,
+} from "./email";
+
+const user = {
+  name: "Alex Beispiel",
+  email: "alex@youngfounders.network",
+  privateEmail: "alex@example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(sendMail).mockResolvedValue({ status: "sent" });
+});
+
+describe("user-state emails", () => {
+  it("does not send before the static Brevo ID is configured", async () => {
+    await sendUserStateEmail({ user, event: "member_activated" });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("emits only for actual state transitions", async () => {
+    await notifyMemberStatusChange({
+      user,
+      previous: "active",
+      next: "active",
+    });
+    await notifyTeamOnboardingChange({
+      user,
+      previous: "not_started",
+      next: "not_started",
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("supports a dedicated Workspace account email", async () => {
+    await sendWorkspaceAccountReadyEmail({
+      recoveryEmail: "alex@example.com",
+      applicantName: "Alex Beispiel",
+      workspaceEmail: "alex@youngfounders.network",
+      temporaryPassword: "temporary-password",
+      loginUrl: "https://ybase.example/login",
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/app/lib/server/users/email.ts
+++ b/app/lib/server/users/email.ts
@@ -1,0 +1,130 @@
+import type {
+  MemberStatus,
+  StoredMemberStatus,
+  TeamOnboardingStatus,
+  User,
+} from "../../db/types";
+import { type EmailRecipient, sendMail } from "../../email/brevo";
+import {
+  type UserStateEmailEvent,
+  USER_STATE_EMAIL_TEMPLATES,
+} from "../../email/templates";
+import { appUrl } from "../../email/urls";
+import { YFN_ORGANIZATION } from "../../organization";
+
+type UserEmailProfile = Pick<User, "name" | "email" | "privateEmail">;
+
+const MEMBER_STATUS_EMAIL_EVENTS: Record<MemberStatus, UserStateEmailEvent> = {
+  onboarding: "member_onboarding_started",
+  active: "member_activated",
+  offboarding_planned: "member_offboarding_planned",
+  offboarding: "member_offboarding_started",
+  archived: "member_archived",
+  excluded: "member_excluded",
+};
+
+const TEAM_ONBOARDING_EMAIL_EVENTS: Record<
+  TeamOnboardingStatus,
+  UserStateEmailEvent | undefined
+> = {
+  not_started: undefined,
+  in_progress: "team_onboarding_started",
+  completed: "team_onboarding_completed",
+};
+
+export async function notifyMemberStatusChange(input: {
+  user: UserEmailProfile;
+  previous: StoredMemberStatus;
+  next: MemberStatus;
+}): Promise<void> {
+  if (input.previous === input.next) return;
+  await sendUserStateEmail({
+    user: input.user,
+    event: MEMBER_STATUS_EMAIL_EVENTS[input.next],
+  });
+}
+
+export async function notifyTeamOnboardingChange(input: {
+  user: UserEmailProfile;
+  previous: TeamOnboardingStatus;
+  next: TeamOnboardingStatus;
+}): Promise<void> {
+  if (input.previous === input.next) return;
+  const event = TEAM_ONBOARDING_EMAIL_EVENTS[input.next];
+  if (!event) return;
+  await sendUserStateEmail({ user: input.user, event });
+}
+
+export async function sendUserStateEmail(input: {
+  user: UserEmailProfile;
+  event: UserStateEmailEvent;
+}): Promise<void> {
+  const recipient = userRecipient(input.user);
+  if (!recipient) return;
+
+  await sendConfiguredUserEmail(input.event, recipient, {
+    memberName: input.user.name ?? "",
+    memberEmail: input.user.email ?? "",
+    privateEmail: input.user.privateEmail ?? "",
+  });
+}
+
+export async function sendWorkspaceAccountReadyEmail(input: {
+  recoveryEmail: string;
+  applicantName?: string;
+  workspaceEmail: string;
+  temporaryPassword: string;
+  loginUrl: string;
+}): Promise<void> {
+  await sendConfiguredUserEmail(
+    "workspace_account_ready",
+    { email: input.recoveryEmail, name: input.applicantName },
+    {
+      memberName: input.applicantName ?? "",
+      workspaceEmail: input.workspaceEmail,
+      temporaryPassword: input.temporaryPassword,
+      loginUrl: input.loginUrl,
+    },
+  );
+}
+
+async function sendConfiguredUserEmail(
+  event: UserStateEmailEvent,
+  recipient: EmailRecipient,
+  params: Record<string, string>,
+): Promise<void> {
+  const template = USER_STATE_EMAIL_TEMPLATES[event];
+  const templateId = template.templateId;
+  if (!templateId) return;
+
+  try {
+    const delivery = await sendMail({
+      to: [recipient],
+      templateId,
+      params: {
+        organizationName: YFN_ORGANIZATION.name,
+        ybaseUrl: safeAppUrl("/"),
+        ...params,
+      },
+      tags: ["ybase", "user-state", template.tag],
+    });
+    if (delivery.status === "skipped" && delivery.reason !== "disabled") {
+      console.warn(`User-state email ${event} was skipped`, delivery.reason);
+    }
+  } catch (error) {
+    console.error(`Could not send user-state email ${event}`, error);
+  }
+}
+
+function userRecipient(user: UserEmailProfile): EmailRecipient | null {
+  const email = user.privateEmail?.trim() || user.email?.trim();
+  return email ? { email, name: user.name } : null;
+}
+
+function safeAppUrl(path: string): string {
+  try {
+    return appUrl(path);
+  } catch {
+    return "";
+  }
+}

--- a/app/lib/server/users/infractions.ts
+++ b/app/lib/server/users/infractions.ts
@@ -7,6 +7,7 @@ import { newId } from "../../db/ids";
 import type { MemberInfraction, User } from "../../db/types";
 import { addLog } from "../logs";
 import { loadManagedMember } from "./access";
+import { notifyMemberStatusChange } from "./email";
 
 const MAX_INFRACTIONS = 2;
 const ELIGIBLE_STATUSES = ["active", "offboarding_planned"] as const;
@@ -87,6 +88,11 @@ export async function recordMemberInfraction(input: RecordInfractionInput) {
         `${target.name ?? target.email}: Verstoß ${infractionCount}/${MAX_INFRACTIONS}`,
       );
       if (memberExcluded) {
+        await notifyMemberStatusChange({
+          user: target,
+          previous: target.memberStatus,
+          next: "excluded",
+        });
         await addLog(
           currentUser.organizationId,
           currentUser._id,

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -10,6 +10,7 @@ import {
   requireActiveOrganizationDepartment,
   requireActiveOrganizationTeam,
 } from "./access";
+import { notifyMemberStatusChange, notifyTeamOnboardingChange } from "./email";
 import { memberStatusPatch, teamOnboardingPatch } from "./memberLifecycle";
 
 const memberStatusSchema = z.enum([
@@ -96,9 +97,18 @@ export async function setMemberStatus(input: {
       throw new Error("Ein Lead benötigt ein zugeordnetes weiteres Team.");
     }
   }
+  if (target.memberStatus === status) return;
 
   const patch = memberStatusPatch(target.memberStatus, status, Date.now());
-  await (await users()).updateOne({ _id: target._id }, { $set: patch });
+  const result = await (
+    await users()
+  ).updateOne(
+    { _id: target._id, memberStatus: target.memberStatus },
+    { $set: patch },
+  );
+  if (result.modifiedCount !== 1) {
+    throw new Error("Das Mitglied wurde zwischenzeitlich geändert.");
+  }
   await addLog(
     currentUser.organizationId,
     currentUser._id,
@@ -106,6 +116,11 @@ export async function setMemberStatus(input: {
     target._id,
     `${target.name ?? target.email}: ${target.memberStatus} → ${status}`,
   );
+  await notifyMemberStatusChange({
+    user: target,
+    previous: target.memberStatus,
+    next: status,
+  });
 }
 
 export async function setTeamOnboardingStatus(input: {
@@ -121,13 +136,22 @@ export async function setTeamOnboardingStatus(input: {
       "Das Onboarding eines freigegebenen Teammitglieds kann nicht erneut geöffnet werden.",
     );
   }
+  if (target.teamOnboardingStatus === status) return;
 
   const patch = teamOnboardingPatch(
     target.teamOnboardingStatus,
     status,
     Date.now(),
   );
-  await (await users()).updateOne({ _id: target._id }, { $set: patch });
+  const result = await (
+    await users()
+  ).updateOne(
+    { _id: target._id, teamOnboardingStatus: target.teamOnboardingStatus },
+    { $set: patch },
+  );
+  if (result.modifiedCount !== 1) {
+    throw new Error("Das Mitglied wurde zwischenzeitlich geändert.");
+  }
   await addLog(
     currentUser.organizationId,
     currentUser._id,
@@ -135,4 +159,9 @@ export async function setTeamOnboardingStatus(input: {
     target._id,
     `${target.name ?? target.email}: ${target.teamOnboardingStatus} → ${status}`,
   );
+  await notifyTeamOnboardingChange({
+    user: target,
+    previous: target.teamOnboardingStatus,
+    next: status,
+  });
 }


### PR DESCRIPTION
## summary

- add a centralized static Brevo catalog and best-effort sender for user-state emails
- notify onboarding, team onboarding, activation, offboarding, archive/exclusion, and workspace-account events
- keep new lifecycle templates disabled until their Brevo IDs are added to the template catalog

## validation

- `pnpm test` (590 tests passed)
- `pnpm exec vitest run app/lib/email/templates.test.ts app/lib/server/users/email.test.ts app/lib/server/applications/decision.test.ts app/lib/server/memberships/accessClosure.test.ts app/lib/server/users/users.test.ts` (52 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome lint` on all changed files
- `pnpm lint` (passed with 3 pre-existing warnings)
- `pnpm lint:lines` (existing failure in `app/components/Dialogs/CreateJobPostingDialog.tsx`)