### PR TITLE
fix(recruiting): require member profiles before interviews

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -31,24 +31,20 @@ export function ApplicationAdmissionProfile({
   onSelect,
 }: ApplicationAdmissionProfileProps) {
   if (!hasProfile || !dateOfBirth) {
-    return (
-      <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-        {canSync ? (
-          <ProfileSearch
-            candidates={candidates}
-            isPending={isPending}
-            isSearching={isSearching}
-            selectingProfileId={selectingProfileId}
-            onSearch={onSearch}
-            onSelect={onSelect}
-          />
-        ) : null}
-      </div>
-    );
+    return canSync ? (
+      <ProfileSearch
+        candidates={candidates}
+        isPending={isPending}
+        isSearching={isSearching}
+        selectingProfileId={selectingProfileId}
+        onSearch={onSearch}
+        onSelect={onSelect}
+      />
+    ) : null;
   }
 
   return (
-    <div className="space-y-3 rounded-lg border p-4">
+    <div className="space-y-4">
       <div className="space-y-1">
         <p className="text-sm font-medium">Geburtsdatum</p>
         <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
@@ -92,8 +88,8 @@ function ProfileSearch({
   onSearch: () => void;
   onSelect: (profileId: string) => void;
 }) {
-  return (
-    <div className="space-y-3">
+  if (candidates === null) {
+    return (
       <Button
         type="button"
         variant="outline"
@@ -107,49 +103,69 @@ function ProfileSearch({
           aria-hidden="true"
           className={isSearching ? "size-4 animate-spin" : "size-4"}
         />
-        {candidates === null ? "Member-Profile suchen" : "Suche aktualisieren"}
+        Member-Profile suchen
       </Button>
+    );
+  }
 
-      {candidates === null ? null : candidates.length > 0 ? (
-        <fieldset className="space-y-2">
-          <legend className="text-sm font-medium">
-            Passendes Profil auswählen
-          </legend>
-          <ul className="space-y-2">
-            {candidates.map((candidate) => (
-              <li key={candidate.id}>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="member"
-                  className="h-auto w-full justify-start whitespace-normal px-4 text-left"
-                  disabled={isPending}
-                  aria-label={`${candidate.name} als Member-Profil zuordnen`}
-                  onClick={() => onSelect(candidate.id)}
-                >
-                  <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-                    <span className="font-semibold">{candidate.name}</span>
-                    {candidate.email ? (
-                      <span className="break-all text-xs font-normal text-muted-foreground">
-                        {candidate.email}
-                      </span>
-                    ) : null}
-                    <span className="text-xs font-normal text-muted-foreground">
-                      Geburtsdatum:{" "}
-                      {formatFieldValue(candidate.dateOfBirth, "INPUT_DATE")}
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium">
+          {candidates.length > 0
+            ? "Passendes Profil auswählen"
+            : "Keine Treffer"}
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          aria-busy={isSearching}
+          onClick={onSearch}
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={isSearching ? "size-3.5 animate-spin" : "size-3.5"}
+          />
+          Aktualisieren
+        </Button>
+      </div>
+
+      {candidates.length > 0 ? (
+        <ul className="divide-y border-y">
+          {candidates.map((candidate) => (
+            <li key={candidate.id}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="member"
+                className="h-auto w-full justify-between whitespace-normal rounded-none px-2 py-3 text-left hover:bg-muted/50"
+                disabled={isPending}
+                aria-label={`${candidate.name} als Member-Profil zuordnen`}
+                onClick={() => onSelect(candidate.id)}
+              >
+                <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+                  <span className="font-semibold">{candidate.name}</span>
+                  {candidate.email ? (
+                    <span className="break-all text-xs font-normal text-muted-foreground">
+                      {candidate.email}
                     </span>
-                  </span>
-                  {selectingProfileId === candidate.id ? (
-                    <Loader2
-                      aria-hidden="true"
-                      className="size-4 animate-spin"
-                    />
                   ) : null}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </fieldset>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    Geburtsdatum:{" "}
+                    {formatFieldValue(candidate.dateOfBirth, "INPUT_DATE")}
+                  </span>
+                </span>
+                {selectingProfileId === candidate.id ? (
+                  <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+                ) : (
+                  <span className="text-sm font-semibold">Zuordnen</span>
+                )}
+              </Button>
+            </li>
+          ))}
+        </ul>
       ) : (
         <p className="text-sm text-muted-foreground">
           Kein aktives Member-Profil gefunden. Vor der Aufnahme muss die Person

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -8,8 +8,8 @@ import { Label } from "@/components/ui/label";
 import { useApplicationMutations } from "@/lib/client/applications/hooks/useApplicationMutations";
 import type { ApplicationWithFiles } from "@/lib/db/types";
 import { ageOnDate } from "@/lib/members/legalDates";
-import { DATE_TIME_FORMAT } from "./applicationPresentation";
 import { ApplicationAdmissionProfile } from "./ApplicationAdmissionProfile";
+import { DATE_TIME_FORMAT } from "./applicationPresentation";
 
 const EDITABLE_STATUSES = new Set(["received", "review", "interview"]);
 
@@ -83,7 +83,14 @@ export function ApplicationAdmissionRequirements({
 
   return (
     <section className="space-y-4 border-t pt-5">
-      <h3 className="text-xl font-semibold">Aufnahmevoraussetzungen</h3>
+      <div className="space-y-1">
+        <h3 className="text-xl font-semibold">Member-Profil</h3>
+        {!hasProfile ? (
+          <p className="text-sm text-muted-foreground">
+            Für die Zusage erforderlich
+          </p>
+        ) : null}
+      </div>
       <ApplicationAdmissionProfile
         canSync={isEditable}
         candidates={searchMemberPlatformProfiles.data ?? null}


### PR DESCRIPTION
## summary

- move the required member profile assignment below the timeline using existing YBase sections and controls
- block interview progression in the UI and server until a valid profile is linked, and remove redundant positive age copy

## validation

- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run app/lib/server/applications/applications.test.ts app/lib/applications/admissionEligibility.test.ts`