### PR TITLE
feat(onboarding): send workspace access emails

### DIFF
--- a/app/lib/applications/decisionEmail.test.ts
+++ b/app/lib/applications/decisionEmail.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  appendWorkspaceAccessDetails,
-  applicationDecisionEmailDefaults,
-} from "./decisionEmail";
+import { applicationDecisionEmailDefaults } from "./decisionEmail";
 
 describe("applicationDecisionEmailDefaults", () => {
   test("prefills an acceptance email with applicant and job title", () => {
@@ -16,19 +13,6 @@ describe("applicationDecisionEmailDefaults", () => {
     expect(email.subject).toContain("Fundraising");
     expect(email.message).toContain("Hey Alex Beispiel");
     expect(email.message).toContain("Zusage");
-  });
-
-  test("adds temporary Workspace access details", () => {
-    const message = appendWorkspaceAccessDetails({
-      message: "Willkommen im Team!",
-      primaryEmail: "alex@youngfounders.network",
-      temporaryPassword: "temporary-password",
-      loginUrl: "https://ybase.example/login",
-    });
-
-    expect(message).toContain("alex@youngfounders.network");
-    expect(message).toContain("temporary-password");
-    expect(message).toContain("https://ybase.example/login");
   });
 
   test("prefills a rejection email without requiring a name", () => {

--- a/app/lib/applications/decisionEmail.ts
+++ b/app/lib/applications/decisionEmail.ts
@@ -17,7 +17,7 @@ export function applicationDecisionEmailDefaults(input: {
   if (input.decision === "accepted") {
     return {
       subject: `Zusage für deine Bewerbung als ${input.jobTitle}`,
-      message: `${greeting}\n\nvielen Dank für deine Bewerbung. Wir freuen uns, dir für die Position ${input.jobTitle} eine Zusage zu geben.\n\nDein YFN-Konto wird mit der Zusage eingerichtet. Die Zugangsdaten und den Link zu YBase findest du in dieser E-Mail.`,
+      message: `${greeting}\n\nvielen Dank für deine Bewerbung. Wir freuen uns, dir für die Position ${input.jobTitle} eine Zusage zu geben.\n\nDein YFN-Konto wird mit der Zusage eingerichtet. Deine Google-Workspace-Zugangsdaten erhältst du in einer separaten E-Mail.`,
     };
   }
 
@@ -25,13 +25,4 @@ export function applicationDecisionEmailDefaults(input: {
     subject: `Rückmeldung zu deiner Bewerbung als ${input.jobTitle}`,
     message: `${greeting}\n\nvielen Dank für deine Bewerbung und dein Interesse an der Position ${input.jobTitle}. Leider können wir dir dieses Mal keine Zusage geben.\n\nWir wünschen dir für deinen weiteren Weg alles Gute.`,
   };
-}
-
-export function appendWorkspaceAccessDetails(input: {
-  message: string;
-  primaryEmail: string;
-  temporaryPassword: string;
-  loginUrl: string;
-}): string {
-  return `${input.message.trim()}\n\nDein YFN-Zugang\nE-Mail: ${input.primaryEmail}\nTemporäres Passwort: ${input.temporaryPassword}\n\nBitte ändere das Passwort bei deiner ersten Anmeldung. Anschließend kannst du dich direkt über Google in YBase anmelden:\n${input.loginUrl}`;
 }

--- a/app/lib/email/templates.test.ts
+++ b/app/lib/email/templates.test.ts
@@ -3,8 +3,11 @@ import { BREVO_TEMPLATE_IDS, USER_STATE_EMAIL_TEMPLATES } from "./templates";
 
 describe("user-state Brevo templates", () => {
   it("uses the central static Brevo template catalog", () => {
-    expect(USER_STATE_EMAIL_TEMPLATES.member_activated.templateId).toBe(
-      BREVO_TEMPLATE_IDS.MEMBER_ACTIVATED,
+    expect(BREVO_TEMPLATE_IDS.MEMBERSHIP_GUARDIAN_CONSENT).toBeUndefined();
+    expect(BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_STARTED).toBe(171);
+    expect(BREVO_TEMPLATE_IDS.WORKSPACE_ACCOUNT_READY).toBe(172);
+    expect(USER_STATE_EMAIL_TEMPLATES.team_onboarding_started.templateId).toBe(
+      BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_STARTED,
     );
     expect(USER_STATE_EMAIL_TEMPLATES.workspace_account_ready.templateId).toBe(
       BREVO_TEMPLATE_IDS.WORKSPACE_ACCOUNT_READY,
@@ -12,6 +15,10 @@ describe("user-state Brevo templates", () => {
   });
 
   it("keeps every user-state event tagged", () => {
+    expect(Object.keys(USER_STATE_EMAIL_TEMPLATES)).toEqual([
+      "team_onboarding_started",
+      "workspace_account_ready",
+    ]);
     for (const template of Object.values(USER_STATE_EMAIL_TEMPLATES)) {
       expect(template.tag).toMatch(/\S/);
     }

--- a/app/lib/email/templates.ts
+++ b/app/lib/email/templates.ts
@@ -8,62 +8,20 @@ export const BREVO_TEMPLATE_IDS = {
   APPLICATION_RECEIVED_RECRUITING_TEAM: 150,
   APPLICATION_ACCEPTED: 151,
   APPLICATION_REJECTED: 152,
-  MEMBERSHIP_GUARDIAN_CONSENT: 153,
+  MEMBERSHIP_GUARDIAN_CONSENT: undefined,
 
-  MEMBER_ONBOARDING_STARTED: undefined,
-  MEMBER_ACTIVATED: undefined,
-  TEAM_ONBOARDING_STARTED: undefined,
-  TEAM_ONBOARDING_COMPLETED: undefined,
-  MEMBER_OFFBOARDING_PLANNED: undefined,
-  MEMBER_OFFBOARDING_STARTED: undefined,
-  MEMBER_ARCHIVED: undefined,
-  MEMBER_EXCLUDED: undefined,
-  WORKSPACE_ACCOUNT_READY: undefined,
+  TEAM_ONBOARDING_STARTED: 171,
+  WORKSPACE_ACCOUNT_READY: 172,
 } as const;
 
 export type UserStateEmailEvent =
-  | "member_onboarding_started"
-  | "member_activated"
   | "team_onboarding_started"
-  | "team_onboarding_completed"
-  | "member_offboarding_planned"
-  | "member_offboarding_started"
-  | "member_archived"
-  | "member_excluded"
   | "workspace_account_ready";
 
 export const USER_STATE_EMAIL_TEMPLATES = {
-  member_onboarding_started: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_ONBOARDING_STARTED,
-    tag: "member-onboarding-started",
-  },
-  member_activated: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_ACTIVATED,
-    tag: "member-activated",
-  },
   team_onboarding_started: {
     templateId: BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_STARTED,
     tag: "team-onboarding-started",
-  },
-  team_onboarding_completed: {
-    templateId: BREVO_TEMPLATE_IDS.TEAM_ONBOARDING_COMPLETED,
-    tag: "team-onboarding-completed",
-  },
-  member_offboarding_planned: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_OFFBOARDING_PLANNED,
-    tag: "member-offboarding-planned",
-  },
-  member_offboarding_started: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_OFFBOARDING_STARTED,
-    tag: "member-offboarding-started",
-  },
-  member_archived: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_ARCHIVED,
-    tag: "member-archived",
-  },
-  member_excluded: {
-    templateId: BREVO_TEMPLATE_IDS.MEMBER_EXCLUDED,
-    tag: "member-excluded",
   },
   workspace_account_ready: {
     templateId: BREVO_TEMPLATE_IDS.WORKSPACE_ACCOUNT_READY,

--- a/app/lib/server/applications/admissionRequirements.test.ts
+++ b/app/lib/server/applications/admissionRequirements.test.ts
@@ -2,6 +2,16 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
 vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
+vi.mock("../../email/templates", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../email/templates")>();
+  return {
+    ...actual,
+    BREVO_TEMPLATE_IDS: {
+      ...actual.BREVO_TEMPLATE_IDS,
+      MEMBERSHIP_GUARDIAN_CONSENT: 999,
+    },
+  };
+});
 
 import { requirePermission } from "../../auth/session";
 import { getClient } from "../../db/client";

--- a/app/lib/server/applications/decision.test.ts
+++ b/app/lib/server/applications/decision.test.ts
@@ -5,6 +5,11 @@ vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
 vi.mock("../../googleWorkspace/users", () => ({
   provisionWorkspaceUser: vi.fn(),
 }));
+vi.mock("../users/email", () => ({
+  requireWorkspaceAccountReadyTemplateId: vi.fn(),
+  sendUserStateEmail: vi.fn(),
+  sendWorkspaceAccountReadyEmail: vi.fn(),
+}));
 
 import { requirePermission } from "../../auth/session";
 import {
@@ -23,6 +28,11 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { sendApplicationDecision } from "./decision";
+import {
+  requireWorkspaceAccountReadyTemplateId,
+  sendUserStateEmail,
+  sendWorkspaceAccountReadyEmail,
+} from "../users/email";
 
 const organizationId = newId();
 const actorId = newId();
@@ -51,6 +61,9 @@ beforeEach(async () => {
     primaryEmail: yfnEmail,
     temporaryPassword: "temporary-password",
   });
+  vi.mocked(sendWorkspaceAccountReadyEmail).mockResolvedValue();
+  vi.mocked(sendUserStateEmail).mockResolvedValue();
+  vi.mocked(requireWorkspaceAccountReadyTemplateId).mockReturnValue(170);
   vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://ybase.example");
   await (
     await organizations()
@@ -96,7 +109,7 @@ beforeEach(async () => {
   await (await applications()).insertOne(application);
 });
 
-test("sends the edited acceptance email before changing the status", async () => {
+test("sends acceptance, Workspace access, and onboarding instructions in order", async () => {
   await sendApplicationDecision({
     applicationId,
     decision: "accepted",
@@ -105,17 +118,39 @@ test("sends the edited acceptance email before changing the status", async () =>
     message: "Wir freuen uns sehr auf dich.",
   });
 
-  expect(sendMail).toHaveBeenCalledWith(
+  expect(sendMail).toHaveBeenNthCalledWith(
+    1,
     expect.objectContaining({
       to: [{ email: "alex@example.com", name: "Alex Beispiel" }],
       subject: "Individuelle Zusage",
       params: expect.objectContaining({
-        message: expect.stringContaining("temporary-password"),
+        message: "Wir freuen uns sehr auf dich.",
         jobTitle: "Fundraising",
         organizationName: YFN_ORGANIZATION.name,
       }),
     }),
   );
+  expect(sendWorkspaceAccountReadyEmail).toHaveBeenCalledWith({
+    recoveryEmail: "alex@example.com",
+    applicantName: "Alex Beispiel",
+    workspaceEmail: yfnEmail,
+    temporaryPassword: "temporary-password",
+    loginUrl: "https://ybase.example/login",
+  });
+  expect(sendUserStateEmail).toHaveBeenCalledWith({
+    user: expect.objectContaining({
+      name: "Alex Beispiel",
+      privateEmail: "alex@example.com",
+      teamOnboardingStatus: "in_progress",
+    }),
+    event: "team_onboarding_started",
+  });
+  expect(vi.mocked(sendMail).mock.invocationCallOrder[0]).toBeLessThan(
+    vi.mocked(sendWorkspaceAccountReadyEmail).mock.invocationCallOrder[0],
+  );
+  expect(
+    vi.mocked(sendWorkspaceAccountReadyEmail).mock.invocationCallOrder[0],
+  ).toBeLessThan(vi.mocked(sendUserStateEmail).mock.invocationCallOrder[0]);
   const stored = await (await applications()).findOne({ _id: applicationId });
   expect(stored).toMatchObject({
     status: "accepted",
@@ -123,6 +158,8 @@ test("sends the edited acceptance email before changing the status", async () =>
     workspaceUserId: "google-user-1",
     workspaceProvisioningStatus: "invited",
     onboardingUserId: expect.any(String),
+    onboardingStartedAt: expect.any(Number),
+    onboardingStartedBy: actorId,
   });
   expect(JSON.stringify(stored)).not.toContain("temporary-password");
   expect(stored?.history).toEqual(
@@ -154,7 +191,7 @@ test("sends the edited acceptance email before changing the status", async () =>
     role: "member",
     teamId: postingTeamId,
     memberStatus: "onboarding",
-    teamOnboardingStatus: "not_started",
+    teamOnboardingStatus: "in_progress",
   });
 });
 
@@ -269,6 +306,33 @@ test.each([
   expect(stored?.history).toBeUndefined();
   expect(stored?.workspaceProvisioningStatus).toBe("provisioned");
   expect(await (await users()).countDocuments({ applicationId })).toBe(0);
+});
+
+test("records a failed Workspace credentials delivery", async () => {
+  vi.mocked(sendWorkspaceAccountReadyEmail).mockRejectedValueOnce(
+    new Error("Brevo unavailable"),
+  );
+
+  await expect(
+    sendApplicationDecision({
+      applicationId,
+      decision: "accepted",
+      yfnEmail,
+      subject: "Zusage",
+      message: "Willkommen!",
+    }),
+  ).rejects.toThrow("Brevo unavailable");
+
+  expect(sendUserStateEmail).not.toHaveBeenCalled();
+  expect(await (await users()).countDocuments({ applicationId })).toBe(0);
+  expect(
+    await (await applications()).findOne({ _id: applicationId }),
+  ).toMatchObject({
+    status: "review",
+    workspaceProvisioningStatus: "provisioned",
+    workspaceProvisioningError:
+      "Workspace-Konto erstellt, Zugangsdaten nicht versendet",
+  });
 });
 
 test("does not overwrite a withdrawal that happens during delivery", async () => {

--- a/app/lib/server/applications/decision.ts
+++ b/app/lib/server/applications/decision.ts
@@ -6,6 +6,7 @@ import type { ApplicationDecision } from "../../applications/decisionEmail";
 import { isApplicationStatusTransitionAllowed } from "../../applications/transitions";
 import { applications, jobPostings } from "../../db/collections";
 import type { Application } from "../../db/types";
+import { sendUserStateEmail } from "../users/email";
 import { loadOwnedApplication } from "./access";
 import { recordDecisionLogs } from "./decisionAudit";
 import { prepareAcceptance, sendDecisionEmail } from "./decisionDelivery";
@@ -79,6 +80,12 @@ export async function sendApplicationDecision(
       workspaceUserId: prepared.workspaceUserId,
       workspaceAccess: prepared.workspaceAccess,
     });
+    if (acceptedMember) {
+      await sendUserStateEmail({
+        user: acceptedMember.member,
+        event: "team_onboarding_started",
+      });
+    }
     statusDetails = await persistDecision({
       application,
       decision,
@@ -178,6 +185,8 @@ async function persistDecision(input: {
           ? {
               onboardingUserId: input.onboardingUserId,
               onboardingLinkedAt: entry.timestamp,
+              onboardingStartedAt: entry.timestamp,
+              onboardingStartedBy: input.userId,
               cleanupEligibleAt: entry.timestamp,
             }
           : {}),

--- a/app/lib/server/applications/decisionDelivery.ts
+++ b/app/lib/server/applications/decisionDelivery.ts
@@ -1,11 +1,13 @@
-import { appendWorkspaceAccessDetails } from "../../applications/decisionEmail";
 import type { ApplicationDecision } from "../../applications/decisionEmail";
 import type { Application } from "../../db/types";
 import { sendMail } from "../../email/brevo";
 import { BREVO_TEMPLATE_IDS } from "../../email/templates";
 import { provisionWorkspaceUser } from "../../googleWorkspace/users";
 import { YFN_ORGANIZATION } from "../../organization";
-import { sendWorkspaceAccountReadyEmail } from "../users/email";
+import {
+  requireWorkspaceAccountReadyTemplateId,
+  sendWorkspaceAccountReadyEmail,
+} from "../users/email";
 import {
   recordWorkspaceDeliveryFailure,
   recordWorkspaceProvisioned,
@@ -36,6 +38,7 @@ export async function prepareAcceptance(input: {
   workspaceUserId: string;
   workspaceAccess: WorkspaceAccessDetails;
 }> {
+  requireWorkspaceAccountReadyTemplateId();
   const loginUrl = ybaseLoginUrl();
   const reservation = await reserveWorkspaceProvisioning({
     application: input.application,
@@ -63,12 +66,7 @@ export async function prepareAcceptance(input: {
     };
     return {
       workspaceUserId: account.userId,
-      message: appendWorkspaceAccessDetails({
-        message: input.message,
-        primaryEmail: workspaceAccess.primaryEmail,
-        temporaryPassword: workspaceAccess.temporaryPassword,
-        loginUrl,
-      }),
+      message: input.message,
       workspaceAccess,
     };
   } catch (error) {
@@ -121,13 +119,18 @@ export async function sendDecisionEmail(input: {
   }
 
   if (input.decision === "accepted" && input.workspaceAccess) {
-    await sendWorkspaceAccountReadyEmail({
-      recoveryEmail: input.application.applicantEmail,
-      applicantName: input.application.applicantName,
-      workspaceEmail: input.workspaceAccess.primaryEmail,
-      temporaryPassword: input.workspaceAccess.temporaryPassword,
-      loginUrl: input.workspaceAccess.loginUrl,
-    });
+    try {
+      await sendWorkspaceAccountReadyEmail({
+        recoveryEmail: input.application.applicantEmail,
+        applicantName: input.application.applicantName,
+        workspaceEmail: input.workspaceAccess.primaryEmail,
+        temporaryPassword: input.workspaceAccess.temporaryPassword,
+        loginUrl: input.workspaceAccess.loginUrl,
+      });
+    } catch (error) {
+      await recordDeliveryFailure(input);
+      throw error;
+    }
   }
 }
 

--- a/app/lib/server/applications/guardianConsentDelivery.ts
+++ b/app/lib/server/applications/guardianConsentDelivery.ts
@@ -15,6 +15,7 @@ export async function deliverGuardianConsentRequest(input: {
   representativeEmail: string;
   requestedAt: number;
 }): Promise<string> {
+  const templateId = requireGuardianConsentTemplateId();
   const { token, tokenHash } = createGuardianConsentToken();
   const consent: GuardianConsent = {
     representativeName: input.representativeName,
@@ -32,7 +33,7 @@ export async function deliverGuardianConsentRequest(input: {
           name: consent.representativeName,
         },
       ],
-      templateId: BREVO_TEMPLATE_IDS.MEMBERSHIP_GUARDIAN_CONSENT,
+      templateId,
       params: {
         representativeName: consent.representativeName,
         applicantName:
@@ -50,6 +51,16 @@ export async function deliverGuardianConsentRequest(input: {
     throw error;
   }
   return tokenHash;
+}
+
+function requireGuardianConsentTemplateId(): number {
+  const templateId = BREVO_TEMPLATE_IDS.MEMBERSHIP_GUARDIAN_CONSENT;
+  if (!templateId) {
+    throw new Error(
+      "Brevo-Template für die Vertretungszustimmung ist nicht konfiguriert",
+    );
+  }
+  return templateId;
 }
 
 async function reserveGuardianRequest(

--- a/app/lib/server/applications/memberProvisioning.ts
+++ b/app/lib/server/applications/memberProvisioning.ts
@@ -20,7 +20,16 @@ export async function createAcceptedApplicantMember(
     applicationId: input.application._id,
     organizationId: input.organizationId,
   });
-  if (existing) return { isCreated: false, member: existing };
+  if (existing) {
+    if (existing.teamOnboardingStatus === "not_started") {
+      await userCollection.updateOne(
+        { _id: existing._id, teamOnboardingStatus: "not_started" },
+        { $set: { teamOnboardingStatus: "in_progress" } },
+      );
+      existing.teamOnboardingStatus = "in_progress";
+    }
+    return { isCreated: false, member: existing };
+  }
 
   const now = Date.now();
   const member: User = {
@@ -45,7 +54,7 @@ export async function createAcceptedApplicantMember(
     teamId: input.teamId,
     applicationId: input.application._id,
     memberStatus: "onboarding",
-    teamOnboardingStatus: "not_started",
+    teamOnboardingStatus: "in_progress",
     publicProfileSetupRequired: true,
     registeredAt: now,
   };

--- a/app/lib/server/memberships/accessClosure.ts
+++ b/app/lib/server/memberships/accessClosure.ts
@@ -3,7 +3,6 @@ import { memberships, users } from "../../db/collections";
 import type { Membership, User } from "../../db/types";
 import { suspendWorkspaceUser } from "../../googleWorkspace/membershipLifecycle";
 import { terminalMemberStatus } from "../../members/termination";
-import { notifyMemberStatusChange } from "../users/email";
 
 export async function syncEndedMembershipAccess(
   membership: Membership,
@@ -42,11 +41,6 @@ export async function syncEndedMembershipAccess(
     await users()
   ).updateOne({ _id: user._id, membershipId: membership._id }, update);
   if (projected.matchedCount !== 1) return;
-  await notifyMemberStatusChange({
-    user,
-    previous: user.memberStatus,
-    next: status,
-  });
   await (
     await memberships()
   ).updateOne(

--- a/app/lib/server/memberships/handover.ts
+++ b/app/lib/server/memberships/handover.ts
@@ -1,7 +1,6 @@
 import { memberships, users } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { HandoverTask, Membership, User } from "../../db/types";
-import { notifyMemberStatusChange } from "../users/email";
 import { appendMembershipEvent } from "./events";
 
 const HANDOVER_TASKS: Array<Pick<HandoverTask, "category" | "title">> = [
@@ -88,7 +87,7 @@ export async function ensureMembershipHandover(
         );
   if (!stored?.handoverStartedAt) return false;
 
-  const statusUpdate = await (
+  await (
     await users()
   ).updateOne(
     {
@@ -103,13 +102,6 @@ export async function ensureMembershipHandover(
       },
     },
   );
-  if (statusUpdate.modifiedCount === 1) {
-    await notifyMemberStatusChange({
-      user: member,
-      previous: member.memberStatus,
-      next: "offboarding_planned",
-    });
-  }
   await appendMembershipEvent({
     organizationId: membership.organizationId,
     membershipId: membership._id,

--- a/app/lib/server/reimbursementInvites/redemption.ts
+++ b/app/lib/server/reimbursementInvites/redemption.ts
@@ -7,7 +7,6 @@ import {
 } from "../../members/status";
 import { YFN_ORGANIZATION } from "../../organization";
 import { addLog } from "../logs";
-import { notifyMemberStatusChange } from "../users/email";
 import {
   hashReimbursementInviteToken,
   isReimbursementInviteToken,
@@ -72,9 +71,4 @@ export async function redeemReimbursementInvite(token: string): Promise<void> {
     invite._id,
     email,
   );
-  await notifyMemberStatusChange({
-    user,
-    previous: user.memberStatus,
-    next: "active",
-  });
 }

--- a/app/lib/server/users/creation.ts
+++ b/app/lib/server/users/creation.ts
@@ -10,7 +10,6 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { addLog } from "../logs";
 import { requireActiveOrganizationTeam } from "./access";
 import { phoneSchema, privateEmailSchema } from "./contactDetails";
-import { sendUserStateEmail } from "./email";
 import { provisionManualMemberWorkspace } from "./manualWorkspaceProvisioning";
 
 const MEMBER_EMAIL_CONFLICT_MESSAGE =
@@ -70,7 +69,7 @@ export async function createMember(input: CreateMemberInput): Promise<User> {
     teamId: memberInput.teamId,
     isTeamLead: memberInput.isTeamLead,
     memberStatus: "onboarding",
-    teamOnboardingStatus: "not_started",
+    teamOnboardingStatus: "in_progress",
     publicProfileSetupRequired: true,
     registeredAt: createdAt,
   };
@@ -118,10 +117,5 @@ export async function createMember(input: CreateMemberInput): Promise<User> {
     createdMember._id,
     `${memberInput.name} (${memberInput.email})`,
   );
-  await sendUserStateEmail({
-    user: createdMember,
-    event: "member_onboarding_started",
-  });
-
   return createdMember;
 }

--- a/app/lib/server/users/email.test.ts
+++ b/app/lib/server/users/email.test.ts
@@ -4,9 +4,7 @@ vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
 
 import { sendMail } from "../../email/brevo";
 import {
-  notifyMemberStatusChange,
   notifyTeamOnboardingChange,
-  sendUserStateEmail,
   sendWorkspaceAccountReadyEmail,
 } from "./email";
 
@@ -22,18 +20,7 @@ beforeEach(() => {
 });
 
 describe("user-state emails", () => {
-  it("does not send before the static Brevo ID is configured", async () => {
-    await sendUserStateEmail({ user, event: "member_activated" });
-
-    expect(sendMail).not.toHaveBeenCalled();
-  });
-
   it("emits only for actual state transitions", async () => {
-    await notifyMemberStatusChange({
-      user,
-      previous: "active",
-      next: "active",
-    });
     await notifyTeamOnboardingChange({
       user,
       previous: "not_started",
@@ -43,7 +30,33 @@ describe("user-state emails", () => {
     expect(sendMail).not.toHaveBeenCalled();
   });
 
-  it("supports a dedicated Workspace account email", async () => {
+  it("sends the onboarding-required template when onboarding starts", async () => {
+    await notifyTeamOnboardingChange({
+      user,
+      previous: "not_started",
+      next: "in_progress",
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: [{ email: "alex@example.com", name: "Alex Beispiel" }],
+        templateId: 171,
+        params: expect.objectContaining({ memberName: "Alex Beispiel" }),
+      }),
+    );
+  });
+
+  it("does not send a separate team onboarding completion email", async () => {
+    await notifyTeamOnboardingChange({
+      user,
+      previous: "in_progress",
+      next: "completed",
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends Workspace credentials with the resolved Brevo template", async () => {
     await sendWorkspaceAccountReadyEmail({
       recoveryEmail: "alex@example.com",
       applicantName: "Alex Beispiel",
@@ -52,6 +65,16 @@ describe("user-state emails", () => {
       loginUrl: "https://ybase.example/login",
     });
 
-    expect(sendMail).not.toHaveBeenCalled();
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateId: 172,
+        params: expect.objectContaining({
+          memberName: "Alex Beispiel",
+          workspaceEmail: "alex@youngfounders.network",
+          temporaryPassword: "temporary-password",
+          loginUrl: "https://ybase.example/login",
+        }),
+      }),
+    );
   });
 });

--- a/app/lib/server/users/email.ts
+++ b/app/lib/server/users/email.ts
@@ -1,27 +1,13 @@
-import type {
-  MemberStatus,
-  StoredMemberStatus,
-  TeamOnboardingStatus,
-  User,
-} from "../../db/types";
+import type { TeamOnboardingStatus, User } from "../../db/types";
 import { type EmailRecipient, sendMail } from "../../email/brevo";
 import {
-  type UserStateEmailEvent,
   USER_STATE_EMAIL_TEMPLATES,
+  type UserStateEmailEvent,
 } from "../../email/templates";
 import { appUrl } from "../../email/urls";
 import { YFN_ORGANIZATION } from "../../organization";
 
 type UserEmailProfile = Pick<User, "name" | "email" | "privateEmail">;
-
-const MEMBER_STATUS_EMAIL_EVENTS: Record<MemberStatus, UserStateEmailEvent> = {
-  onboarding: "member_onboarding_started",
-  active: "member_activated",
-  offboarding_planned: "member_offboarding_planned",
-  offboarding: "member_offboarding_started",
-  archived: "member_archived",
-  excluded: "member_excluded",
-};
 
 const TEAM_ONBOARDING_EMAIL_EVENTS: Record<
   TeamOnboardingStatus,
@@ -29,20 +15,8 @@ const TEAM_ONBOARDING_EMAIL_EVENTS: Record<
 > = {
   not_started: undefined,
   in_progress: "team_onboarding_started",
-  completed: "team_onboarding_completed",
+  completed: undefined,
 };
-
-export async function notifyMemberStatusChange(input: {
-  user: UserEmailProfile;
-  previous: StoredMemberStatus;
-  next: MemberStatus;
-}): Promise<void> {
-  if (input.previous === input.next) return;
-  await sendUserStateEmail({
-    user: input.user,
-    event: MEMBER_STATUS_EMAIL_EVENTS[input.next],
-  });
-}
 
 export async function notifyTeamOnboardingChange(input: {
   user: UserEmailProfile;
@@ -76,16 +50,36 @@ export async function sendWorkspaceAccountReadyEmail(input: {
   temporaryPassword: string;
   loginUrl: string;
 }): Promise<void> {
-  await sendConfiguredUserEmail(
-    "workspace_account_ready",
-    { email: input.recoveryEmail, name: input.applicantName },
-    {
+  const template = USER_STATE_EMAIL_TEMPLATES.workspace_account_ready;
+  const templateId = requireWorkspaceAccountReadyTemplateId();
+
+  const delivery = await sendMail({
+    to: [{ email: input.recoveryEmail, name: input.applicantName }],
+    templateId,
+    params: {
+      organizationName: YFN_ORGANIZATION.name,
+      ybaseUrl: safeAppUrl("/"),
       memberName: input.applicantName ?? "",
       workspaceEmail: input.workspaceEmail,
       temporaryPassword: input.temporaryPassword,
       loginUrl: input.loginUrl,
     },
-  );
+    tags: ["ybase", "user-state", template.tag],
+  });
+  if (delivery.status !== "sent") {
+    throw new Error("Google-Workspace-Zugang konnte nicht versendet werden");
+  }
+}
+
+export function requireWorkspaceAccountReadyTemplateId(): number {
+  const templateId =
+    USER_STATE_EMAIL_TEMPLATES.workspace_account_ready.templateId;
+  if (!templateId) {
+    throw new Error(
+      "Brevo-Template für Google-Workspace-Zugang ist nicht konfiguriert",
+    );
+  }
+  return templateId;
 }
 
 async function sendConfiguredUserEmail(

--- a/app/lib/server/users/infractions.ts
+++ b/app/lib/server/users/infractions.ts
@@ -7,7 +7,6 @@ import { newId } from "../../db/ids";
 import type { MemberInfraction, User } from "../../db/types";
 import { addLog } from "../logs";
 import { loadManagedMember } from "./access";
-import { notifyMemberStatusChange } from "./email";
 
 const MAX_INFRACTIONS = 2;
 const ELIGIBLE_STATUSES = ["active", "offboarding_planned"] as const;
@@ -88,11 +87,6 @@ export async function recordMemberInfraction(input: RecordInfractionInput) {
         `${target.name ?? target.email}: Verstoß ${infractionCount}/${MAX_INFRACTIONS}`,
       );
       if (memberExcluded) {
-        await notifyMemberStatusChange({
-          user: target,
-          previous: target.memberStatus,
-          next: "excluded",
-        });
         await addLog(
           currentUser.organizationId,
           currentUser._id,

--- a/app/lib/server/users/lifecycleActions.ts
+++ b/app/lib/server/users/lifecycleActions.ts
@@ -10,7 +10,7 @@ import {
   requireActiveOrganizationDepartment,
   requireActiveOrganizationTeam,
 } from "./access";
-import { notifyMemberStatusChange, notifyTeamOnboardingChange } from "./email";
+import { notifyTeamOnboardingChange } from "./email";
 import { memberStatusPatch, teamOnboardingPatch } from "./memberLifecycle";
 
 const memberStatusSchema = z.enum([
@@ -116,11 +116,6 @@ export async function setMemberStatus(input: {
     target._id,
     `${target.name ?? target.email}: ${target.memberStatus} → ${status}`,
   );
-  await notifyMemberStatusChange({
-    user: target,
-    previous: target.memberStatus,
-    next: status,
-  });
 }
 
 export async function setTeamOnboardingStatus(input: {

--- a/app/lib/server/users/manualWorkspaceProvisioning.test.ts
+++ b/app/lib/server/users/manualWorkspaceProvisioning.test.ts
@@ -1,13 +1,20 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
-vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
 vi.mock("../../googleWorkspace/users", () => ({
   provisionWorkspaceUser: vi.fn(),
 }));
+vi.mock("./email", () => ({
+  requireWorkspaceAccountReadyTemplateId: vi.fn(),
+  sendUserStateEmail: vi.fn(),
+  sendWorkspaceAccountReadyEmail: vi.fn(),
+}));
 
-import { sendMail } from "../../email/brevo";
-import { BREVO_TEMPLATE_IDS } from "../../email/templates";
 import { provisionWorkspaceUser } from "../../googleWorkspace/users";
+import {
+  requireWorkspaceAccountReadyTemplateId,
+  sendUserStateEmail,
+  sendWorkspaceAccountReadyEmail,
+} from "./email";
 import { provisionManualMemberWorkspace } from "./manualWorkspaceProvisioning";
 
 afterEach(() => vi.unstubAllEnvs());
@@ -20,10 +27,9 @@ beforeEach(() => {
     primaryEmail: "alex@youngfounders.network",
     temporaryPassword: "temporary-password",
   });
-  vi.mocked(sendMail).mockResolvedValue({
-    status: "sent",
-    messageId: "message-1",
-  });
+  vi.mocked(requireWorkspaceAccountReadyTemplateId).mockReturnValue(170);
+  vi.mocked(sendUserStateEmail).mockResolvedValue();
+  vi.mocked(sendWorkspaceAccountReadyEmail).mockResolvedValue();
 });
 
 test("creates a Workspace account and sends its credentials privately", async () => {
@@ -42,23 +48,30 @@ test("creates a Workspace account and sends its credentials privately", async ()
     givenName: "Alex",
     familyName: "Beispiel",
   });
-  expect(sendMail).toHaveBeenCalledWith(
-    expect.objectContaining({
-      to: [{ email: "alex@example.com", name: "Alex Beispiel" }],
-      templateId: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
-      subject: "Deine Zugangsdaten für YFN",
-      params: expect.objectContaining({
-        message: expect.stringContaining("temporary-password"),
-      }),
-    }),
-  );
+  expect(sendWorkspaceAccountReadyEmail).toHaveBeenCalledWith({
+    recoveryEmail: "alex@example.com",
+    applicantName: "Alex Beispiel",
+    workspaceEmail: "alex@youngfounders.network",
+    temporaryPassword: "temporary-password",
+    loginUrl: "https://ybase.example/login",
+  });
+  expect(sendUserStateEmail).toHaveBeenCalledWith({
+    user: {
+      name: "Alex Beispiel",
+      email: "alex@youngfounders.network",
+      privateEmail: "alex@example.com",
+    },
+    event: "team_onboarding_started",
+  });
+  expect(
+    vi.mocked(sendWorkspaceAccountReadyEmail).mock.invocationCallOrder[0],
+  ).toBeLessThan(vi.mocked(sendUserStateEmail).mock.invocationCallOrder[0]);
 });
 
-test.each([
-  { status: "skipped", reason: "disabled" } as const,
-  { status: "skipped", reason: "recipient-not-allowed" } as const,
-])("fails onboarding when credentials are not delivered", async (delivery) => {
-  vi.mocked(sendMail).mockResolvedValueOnce(delivery);
+test("fails onboarding when Workspace credentials are not delivered", async () => {
+  vi.mocked(sendWorkspaceAccountReadyEmail).mockRejectedValueOnce(
+    new Error("Google-Workspace-Zugang konnte nicht versendet werden"),
+  );
 
   await expect(
     provisionManualMemberWorkspace({
@@ -66,7 +79,26 @@ test.each([
       primaryEmail: "alex@youngfounders.network",
       privateEmail: "alex@example.com",
     }),
-  ).rejects.toThrow("Zugangsdaten konnten nicht versendet werden");
+  ).rejects.toThrow("Google-Workspace-Zugang konnte nicht versendet werden");
+});
+
+test("does not provision before the access template is configured", async () => {
+  vi.mocked(requireWorkspaceAccountReadyTemplateId).mockImplementationOnce(
+    () => {
+      throw new Error(
+        "Brevo-Template für Google-Workspace-Zugang ist nicht konfiguriert",
+      );
+    },
+  );
+
+  await expect(
+    provisionManualMemberWorkspace({
+      name: "Alex Beispiel",
+      primaryEmail: "alex@youngfounders.network",
+      privateEmail: "alex@example.com",
+    }),
+  ).rejects.toThrow("nicht konfiguriert");
+  expect(provisionWorkspaceUser).not.toHaveBeenCalled();
 });
 
 test("validates the login URL before creating the account", async () => {

--- a/app/lib/server/users/manualWorkspaceProvisioning.ts
+++ b/app/lib/server/users/manualWorkspaceProvisioning.ts
@@ -1,9 +1,10 @@
-import { appendWorkspaceAccessDetails } from "../../applications/decisionEmail";
-import { sendMail } from "../../email/brevo";
-import { BREVO_TEMPLATE_IDS } from "../../email/templates";
 import { appUrl } from "../../email/urls";
 import { provisionWorkspaceUser } from "../../googleWorkspace/users";
-import { YFN_ORGANIZATION } from "../../organization";
+import {
+  requireWorkspaceAccountReadyTemplateId,
+  sendUserStateEmail,
+  sendWorkspaceAccountReadyEmail,
+} from "./email";
 
 interface ManualWorkspaceProvisioningInput {
   name: string;
@@ -14,6 +15,7 @@ interface ManualWorkspaceProvisioningInput {
 export async function provisionManualMemberWorkspace(
   input: ManualWorkspaceProvisioningInput,
 ): Promise<{ userId: string }> {
+  requireWorkspaceAccountReadyTemplateId();
   const loginUrl = appUrl("/login");
   const { givenName, familyName } = workspaceMemberName(
     input.name,
@@ -26,27 +28,21 @@ export async function provisionManualMemberWorkspace(
     givenName,
     familyName,
   });
-  const message = appendWorkspaceAccessDetails({
-    message: `Hey ${givenName},\n\nwillkommen bei ${YFN_ORGANIZATION.name}. Dein Google-Workspace-Konto wurde für dein Onboarding eingerichtet.`,
-    primaryEmail: account.primaryEmail,
+  await sendWorkspaceAccountReadyEmail({
+    recoveryEmail: input.privateEmail,
+    applicantName: input.name,
+    workspaceEmail: account.primaryEmail,
     temporaryPassword: account.temporaryPassword,
     loginUrl,
   });
-  const delivery = await sendMail({
-    to: [{ email: input.privateEmail, name: input.name }],
-    templateId: BREVO_TEMPLATE_IDS.APPLICATION_ACCEPTED,
-    subject: "Deine Zugangsdaten für YFN",
-    params: {
-      applicantName: input.name,
-      jobTitle: "Mitglied",
-      organizationName: YFN_ORGANIZATION.name,
-      message,
+  await sendUserStateEmail({
+    user: {
+      name: input.name,
+      email: input.primaryEmail,
+      privateEmail: input.privateEmail,
     },
-    tags: ["ybase", "member", "manual-onboarding"],
+    event: "team_onboarding_started",
   });
-  if (delivery.status !== "sent") {
-    throw new Error("Zugangsdaten konnten nicht versendet werden");
-  }
 
   return { userId: account.userId };
 }

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -176,7 +176,7 @@ test("createMember starts a member in onboarding and writes a log", async () => 
     teamId: "manual-team",
     isTeamLead: true,
     memberStatus: "onboarding",
-    teamOnboardingStatus: "not_started",
+    teamOnboardingStatus: "in_progress",
     publicProfileSetupRequired: true,
     googleWorkspaceUserId: "google-manual-member",
   });


### PR DESCRIPTION
## Summary
- Wire the verified Brevo templates for team onboarding and Google Workspace credentials.
- Send acceptance, Workspace access, and onboarding instructions as separate messages while starting onboarding automatically.
- Remove automatic member lifecycle notifications and fail safely when the guardian-consent template is unavailable.
- Record failed Workspace credential delivery for reliable retries.

## Validation
- `pnpm exec tsc --noEmit`
- 13 focused Vitest files, 90 tests passed; final decision-flow regression test passed with 8 tests
- Biome, Prettier, and `git diff --check` passed