### PR TITLE
feat(recruiting): search admission profiles by applicant name

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -23,16 +23,17 @@ export function ApplicationAdmissionProfile({
 }) {
   if (!hasProfile || !dateOfBirth) {
     return (
-      <div className="space-y-3 rounded-lg border border-destructive/40 p-4">
-        <p className="text-sm text-destructive">
-          Über die private Bewerbungs-E-Mail wurde noch kein eindeutiges,
-          aktives Member-Plattform-Profil mit Geburtsdatum gefunden.
+      <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+        <p className="text-sm text-muted-foreground">
+          Noch kein Member-Plattform-Profil zugeordnet. Die Suche verwendet
+          zuerst den Namen aus der Bewerbung und die private E-Mail nur zur
+          Eingrenzung.
         </p>
         {canSync ? (
           <SyncButton
             isPending={isPending}
             isSyncing={isSyncing}
-            label="Member-Plattform erneut prüfen"
+            label="Profil erneut suchen"
             onSync={onSync}
           />
         ) : null}

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -44,10 +44,10 @@ export function ApplicationAdmissionRequirements({
       });
       toast.success("Member-Plattform-Profil synchronisiert");
     } catch (error) {
-      toast.error(
+      toast(
         error instanceof Error
           ? error.message
-          : "Member-Plattform-Profil konnte nicht synchronisiert werden",
+          : "Member-Plattform-Profil konnte nicht gefunden werden",
       );
     }
   }

--- a/app/lib/server/applications/admissionRequirements.test.ts
+++ b/app/lib/server/applications/admissionRequirements.test.ts
@@ -111,6 +111,93 @@ test("imports the birth date from one eligible member-platform profile", async (
   ).not.toHaveProperty("guardianConsent");
 });
 
+test("prefers an exact applicant name when the private email differs", async () => {
+  await Promise.all([
+    insertPlatformProfile({
+      id: "platform-name-match",
+      email: "new-address@example.com",
+      birthDate: "2004-01-01T00:00:00.000Z",
+    }),
+    insertPlatformProfile({
+      id: "platform-email-match",
+      email: "alex@example.com",
+      birthDate: "2003-01-01T00:00:00.000Z",
+      firstName: "Andere",
+      lastName: "Person",
+    }),
+  ]);
+
+  await syncApplicationMemberPlatformProfile({
+    applicationId: application._id,
+  });
+
+  expect(
+    await (await applications()).findOne({ _id: application._id }),
+  ).toMatchObject({
+    dateOfBirth: "2004-01-01",
+    memberPlatformUserId: "platform-name-match",
+  });
+});
+
+test("uses the private email to disambiguate identical names", async () => {
+  await Promise.all([
+    insertPlatformProfile({
+      id: "platform-other-alex",
+      email: "other@example.com",
+      birthDate: "2003-01-01T00:00:00.000Z",
+    }),
+    insertPlatformProfile({
+      id: "platform-applicant",
+      email: "alex@example.com",
+      birthDate: "2004-01-01T00:00:00.000Z",
+    }),
+  ]);
+
+  await syncApplicationMemberPlatformProfile({
+    applicationId: application._id,
+  });
+
+  expect(
+    await (await applications()).findOne({ _id: application._id }),
+  ).toMatchObject({
+    dateOfBirth: "2004-01-01",
+    memberPlatformUserId: "platform-applicant",
+  });
+});
+
+test("falls back to the private email when the application has no name", async () => {
+  await insertPlatformProfile({
+    id: "platform-email-fallback",
+    email: "alex@example.com",
+    birthDate: "2004-01-01T00:00:00.000Z",
+    firstName: "Andere",
+    lastName: "Person",
+  });
+  await (
+    await applications()
+  ).updateOne({ _id: application._id }, { $unset: { applicantName: "" } });
+
+  await syncApplicationMemberPlatformProfile({
+    applicationId: application._id,
+  });
+
+  expect(
+    await (await applications()).findOne({ _id: application._id }),
+  ).toMatchObject({ memberPlatformUserId: "platform-email-fallback" });
+});
+
+test("reports the email fallback when an application has no name", async () => {
+  await (
+    await applications()
+  ).updateOne({ _id: application._id }, { $unset: { applicantName: "" } });
+
+  await expect(
+    syncApplicationMemberPlatformProfile({
+      applicationId: application._id,
+    }),
+  ).rejects.toThrow("private Bewerbungs-E-Mail");
+});
+
 test("sends a secure guardian link and stores only its hash", async () => {
   await seedMemberPlatformSnapshot("2009-01-01");
   await requestGuardianConsent({
@@ -176,7 +263,7 @@ test("rejects synchronization without one matching active profile", async () => 
     syncApplicationMemberPlatformProfile({
       applicationId: application._id,
     }),
-  ).rejects.toThrow("Kein eindeutiges");
+  ).rejects.toThrow("mit dem Namen");
   expect(
     await (await applications()).findOne({ _id: application._id }),
   ).not.toHaveProperty("dateOfBirth");
@@ -200,7 +287,7 @@ test("rejects ambiguous member-platform profiles with the same email", async () 
     syncApplicationMemberPlatformProfile({
       applicationId: application._id,
     }),
-  ).rejects.toThrow("Kein eindeutiges");
+  ).rejects.toThrow("Mehrere aktive");
 });
 
 test("checks every matching profile before accepting a unique claim", async () => {
@@ -222,7 +309,7 @@ test("checks every matching profile before accepting a unique claim", async () =
     syncApplicationMemberPlatformProfile({
       applicationId: application._id,
     }),
-  ).rejects.toThrow("Kein eindeutiges");
+  ).rejects.toThrow("Mehrere aktive");
 });
 
 async function seedMemberPlatformSnapshot(dateOfBirth: string): Promise<void> {
@@ -239,6 +326,8 @@ async function insertPlatformProfile(input: {
   email: string;
   birthDate: string;
   state?: string;
+  firstName?: string;
+  lastName?: string;
 }): Promise<void> {
   const database = (await getClient()).db(PLATFORM_DATABASE);
   await Promise.all([
@@ -246,8 +335,8 @@ async function insertPlatformProfile(input: {
       id: input.id,
       deletedAt: null,
       person: {
-        firstName: "Alex",
-        lastName: "Beispiel",
+        firstName: input.firstName ?? "Alex",
+        lastName: input.lastName ?? "Beispiel",
         birthDate: input.birthDate,
       },
       contact: { email: input.email },

--- a/app/lib/server/applications/admissionRequirements.ts
+++ b/app/lib/server/applications/admissionRequirements.ts
@@ -20,9 +20,10 @@ export async function syncApplicationMemberPlatformProfile(input: {
     parsed.applicationId,
   );
   assertRequirementsEditable(application);
-  const snapshot = await findApplicationMemberPlatformProfile(
-    application.applicantEmailNormalized,
-  );
+  const snapshot = await findApplicationMemberPlatformProfile({
+    applicantName: application.applicantName,
+    privateEmail: application.applicantEmailNormalized,
+  });
   const unchanged =
     application.memberPlatformUserId === snapshot.memberPlatformUserId &&
     application.dateOfBirth === snapshot.dateOfBirth;

--- a/app/lib/server/applications/ingest.ts
+++ b/app/lib/server/applications/ingest.ts
@@ -100,9 +100,10 @@ export async function ingestTallySubmission(
     return { status: "ignored", reason: "missing-phone" };
   }
 
-  const memberPlatformSnapshot = await tryFindApplicationMemberPlatformProfile(
-    parsed.emailNormalized,
-  );
+  const memberPlatformSnapshot = await tryFindApplicationMemberPlatformProfile({
+    applicantName: parsed.name,
+    privateEmail: parsed.emailNormalized,
+  });
   const withdrawal = createApplicationWithdrawalToken();
 
   const application: Application = {

--- a/app/lib/server/applications/memberPlatformAdmission.ts
+++ b/app/lib/server/applications/memberPlatformAdmission.ts
@@ -1,6 +1,9 @@
 import type { Db } from "mongodb";
-import type { MemberPlatformProfile } from "../../memberPlatform/suggestions";
-import { normalizeEmail } from "../../memberPlatform/suggestions";
+import {
+  type MemberPlatformProfile,
+  normalizeEmail,
+  normalizeName,
+} from "../../memberPlatform/suggestions";
 import { LINKABLE_MEMBER_PLATFORM_STATES } from "../../memberPlatform/states";
 import { ageOnDate } from "../../members/legalDates";
 import { getMemberPlatformDb } from "../memberPlatform/client";
@@ -15,30 +18,39 @@ type Resolution =
   | { snapshot: ApplicationMemberPlatformSnapshot }
   | { error: string };
 
-const NOT_FOUND_ERROR =
-  "Kein eindeutiges, aktives Member-Plattform-Profil für die private Bewerbungs-E-Mail gefunden.";
+const NAME_NOT_FOUND_ERROR =
+  "Kein aktives Member-Plattform-Profil mit dem Namen aus der Bewerbung gefunden.";
+const EMAIL_NOT_FOUND_ERROR =
+  "Kein aktives Member-Plattform-Profil für die private Bewerbungs-E-Mail gefunden.";
+const AMBIGUOUS_ERROR =
+  "Mehrere aktive Member-Plattform-Profile mit diesem Namen gefunden. Die private Bewerbungs-E-Mail konnte sie nicht eindeutig unterscheiden.";
 const BIRTH_DATE_ERROR =
   "Das Member-Plattform-Profil enthält kein gültiges Geburtsdatum.";
 
+interface ApplicationProfileLookup {
+  applicantName?: string;
+  privateEmail: string;
+}
+
 export async function findApplicationMemberPlatformProfile(
-  privateEmail: string,
+  lookup: ApplicationProfileLookup,
 ): Promise<ApplicationMemberPlatformSnapshot> {
   const database = await getMemberPlatformDb();
   if (!database) {
     throw new Error("Die Member-Plattform ist nicht konfiguriert.");
   }
-  const resolution = await resolveProfile(database, privateEmail);
+  const resolution = await resolveProfile(database, lookup);
   if ("error" in resolution) throw new Error(resolution.error);
   return resolution.snapshot;
 }
 
 export async function tryFindApplicationMemberPlatformProfile(
-  privateEmail: string,
+  lookup: ApplicationProfileLookup,
 ): Promise<ApplicationMemberPlatformSnapshot | undefined> {
   try {
     const database = await getMemberPlatformDb();
     if (!database) return undefined;
-    const resolution = await resolveProfile(database, privateEmail);
+    const resolution = await resolveProfile(database, lookup);
     return "snapshot" in resolution ? resolution.snapshot : undefined;
   } catch (error) {
     console.error("member-platform application snapshot failed", error);
@@ -48,20 +60,30 @@ export async function tryFindApplicationMemberPlatformProfile(
 
 async function resolveProfile(
   database: Db,
-  privateEmail: string,
+  lookup: ApplicationProfileLookup,
 ): Promise<Resolution> {
-  const email = normalizeEmail(privateEmail);
+  const email = normalizeEmail(lookup.privateEmail);
+  const nameQueries = buildNameQueries(lookup.applicantName);
+  const candidateQueries = [
+    ...nameQueries,
+    ...(email ? [{ "contact.email": email }] : []),
+  ];
+  const notFoundError =
+    nameQueries.length > 0 ? NAME_NOT_FOUND_ERROR : EMAIL_NOT_FOUND_ERROR;
+  if (candidateQueries.length === 0) return { error: notFoundError };
+
   const profiles = await database
     .collection<MemberPlatformProfile>("users")
-    .find({ deletedAt: null, "contact.email": email })
-    .collation({ locale: "en", strength: 2 })
+    .find({ deletedAt: null, $or: candidateQueries })
+    .collation({ locale: "de", strength: 1 })
     .project<MemberPlatformProfile>({
       _id: 0,
       id: 1,
       person: 1,
+      contact: 1,
     })
     .toArray();
-  if (profiles.length === 0) return { error: NOT_FOUND_ERROR };
+  if (profiles.length === 0) return { error: notFoundError };
 
   const states = await database
     .collection("user-states")
@@ -73,9 +95,13 @@ async function resolveProfile(
     .toArray();
   const eligibleIds = new Set(states.map(({ userId }) => userId));
   const eligibleProfiles = profiles.filter(({ id }) => eligibleIds.has(id));
-  if (eligibleProfiles.length !== 1) return { error: NOT_FOUND_ERROR };
+  const profile = selectProfile(eligibleProfiles, lookup);
+  if (!profile) {
+    return {
+      error: eligibleProfiles.length > 1 ? AMBIGUOUS_ERROR : notFoundError,
+    };
+  }
 
-  const profile = eligibleProfiles[0];
   const dateOfBirth = normalizeBirthDate(profile.person?.birthDate);
   if (!dateOfBirth) return { error: BIRTH_DATE_ERROR };
   return {
@@ -85,6 +111,51 @@ async function resolveProfile(
       dateOfBirth,
     },
   };
+}
+
+function buildNameQueries(
+  applicantName?: string,
+): Array<Record<string, string>> {
+  const parts = applicantName?.trim().split(/\s+/).filter(Boolean) ?? [];
+  const queries: Array<Record<string, string>> = [];
+  for (let splitAt = 1; splitAt < parts.length; splitAt += 1) {
+    queries.push({
+      "person.firstName": parts.slice(0, splitAt).join(" "),
+      "person.lastName": parts.slice(splitAt).join(" "),
+    });
+  }
+  return queries;
+}
+
+function selectProfile(
+  profiles: MemberPlatformProfile[],
+  lookup: ApplicationProfileLookup,
+): MemberPlatformProfile | undefined {
+  const name = normalizeName(lookup.applicantName);
+  const email = normalizeEmail(lookup.privateEmail);
+  const nameMatches = name
+    ? profiles.filter(
+        (profile) =>
+          normalizeName(
+            [profile.person?.firstName, profile.person?.lastName]
+              .filter(Boolean)
+              .join(" "),
+          ) === name,
+      )
+    : [];
+
+  if (nameMatches.length === 1) return nameMatches[0];
+  if (nameMatches.length > 1) {
+    const emailMatches = nameMatches.filter(
+      (profile) => normalizeEmail(profile.contact?.email) === email,
+    );
+    return emailMatches.length === 1 ? emailMatches[0] : undefined;
+  }
+
+  const emailMatches = profiles.filter(
+    (profile) => normalizeEmail(profile.contact?.email) === email,
+  );
+  return emailMatches.length === 1 ? emailMatches[0] : undefined;
 }
 
 function normalizeBirthDate(value: string | Date | undefined): string | null {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -260,16 +260,18 @@ being duplicated on the membership.
 Onboarding then uses the existing `users.memberStatus`: `onboarding` while the
 member confirms personal data and completes required acknowledgements, then
 `active`. Before admission, YBase resolves exactly one active member-platform
-profile from the private application email and stores its external ID,
-birth-date snapshot and sync time on the application. The birth date is not
-collected again in YBase. A missing or ambiguous profile blocks admission; a
-free global profile search is not exposed. The accepted onboarding user
-inherits the confirmed external ID. All document executions reference the
-membership directly. Individual tasks determine progress without introducing
-a second aggregate operational status. Current board authorization continues
-to use `users.boardMembership`; there is no parallel mandate collection. The
-internal `memberships.legalStatus` supports legal workflows but is not displayed
-as a parallel lifecycle:
+profile primarily from the applicant name. The private application email only
+disambiguates people with the same name and remains a fallback for applications
+without a usable name. YBase stores the profile's external ID, birth-date
+snapshot and sync time on the application; the birth date is not a search
+criterion and is not collected again in YBase. A missing or ambiguous profile
+blocks admission; a free global profile search is not exposed. The accepted
+onboarding user inherits the confirmed external ID. All document executions
+reference the membership directly. Individual tasks determine progress without
+introducing a second aggregate operational status. Current board authorization
+continues to use `users.boardMembership`; there is no parallel mandate
+collection. The internal `memberships.legalStatus` supports legal workflows but
+is not displayed as a parallel lifecycle:
 
 The existing YBase profile linker remains available only to legacy users
 without `membershipId` and exposes at most one unambiguous suggestion. Once a


### PR DESCRIPTION
## summary

- Match active member-platform profiles by applicant name, using the private email only to disambiguate or as a fallback.
- Present missing matches as a neutral search state and document the lookup contract.

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed TypeScript files>`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/server/applications/admissionRequirements.test.ts app/lib/server/applications/ingest.test.ts` (28 passed)
- `pnpm build` not run (repo-wide and expensive)