### PR TITLE
fix(recruiting): stabilize application withdrawal redirects

### DIFF
--- a/app/api/public/applications/withdraw/[token]/route.test.ts
+++ b/app/api/public/applications/withdraw/[token]/route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withdrawApplicationByToken } from "@/lib/server/applications/withdrawal";
+import { POST } from "./route";
+
+vi.mock("@/lib/server/applications/withdrawal", () => ({
+	withdrawApplicationByToken: vi.fn(),
+}));
+
+const withdrawApplication = vi.mocked(withdrawApplicationByToken);
+
+describe("POST /api/public/applications/withdraw/[token]", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000/");
+		vi.stubEnv("AUTH_URL", "http://auth.example");
+	});
+
+	it("redirects to the configured app host after withdrawal", async () => {
+		const response = await POST(
+			new Request("http://0.0.0.0:3000/api/public/applications/withdraw/token"),
+			{ params: Promise.resolve({ token: "token" }) },
+		);
+
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe(
+			"http://localhost:3000/withdraw-application/success",
+		);
+	});
+
+	it("uses the configured app host for invalid links too", async () => {
+		withdrawApplication.mockRejectedValueOnce(new Error("invalid token"));
+
+		const response = await POST(
+			new Request("http://0.0.0.0:3000/api/public/applications/withdraw/token"),
+			{ params: Promise.resolve({ token: "token" }) },
+		);
+
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe(
+			"http://localhost:3000/withdraw-application/invalid",
+		);
+	});
+});

--- a/app/api/public/applications/withdraw/[token]/route.ts
+++ b/app/api/public/applications/withdraw/[token]/route.ts
@@ -2,18 +2,23 @@ import { withdrawApplicationByToken } from "@/lib/server/applications/withdrawal
 
 type RouteContext = { params: Promise<{ token: string }> };
 
+function redirectTo(pathname: string, requestUrl: string): Response {
+	const configuredAppUrl = (
+		process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL
+	)?.trim();
+	const baseUrl = configuredAppUrl
+		? `${configuredAppUrl.replace(/\/+$/, "")}/`
+		: requestUrl;
+
+	return Response.redirect(new URL(pathname, baseUrl), 303);
+}
+
 export async function POST(request: Request, context: RouteContext) {
-  const { token } = await context.params;
-  try {
-    await withdrawApplicationByToken(token);
-    return Response.redirect(
-      new URL("/withdraw-application/success", request.url),
-      303,
-    );
-  } catch {
-    return Response.redirect(
-      new URL("/withdraw-application/invalid", request.url),
-      303,
-    );
-  }
+	const { token } = await context.params;
+	try {
+		await withdrawApplicationByToken(token);
+		return redirectTo("/withdraw-application/success", request.url);
+	} catch {
+		return redirectTo("/withdraw-application/invalid", request.url);
+	}
 }


### PR DESCRIPTION
## summary

- Route redirects now use the configured app URL instead of the incoming request host, avoiding `0.0.0.0` connection failures.
- Added regression coverage for successful and invalid withdrawal redirects.

## validation

- `git diff --check origin/main...HEAD`
- `pnpm exec biome check app/api/public/applications/withdraw/[token]/route.ts app/api/public/applications/withdraw/[token]/route.test.ts`
- `pnpm exec vitest run app/api/public/applications/withdraw/[token]/route.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (passes with three pre-existing warnings)
- `pnpm lint:lines` (fails on pre-existing violations in CreateJobPostingDialog.tsx and decision.ts)