### PR TITLE
feat(recruiting): add atlas member profile selection

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -1,40 +1,46 @@
-import { RefreshCw } from "lucide-react";
+import { Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { ApplicationMemberPlatformCandidate } from "@/lib/server/applications/memberPlatformCandidates";
 import { formatFieldValue } from "./applicationPresentation";
+
+interface ApplicationAdmissionProfileProps {
+  dateOfBirth?: string;
+  hasProfile: boolean;
+  isEligible: boolean;
+  canSync: boolean;
+  candidates: ApplicationMemberPlatformCandidate[] | null;
+  isPending: boolean;
+  isSigned: boolean;
+  isSearching: boolean;
+  selectingProfileId?: string;
+  onSearch: () => void;
+  onSelect: (profileId: string) => void;
+}
 
 export function ApplicationAdmissionProfile({
   dateOfBirth,
   hasProfile,
   isEligible,
   canSync,
+  candidates,
   isPending,
   isSigned,
-  isSyncing,
-  onSync,
-}: {
-  dateOfBirth?: string;
-  hasProfile: boolean;
-  isEligible: boolean;
-  canSync: boolean;
-  isPending: boolean;
-  isSigned: boolean;
-  isSyncing: boolean;
-  onSync: () => void;
-}) {
+  isSearching,
+  selectingProfileId,
+  onSearch,
+  onSelect,
+}: ApplicationAdmissionProfileProps) {
   if (!hasProfile || !dateOfBirth) {
     return (
       <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-        <p className="text-sm text-muted-foreground">
-          Noch kein Member-Plattform-Profil zugeordnet. Die Suche verwendet
-          zuerst den Namen aus der Bewerbung und die private E-Mail nur zur
-          Eingrenzung.
-        </p>
         {canSync ? (
-          <SyncButton
+          <ProfileSearch
+            candidates={candidates}
             isPending={isPending}
-            isSyncing={isSyncing}
-            label="Profil erneut suchen"
-            onSync={onSync}
+            isSearching={isSearching}
+            selectingProfileId={selectingProfileId}
+            onSearch={onSearch}
+            onSelect={onSelect}
           />
         ) : null}
       </div>
@@ -46,9 +52,6 @@ export function ApplicationAdmissionProfile({
       <div className="space-y-1">
         <p className="text-sm font-medium">Geburtsdatum</p>
         <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
-        <p className="text-xs text-muted-foreground">
-          Aus dem eindeutig zugeordneten Member-Plattform-Profil übernommen.
-        </p>
       </div>
       {isEligible ? (
         <p className="text-sm text-green-700">
@@ -61,42 +64,98 @@ export function ApplicationAdmissionProfile({
         </p>
       )}
       {canSync && !isSigned ? (
-        <SyncButton
-          compact
+        <ProfileSearch
+          candidates={candidates}
           isPending={isPending}
-          isSyncing={isSyncing}
-          label="Daten erneut laden"
-          onSync={onSync}
+          isSearching={isSearching}
+          selectingProfileId={selectingProfileId}
+          onSearch={onSearch}
+          onSelect={onSelect}
         />
       ) : null}
     </div>
   );
 }
 
-function SyncButton({
-  compact,
+function ProfileSearch({
+  candidates,
   isPending,
-  isSyncing,
-  label,
-  onSync,
+  isSearching,
+  selectingProfileId,
+  onSearch,
+  onSelect,
 }: {
-  compact?: boolean;
+  candidates: ApplicationMemberPlatformCandidate[] | null;
   isPending: boolean;
-  isSyncing: boolean;
-  label: string;
-  onSync: () => void;
+  isSearching: boolean;
+  selectingProfileId?: string;
+  onSearch: () => void;
+  onSelect: (profileId: string) => void;
 }) {
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size={compact ? "sm" : "member"}
-      className={compact ? undefined : "w-full"}
-      disabled={isPending}
-      onClick={onSync}
-    >
-      <RefreshCw className={isSyncing ? "size-4 animate-spin" : "size-4"} />
-      {label}
-    </Button>
+    <div className="space-y-3">
+      <Button
+        type="button"
+        variant="outline"
+        size="member"
+        className="w-full"
+        disabled={isPending}
+        aria-busy={isSearching}
+        onClick={onSearch}
+      >
+        <RefreshCw
+          aria-hidden="true"
+          className={isSearching ? "size-4 animate-spin" : "size-4"}
+        />
+        {candidates === null ? "Member-Profile suchen" : "Suche aktualisieren"}
+      </Button>
+
+      {candidates === null ? null : candidates.length > 0 ? (
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">
+            Passendes Profil auswählen
+          </legend>
+          <ul className="space-y-2">
+            {candidates.map((candidate) => (
+              <li key={candidate.id}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="member"
+                  className="h-auto w-full justify-start whitespace-normal px-4 text-left"
+                  disabled={isPending}
+                  aria-label={`${candidate.name} als Member-Profil zuordnen`}
+                  onClick={() => onSelect(candidate.id)}
+                >
+                  <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+                    <span className="font-semibold">{candidate.name}</span>
+                    {candidate.email ? (
+                      <span className="break-all text-xs font-normal text-muted-foreground">
+                        {candidate.email}
+                      </span>
+                    ) : null}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      Geburtsdatum:{" "}
+                      {formatFieldValue(candidate.dateOfBirth, "INPUT_DATE")}
+                    </span>
+                  </span>
+                  {selectingProfileId === candidate.id ? (
+                    <Loader2
+                      aria-hidden="true"
+                      className="size-4 animate-spin"
+                    />
+                  ) : null}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Kein aktives Member-Profil gefunden. Vor der Aufnahme muss die Person
+          eines erstellen.
+        </p>
+      )}
+    </div>
   );
 }

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -18,8 +18,11 @@ export function ApplicationAdmissionRequirements({
 }: {
   application: ApplicationWithFiles;
 }) {
-  const { syncMemberPlatformProfile, requestGuardianConsent } =
-    useApplicationMutations();
+  const {
+    searchMemberPlatformProfiles,
+    selectMemberPlatformProfile,
+    requestGuardianConsent,
+  } = useApplicationMutations();
   const [representativeName, setRepresentativeName] = useState(
     application.guardianConsent?.representativeName ?? "",
   );
@@ -33,22 +36,31 @@ export function ApplicationAdmissionRequirements({
   const isEligible = age !== null && age >= 16 && age < 25;
   const consent = application.guardianConsent;
   const pending =
-    syncMemberPlatformProfile.isPending || requestGuardianConsent.isPending;
+    searchMemberPlatformProfiles.isPending ||
+    selectMemberPlatformProfile.isPending ||
+    requestGuardianConsent.isPending;
   const isEditable = EDITABLE_STATUSES.has(application.status);
   if (application.status === "rejected") return null;
 
-  async function syncProfile() {
+  async function searchProfiles() {
     try {
-      await syncMemberPlatformProfile.mutateAsync({
+      await searchMemberPlatformProfiles.mutateAsync({
         applicationId: application._id,
       });
-      toast.success("Member-Plattform-Profil synchronisiert");
-    } catch (error) {
-      toast(
-        error instanceof Error
-          ? error.message
-          : "Member-Plattform-Profil konnte nicht gefunden werden",
-      );
+    } catch {
+      toast.error("Member-Profile konnten nicht geladen werden.");
+    }
+  }
+
+  async function selectProfile(profileId: string) {
+    try {
+      await selectMemberPlatformProfile.mutateAsync({
+        applicationId: application._id,
+        profileId,
+      });
+      toast.success("Member-Profil zugeordnet");
+    } catch {
+      toast.error("Member-Profil konnte nicht zugeordnet werden.");
     }
   }
 
@@ -74,13 +86,20 @@ export function ApplicationAdmissionRequirements({
       <h3 className="text-xl font-semibold">Aufnahmevoraussetzungen</h3>
       <ApplicationAdmissionProfile
         canSync={isEditable}
+        candidates={searchMemberPlatformProfiles.data ?? null}
         dateOfBirth={dateOfBirth}
         hasProfile={hasProfile}
         isEligible={isEligible}
         isPending={pending}
         isSigned={Boolean(consent?.signedAt)}
-        isSyncing={syncMemberPlatformProfile.isPending}
-        onSync={syncProfile}
+        isSearching={searchMemberPlatformProfiles.isPending}
+        selectingProfileId={
+          selectMemberPlatformProfile.isPending
+            ? selectMemberPlatformProfile.variables?.profileId
+            : undefined
+        }
+        onSearch={searchProfiles}
+        onSelect={selectProfile}
       />
       {hasProfile && isEligible && isMinor ? (
         <div className="space-y-4 rounded-lg border p-4">

--- a/app/lib/client/applications/hooks/useApplicationMutations.ts
+++ b/app/lib/client/applications/hooks/useApplicationMutations.ts
@@ -1,9 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { submitApplicationDecision } from "@/lib/server/applications/decisionAction";
+import { requestGuardianConsent } from "@/lib/server/applications/admissionRequirements";
 import {
-  requestGuardianConsent,
-  syncApplicationMemberPlatformProfile,
-} from "@/lib/server/applications/admissionRequirements";
+  searchApplicationMemberPlatformProfilesAction,
+  selectApplicationMemberPlatformProfileAction,
+} from "@/lib/server/applications/admissionRequirementsAction";
 import { setApplicationStatus } from "@/lib/server/applications/status";
 
 export function useApplicationMutations() {
@@ -30,8 +31,30 @@ export function useApplicationMutations() {
         }
       },
     }),
-    syncMemberPlatformProfile: useMutation({
-      mutationFn: syncApplicationMemberPlatformProfile,
+    searchMemberPlatformProfiles: useMutation({
+      mutationFn: async (
+        input: Parameters<
+          typeof searchApplicationMemberPlatformProfilesAction
+        >[0],
+      ) => {
+        const result =
+          await searchApplicationMemberPlatformProfilesAction(input);
+        if (!result.ok)
+          throw new Error("Member-Profile konnten nicht geladen werden.");
+        return result.candidates;
+      },
+    }),
+    selectMemberPlatformProfile: useMutation({
+      mutationFn: async (
+        input: Parameters<
+          typeof selectApplicationMemberPlatformProfileAction
+        >[0],
+      ) => {
+        const result =
+          await selectApplicationMemberPlatformProfileAction(input);
+        if (!result.ok)
+          throw new Error("Member-Profil konnte nicht zugeordnet werden.");
+      },
       onSuccess: invalidate,
     }),
     requestGuardianConsent: useMutation({

--- a/app/lib/server/applications/admissionRequirements.test.ts
+++ b/app/lib/server/applications/admissionRequirements.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
 vi.mock("../../email/brevo", () => ({ sendMail: vi.fn() }));
+vi.mock("./memberPlatformAtlasSearch", () => ({
+  searchMemberPlatformProfilesWithAtlas: vi.fn(),
+}));
 vi.mock("../../email/templates", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../email/templates")>();
   return {
@@ -26,6 +29,11 @@ import {
   requestGuardianConsent,
   syncApplicationMemberPlatformProfile,
 } from "./admissionRequirements";
+import {
+  searchApplicationMemberPlatformProfilesAction,
+  selectApplicationMemberPlatformProfileAction,
+} from "./admissionRequirementsAction";
+import { searchMemberPlatformProfilesWithAtlas } from "./memberPlatformAtlasSearch";
 
 const now = Date.parse("2026-07-31T10:00:00Z");
 const PLATFORM_DATABASE = "application_admission_requirements_test";
@@ -37,6 +45,7 @@ beforeEach(async () => {
   vi.useFakeTimers();
   vi.setSystemTime(now);
   vi.clearAllMocks();
+  vi.mocked(searchMemberPlatformProfilesWithAtlas).mockResolvedValue([]);
   vi.stubEnv("MEMBER_PLATFORM_MONGODB_DB", PLATFORM_DATABASE);
   await (await getClient()).db(PLATFORM_DATABASE).dropDatabase();
   const organizationId = newId();
@@ -70,6 +79,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
   vi.unstubAllEnvs();
 });
@@ -80,6 +90,17 @@ test("imports the birth date from one eligible member-platform profile", async (
     email: "ALEX@example.com",
     birthDate: "2004-01-01T00:00:00.000Z",
   });
+  vi.mocked(searchMemberPlatformProfilesWithAtlas).mockResolvedValue([
+    {
+      id: "platform-adult",
+      person: {
+        firstName: "Alex",
+        lastName: "Beispiel",
+        birthDate: "2004-01-01T00:00:00.000Z",
+      },
+      contact: { email: "ALEX@example.com" },
+    },
+  ]);
   await (
     await applications()
   ).updateOne(
@@ -95,9 +116,12 @@ test("imports the birth date from one eligible member-platform profile", async (
       },
     },
   );
-  await syncApplicationMemberPlatformProfile({
-    applicationId: application._id,
-  });
+  await expect(
+    selectApplicationMemberPlatformProfileAction({
+      applicationId: application._id,
+      profileId: "platform-adult",
+    }),
+  ).resolves.toEqual({ ok: true });
 
   expect(
     await (await applications()).findOne({ _id: application._id }),
@@ -258,15 +282,76 @@ test("restores the previous request when email delivery fails", async () => {
   });
 });
 
-test("rejects synchronization without one matching active profile", async () => {
+test("returns no candidates when no active member profile matches", async () => {
   await expect(
-    syncApplicationMemberPlatformProfile({
+    searchApplicationMemberPlatformProfilesAction({
       applicationId: application._id,
     }),
-  ).rejects.toThrow("mit dem Namen");
+  ).resolves.toEqual({ ok: true, candidates: [] });
   expect(
     await (await applications()).findOne({ _id: application._id }),
   ).not.toHaveProperty("dateOfBirth");
+});
+
+test("returns a safe result when Atlas Search fails", async () => {
+  const error = new Error("Atlas Search failed");
+  vi.mocked(searchMemberPlatformProfilesWithAtlas).mockRejectedValue(error);
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  await expect(
+    searchApplicationMemberPlatformProfilesAction({
+      applicationId: application._id,
+    }),
+  ).resolves.toEqual({ ok: false });
+  expect(consoleError).toHaveBeenCalledWith(
+    "application member profile search failed",
+    error,
+  );
+});
+
+test("returns candidates from Atlas Search", async () => {
+  vi.mocked(searchMemberPlatformProfilesWithAtlas).mockResolvedValue([
+    {
+      id: "platform-exact",
+      person: {
+        firstName: "Alex",
+        lastName: "Beispiel",
+        birthDate: "2004-01-01T00:00:00.000Z",
+      },
+      contact: { email: "alex@example.com" },
+    },
+    {
+      id: "platform-partial",
+      person: {
+        firstName: "Alexander",
+        lastName: "Beispiel",
+        birthDate: "2003-02-02T00:00:00.000Z",
+      },
+      contact: { email: "anderer@example.com" },
+    },
+  ]);
+
+  await expect(
+    searchApplicationMemberPlatformProfilesAction({
+      applicationId: application._id,
+    }),
+  ).resolves.toEqual({
+    ok: true,
+    candidates: [
+      {
+        id: "platform-exact",
+        name: "Alex Beispiel",
+        email: "alex@example.com",
+        dateOfBirth: "2004-01-01",
+      },
+      {
+        id: "platform-partial",
+        name: "Alexander Beispiel",
+        email: "anderer@example.com",
+        dateOfBirth: "2003-02-02",
+      },
+    ],
+  });
 });
 
 test("rejects ambiguous member-platform profiles with the same email", async () => {

--- a/app/lib/server/applications/admissionRequirements.ts
+++ b/app/lib/server/applications/admissionRequirements.ts
@@ -8,6 +8,11 @@ import { addLog } from "../logs";
 import { loadOwnedApplication } from "./access";
 import { deliverGuardianConsentRequest } from "./guardianConsentDelivery";
 import { createApplicationHistoryEntry } from "./history";
+import {
+  loadApplicationMemberPlatformSnapshot,
+  searchApplicationMemberPlatformCandidates,
+  type ApplicationMemberPlatformCandidate,
+} from "./memberPlatformCandidates";
 import { findApplicationMemberPlatformProfile } from "./memberPlatformAdmission";
 
 const OPEN_STATUSES = ["received", "review", "interview"] as const;
@@ -33,6 +38,52 @@ export async function syncApplicationMemberPlatformProfile(input: {
       "Die Member-Plattform-Daten sind durch die Zustimmung bereits bestätigt.",
     );
   }
+  await storeMemberPlatformSnapshot(application, user._id, snapshot);
+}
+
+export async function searchApplicationMemberPlatformProfiles(input: {
+  applicationId: string;
+}): Promise<ApplicationMemberPlatformCandidate[]> {
+  const parsed = z.object({ applicationId: z.string().min(1) }).parse(input);
+  const { application } = await loadOwnedApplication(parsed.applicationId);
+  assertRequirementsEditable(application);
+  return searchApplicationMemberPlatformCandidates({
+    applicantName: application.applicantName,
+    privateEmail: application.applicantEmailNormalized,
+  });
+}
+
+export async function selectApplicationMemberPlatformProfile(input: {
+  applicationId: string;
+  profileId: string;
+}): Promise<void> {
+  const parsed = z
+    .object({
+      applicationId: z.string().min(1),
+      profileId: z.string().trim().min(1).max(120),
+    })
+    .parse(input);
+  const { user, application } = await loadOwnedApplication(
+    parsed.applicationId,
+  );
+  assertRequirementsEditable(application);
+  if (application.guardianConsent?.signedAt) {
+    throw new Error("Aufnahmedaten sind bereits bestätigt.");
+  }
+  const candidates = await searchApplicationMemberPlatformCandidates({
+    applicantName: application.applicantName,
+    privateEmail: application.applicantEmailNormalized,
+  });
+  if (!candidates.some(({ id }) => id === parsed.profileId)) {
+    throw new Error("Member-Profil gehört nicht zu den Suchergebnissen.");
+  }
+  const snapshot = await loadApplicationMemberPlatformSnapshot(
+    parsed.profileId,
+  );
+  const unchanged =
+    application.memberPlatformUserId === snapshot.memberPlatformUserId &&
+    application.dateOfBirth === snapshot.dateOfBirth;
+  if (unchanged) return;
   await storeMemberPlatformSnapshot(application, user._id, snapshot);
 }
 

--- a/app/lib/server/applications/admissionRequirementsAction.ts
+++ b/app/lib/server/applications/admissionRequirementsAction.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import {
+  searchApplicationMemberPlatformProfiles,
+  selectApplicationMemberPlatformProfile,
+} from "./admissionRequirements";
+import type { ApplicationMemberPlatformCandidate } from "./memberPlatformCandidates";
+
+export type ApplicationProfileSearchResult =
+  | { ok: true; candidates: ApplicationMemberPlatformCandidate[] }
+  | { ok: false };
+
+export type ApplicationProfileSelectionResult = { ok: true } | { ok: false };
+
+export async function searchApplicationMemberPlatformProfilesAction(
+  input: Parameters<typeof searchApplicationMemberPlatformProfiles>[0],
+): Promise<ApplicationProfileSearchResult> {
+  try {
+    const candidates = await searchApplicationMemberPlatformProfiles(input);
+    return { ok: true, candidates };
+  } catch (error) {
+    console.error("application member profile search failed", error);
+    return { ok: false };
+  }
+}
+
+export async function selectApplicationMemberPlatformProfileAction(
+  input: Parameters<typeof selectApplicationMemberPlatformProfile>[0],
+): Promise<ApplicationProfileSelectionResult> {
+  try {
+    await selectApplicationMemberPlatformProfile(input);
+    return { ok: true };
+  } catch (error) {
+    console.error("application member profile selection failed", error);
+    return { ok: false };
+  }
+}

--- a/app/lib/server/applications/memberPlatformAtlasSearch.test.ts
+++ b/app/lib/server/applications/memberPlatformAtlasSearch.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { buildMemberPlatformSearchPipeline } from "./memberPlatformAtlasSearch";
+
+test("builds the ybase-search pipeline with boosted email and fuzzy names", () => {
+  const pipeline = buildMemberPlatformSearchPipeline({
+    applicantName: "Alex Beispiel",
+    privateEmail: "ALEX@example.com",
+  });
+  const search = pipeline[0].$search;
+
+  expect(search.index).toBe("ybase-search");
+  expect(search.compound.minimumShouldMatch).toBe(1);
+  expect(search.compound.should).toContainEqual({
+    equals: {
+      path: "contact.email",
+      value: "alex@example.com",
+      score: { boost: { value: 20 } },
+    },
+  });
+  expect(search.compound.should).toContainEqual({
+    autocomplete: {
+      path: "person.lastName",
+      query: "Beispiel",
+      tokenOrder: "sequential",
+      fuzzy: { maxEdits: 1, prefixLength: 1, maxExpansions: 50 },
+      score: { boost: { value: 4 } },
+    },
+  });
+  expect(pipeline).toContainEqual({
+    $match: { "eligibleState.0": { $exists: true } },
+  });
+});

--- a/app/lib/server/applications/memberPlatformAtlasSearch.ts
+++ b/app/lib/server/applications/memberPlatformAtlasSearch.ts
@@ -1,0 +1,127 @@
+import type { Db, Document } from "mongodb";
+import {
+  type MemberPlatformProfile,
+  normalizeEmail,
+} from "../../memberPlatform/suggestions";
+import { LINKABLE_MEMBER_PLATFORM_STATES } from "../../memberPlatform/states";
+
+const SEARCH_INDEX = "ybase-search";
+const SEARCH_RESULT_LIMIT = 30;
+
+interface ApplicationProfileLookup {
+  applicantName?: string;
+  privateEmail: string;
+}
+
+export async function searchMemberPlatformProfilesWithAtlas(
+  database: Db,
+  lookup: ApplicationProfileLookup,
+): Promise<MemberPlatformProfile[]> {
+  return database
+    .collection<MemberPlatformProfile>("users")
+    .aggregate<MemberPlatformProfile>(buildMemberPlatformSearchPipeline(lookup))
+    .toArray();
+}
+
+export function buildMemberPlatformSearchPipeline(
+  lookup: ApplicationProfileLookup,
+): Document[] {
+  const should = buildSearchClauses(lookup);
+  if (should.length === 0) return [{ $limit: 0 }];
+  return [
+    {
+      $search: {
+        index: SEARCH_INDEX,
+        compound: { should, minimumShouldMatch: 1 },
+      },
+    },
+    { $match: { deletedAt: null } },
+    {
+      $lookup: {
+        from: "user-states",
+        let: { profileId: "$id" },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: ["$userId", "$$profileId"] },
+                  {
+                    $in: ["$current", [...LINKABLE_MEMBER_PLATFORM_STATES]],
+                  },
+                ],
+              },
+            },
+          },
+          { $limit: 1 },
+        ],
+        as: "eligibleState",
+      },
+    },
+    { $match: { "eligibleState.0": { $exists: true } } },
+    {
+      $project: {
+        _id: 0,
+        id: 1,
+        person: 1,
+        contact: 1,
+      },
+    },
+    { $limit: SEARCH_RESULT_LIMIT },
+  ];
+}
+
+function buildSearchClauses(lookup: ApplicationProfileLookup): Document[] {
+  const clauses: Document[] = [];
+  const email = normalizeEmail(lookup.privateEmail);
+  if (email) {
+    clauses.push({
+      equals: {
+        path: "contact.email",
+        value: email,
+        score: { boost: { value: 20 } },
+      },
+    });
+  }
+
+  for (const { path, value } of buildNameValues(lookup.applicantName)) {
+    clauses.push(
+      {
+        equals: {
+          path,
+          value: value.toLocaleLowerCase("de"),
+          score: { boost: { value: 10 } },
+        },
+      },
+      {
+        autocomplete: {
+          path,
+          query: value,
+          tokenOrder: "sequential",
+          fuzzy: { maxEdits: 1, prefixLength: 1, maxExpansions: 50 },
+          score: { boost: { value: 4 } },
+        },
+      },
+    );
+  }
+  return clauses;
+}
+
+function buildNameValues(
+  applicantName?: string,
+): Array<{ path: string; value: string }> {
+  const parts = applicantName?.trim().split(/\s+/).filter(Boolean) ?? [];
+  const values = new Map<string, { path: string; value: string }>();
+  const add = (path: string, value: string) => {
+    if (value.length >= 2) values.set(`${path}:${value}`, { path, value });
+  };
+  if (parts.length === 1) {
+    add("person.firstName", parts[0]);
+    add("person.lastName", parts[0]);
+  }
+  for (let splitAt = 1; splitAt < parts.length; splitAt += 1) {
+    add("person.firstName", parts.slice(0, splitAt).join(" "));
+    add("person.lastName", parts.slice(splitAt).join(" "));
+  }
+  return [...values.values()];
+}

--- a/app/lib/server/applications/memberPlatformCandidates.ts
+++ b/app/lib/server/applications/memberPlatformCandidates.ts
@@ -1,0 +1,97 @@
+import {
+  type MemberPlatformProfile,
+  normalizeEmail,
+} from "../../memberPlatform/suggestions";
+import { LINKABLE_MEMBER_PLATFORM_STATES } from "../../memberPlatform/states";
+import { ageOnDate } from "../../members/legalDates";
+import { getMemberPlatformDb } from "../memberPlatform/client";
+import { searchMemberPlatformProfilesWithAtlas } from "./memberPlatformAtlasSearch";
+import type { ApplicationMemberPlatformSnapshot } from "./memberPlatformAdmission";
+
+const CANDIDATE_LIMIT = 5;
+
+export interface ApplicationMemberPlatformCandidate {
+  id: string;
+  name: string;
+  email?: string;
+  dateOfBirth: string;
+}
+
+interface ApplicationProfileLookup {
+  applicantName?: string;
+  privateEmail: string;
+}
+
+export async function searchApplicationMemberPlatformCandidates(
+  lookup: ApplicationProfileLookup,
+): Promise<ApplicationMemberPlatformCandidate[]> {
+  const database = await requireMemberPlatformDb();
+  const profiles = await searchMemberPlatformProfilesWithAtlas(
+    database,
+    lookup,
+  );
+  return profiles
+    .flatMap((profile) => {
+      const candidate = toCandidate(profile);
+      return candidate ? [candidate] : [];
+    })
+    .slice(0, CANDIDATE_LIMIT);
+}
+
+export async function loadApplicationMemberPlatformSnapshot(
+  profileId: string,
+): Promise<ApplicationMemberPlatformSnapshot> {
+  const database = await requireMemberPlatformDb();
+  const [profile, state] = await Promise.all([
+    database
+      .collection<MemberPlatformProfile>("users")
+      .findOne(
+        { id: profileId, deletedAt: null },
+        { projection: { _id: 0, id: 1, person: 1 } },
+      ),
+    database.collection("user-states").findOne({
+      userId: profileId,
+      current: { $in: [...LINKABLE_MEMBER_PLATFORM_STATES] },
+    }),
+  ]);
+  const dateOfBirth = normalizeBirthDate(profile?.person?.birthDate);
+  if (!profile || !state || !dateOfBirth) {
+    throw new Error("Member-Profil ist nicht für die Aufnahme verfügbar.");
+  }
+  return {
+    memberPlatformUserId: profile.id,
+    memberPlatformSyncedAt: Date.now(),
+    dateOfBirth,
+  };
+}
+
+async function requireMemberPlatformDb() {
+  const database = await getMemberPlatformDb();
+  if (!database) throw new Error("Member-Plattform ist nicht konfiguriert.");
+  return database;
+}
+
+function toCandidate(
+  profile: MemberPlatformProfile,
+): ApplicationMemberPlatformCandidate | null {
+  const name = [profile.person?.firstName, profile.person?.lastName]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  const dateOfBirth = normalizeBirthDate(profile.person?.birthDate);
+  if (!profile.id || !name || !dateOfBirth) return null;
+  const email = normalizeEmail(profile.contact?.email);
+  return { id: profile.id, name, dateOfBirth, ...(email ? { email } : {}) };
+}
+
+function normalizeBirthDate(value: string | Date | undefined): string | null {
+  const raw = value instanceof Date ? value.toISOString() : value?.trim();
+  const date = raw?.match(/^(\d{4}-\d{2}-\d{2})/)?.[1];
+  if (!date) return null;
+  try {
+    ageOnDate(date, Date.now());
+    return date;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## summary

- add fuzzy Atlas Search candidate lookup through the `ybase-search` index and restrict results to active member profiles
- let recruiters select one of up to five candidates while server actions keep production render errors generic

## validation

- `pnpm vitest run app/lib/server/applications/memberPlatformAtlasSearch.test.ts app/lib/server/applications/admissionRequirements.test.ts app/lib/server/applications/ingest.test.ts` (31 tests)
- targeted Biome lint, `pnpm build`, and a read-only Atlas index/query smoke test
