### PR TITLE
feat(recruiting): standardize job posting time commitments

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SelectJobPostingUrgency } from "@/components/Selectors/SelectJobPostingUrgency";
+import { SelectJobPostingTimeCommitment } from "@/components/Selectors/SelectJobPostingTimeCommitment";
 import { SelectMembers } from "@/components/Selectors/SelectMembers";
 import { SelectTeam } from "@/components/Selectors/SelectTeam";
 import { Input } from "@/components/ui/input";
@@ -69,12 +70,11 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
           />
         </div>
         <div className="flex flex-col gap-2">
-          <Label htmlFor="jp-time">Zeitaufwand</Label>
-          <Input
+          <Label htmlFor="jp-time">Zeitaufwand pro Woche</Label>
+          <SelectJobPostingTimeCommitment
             id="jp-time"
             value={values.timeCommitment}
-            onChange={(e) => onChange({ timeCommitment: e.target.value })}
-            placeholder="z. B. 5 h/Woche"
+            onValueChange={(timeCommitment) => onChange({ timeCommitment })}
           />
         </div>
         <div className="flex flex-col gap-2">

--- a/app/components/Selectors/SelectJobPostingTimeCommitment.tsx
+++ b/app/components/Selectors/SelectJobPostingTimeCommitment.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  isJobPostingTimeCommitment,
+  JOB_POSTING_TIME_COMMITMENTS,
+  type JobPostingTimeCommitment,
+} from "@/lib/jobPostings/timeCommitment";
+
+interface Props {
+  id: string;
+  value: JobPostingTimeCommitment | "";
+  onValueChange: (timeCommitment: JobPostingTimeCommitment) => void;
+}
+
+export function SelectJobPostingTimeCommitment({
+  id,
+  value,
+  onValueChange,
+}: Props) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(nextValue) => {
+        if (isJobPostingTimeCommitment(nextValue)) onValueChange(nextValue);
+      }}
+    >
+      <SelectTrigger id={id} className="w-full">
+        <SelectValue placeholder="Zeitaufwand wählen" />
+      </SelectTrigger>
+      <SelectContent>
+        {JOB_POSTING_TIME_COMMITMENTS.map((option) => (
+          <SelectItem key={option} value={option}>
+            {option}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/app/lib/db/jobPosting.ts
+++ b/app/lib/db/jobPosting.ts
@@ -1,3 +1,5 @@
+import type { JobPostingTimeCommitment } from "../jobPostings/timeCommitment";
+
 export type JobPostingStatus = "draft" | "published" | "closed" | "archived";
 export type JobPostingUrgency = "normal" | "urgent";
 
@@ -14,7 +16,7 @@ export interface JobPosting {
   tasks?: string;
   requirements?: string;
   benefits?: string;
-  timeCommitment?: string;
+  timeCommitment?: JobPostingTimeCommitment | "";
   location?: string;
   isRemote?: boolean;
   deadline?: string;

--- a/app/lib/jobPostings/form.ts
+++ b/app/lib/jobPostings/form.ts
@@ -1,6 +1,7 @@
 import type { JobPosting, JobPostingUrgency } from "@/lib/db/types";
 import { jobPostingApplicationQuestions } from "./applicationQuestions";
 import { DEFAULT_JOB_POSTING_BENEFITS } from "./benefits";
+import type { JobPostingTimeCommitment } from "./timeCommitment";
 import { jobPostingUrgency } from "./urgency";
 
 export interface JobPostingFormValues {
@@ -12,7 +13,7 @@ export interface JobPostingFormValues {
   tasks: string;
   requirements: string;
   benefits: string;
-  timeCommitment: string;
+  timeCommitment: JobPostingTimeCommitment | "";
   location: string;
   isRemote: boolean;
   deadline: string;

--- a/app/lib/jobPostings/timeCommitment.ts
+++ b/app/lib/jobPostings/timeCommitment.ts
@@ -1,0 +1,14 @@
+export const JOB_POSTING_TIME_COMMITMENTS = [
+  "Unter 4 Stunden",
+  "Zwischen 4 und 8 Stunden",
+  "Über 8 Stunden",
+] as const;
+
+export type JobPostingTimeCommitment =
+  (typeof JOB_POSTING_TIME_COMMITMENTS)[number];
+
+export function isJobPostingTimeCommitment(
+  value: string,
+): value is JobPostingTimeCommitment {
+  return JOB_POSTING_TIME_COMMITMENTS.some((option) => option === value);
+}

--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -7,6 +7,7 @@ import { jobPostings, teams, users } from "../../db/collections";
 import type { JobPostingUrgency } from "../../db/types";
 import { newId } from "../../db/ids";
 import { DEFAULT_JOB_POSTING_BENEFITS } from "../../jobPostings/benefits";
+import { JOB_POSTING_TIME_COMMITMENTS } from "../../jobPostings/timeCommitment";
 import { UNAVAILABLE_MEMBER_STATUSES } from "../../members/status";
 import { addLog } from "../logs";
 import { requireOwnedJobPosting } from "./access";
@@ -28,7 +29,10 @@ const contentSchema = z.object({
   tasks: optionalText,
   requirements: optionalText,
   benefits: optionalText,
-  timeCommitment: optionalText,
+  timeCommitment: z
+    .enum(JOB_POSTING_TIME_COMMITMENTS)
+    .or(z.literal(""))
+    .optional(),
   location: optionalText,
   isRemote: z.boolean().optional(),
   deadline: optionalText,

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -273,6 +273,34 @@ test("updateJobPosting changes the urgency", async () => {
   expect((await getJobPostingById(id)).urgency).toBe("urgent");
 });
 
+test("updateJobPosting only accepts canonical time commitments", async () => {
+  const id = await createJobPostingDraft({
+    title: "T",
+    teamId: teamA,
+    tallyTemplateFormId: "template-1",
+  });
+
+  await expect(
+    updateJobPosting({
+      jobPostingId: id,
+      title: "T",
+      teamId: teamA,
+      // @ts-expect-error Exercise validation for untyped server-action callers.
+      timeCommitment: "5 Stunden pro Woche",
+    }),
+  ).rejects.toThrow();
+
+  await updateJobPosting({
+    jobPostingId: id,
+    title: "T",
+    teamId: teamA,
+    timeCommitment: "Zwischen 4 und 8 Stunden",
+  });
+  expect((await getJobPostingById(id)).timeCommitment).toBe(
+    "Zwischen 4 und 8 Stunden",
+  );
+});
+
 test("stores the exact application questions and forwards them to Tally", async () => {
   const id = await createJobPostingDraft({
     title: "T",

--- a/app/lib/server/jobPostings/tallyForm.test.ts
+++ b/app/lib/server/jobPostings/tallyForm.test.ts
@@ -250,7 +250,7 @@ test("keeps posting details out of Tally and syncs exact role questions", async 
     tasks: "<ul><li>Architektur gestalten</li></ul>",
     requirements: "<p>Erfahrung mit TypeScript</p>",
     benefits: "<ul><li>Zugang zur YFN Community</li></ul>",
-    timeCommitment: "5 Stunden pro Woche",
+    timeCommitment: "Zwischen 4 und 8 Stunden",
     location: "Remote",
     deadline: "2026-08-31",
     applicationQuestions: ["Welche Architektur hast du zuletzt gestaltet?"],
@@ -271,7 +271,7 @@ test("keeps posting details out of Tally and syncs exact role questions", async 
   expect(serialized).not.toContain("Erfahrung mit TypeScript");
   expect(serialized).not.toContain("Benefits");
   expect(serialized).not.toContain("Zugang zur YFN Community");
-  expect(serialized).not.toContain("5 Stunden pro Woche");
+  expect(serialized).not.toContain("Zwischen 4 und 8 Stunden");
   expect(serialized).not.toContain("2026-08-31");
   expect(serialized).toContain("Fragen zur Rolle");
   expect(serialized).toContain("Welche Architektur hast du zuletzt gestaltet?");


### PR DESCRIPTION
## summary

- replaces free-text weekly time commitments with three fixed ranges across the editor, stored type, and server validation
- records the direct Tally migration that removed the redundant availability question from all templates and the existing draft

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec vitest run app/lib/server/jobPostings/jobPostings.test.ts app/lib/server/jobPostings/tallyForm.test.ts`
- `pnpm build`