### PR TITLE
fix(recruiting): require member profiles before interviews

### DIFF
--- a/app/(protected)/applications/[id]/ApplicationReview.tsx
+++ b/app/(protected)/applications/[id]/ApplicationReview.tsx
@@ -42,6 +42,8 @@ export function ApplicationReview({
   const displayName = withdrawn
     ? "Anonymisierte Bewerbung"
     : application.applicantName || "Bewerbung";
+  const isProfileRequired =
+    !application.memberPlatformUserId || !application.dateOfBirth;
   const revisionKey = `${application._id}-${application.updatedAt ?? 0}-${application.status}`;
 
   return (
@@ -68,6 +70,7 @@ export function ApplicationReview({
             jobPostingTitle={application.jobPostingTitle}
             organizationDomain={organizationDomain}
             yfnEmail={application.yfnEmail}
+            isProfileRequired={isProfileRequired}
             acceptanceBlockedReason={getApplicationAdmissionIssue(
               application,
               Date.now(),
@@ -78,6 +81,12 @@ export function ApplicationReview({
         <div className="hidden min-[1280px]:block">
           <ApplicationDetails application={application} />
         </div>
+        <div>
+          <ApplicationHistory
+            application={application}
+            ownersById={ownersById}
+          />
+        </div>
         {!withdrawn ? (
           <div>
             <ApplicationAdmissionRequirements
@@ -86,12 +95,6 @@ export function ApplicationReview({
             />
           </div>
         ) : null}
-        <div>
-          <ApplicationHistory
-            application={application}
-            ownersById={ownersById}
-          />
-        </div>
       </ApplicationReviewSidebar>
     </div>
   );

--- a/app/(protected)/applications/[id]/loading.tsx
+++ b/app/(protected)/applications/[id]/loading.tsx
@@ -64,16 +64,16 @@ export default function ApplicationLoading() {
           <DetailSkeleton />
         </div>
         <div>
-          <section className="space-y-3 border-t pt-5">
-            <Skeleton className="h-6 w-48" />
-            <Skeleton className="h-9 w-full" />
-          </section>
-        </div>
-        <div>
           <section className="space-y-4 border-t pt-5">
             <Skeleton className="h-6 w-28" />
             <Skeleton className="h-4 w-40" />
             <Skeleton className="h-4 w-52" />
+          </section>
+        </div>
+        <div>
+          <section className="space-y-3 border-t pt-5">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-9 w-full" />
           </section>
         </div>
       </ApplicationReviewSidebar>

--- a/app/components/Applications/ApplicationActionFooter.tsx
+++ b/app/components/Applications/ApplicationActionFooter.tsx
@@ -38,6 +38,7 @@ export function ApplicationActionFooter({
   jobPostingTitle,
   organizationDomain,
   yfnEmail,
+  isProfileRequired,
   acceptanceBlockedReason,
 }: {
   applicationId: string;
@@ -46,6 +47,7 @@ export function ApplicationActionFooter({
   jobPostingTitle: string;
   organizationDomain: string;
   yfnEmail?: string;
+  isProfileRequired: boolean;
   acceptanceBlockedReason?: string;
 }) {
   const { setStatus, sendDecision } = useApplicationMutations();
@@ -135,6 +137,7 @@ export function ApplicationActionFooter({
                 disabled={
                   setStatus.isPending ||
                   sendDecision.isPending ||
+                  (action.status === "interview" && isProfileRequired) ||
                   (action.status === "accepted" &&
                     Boolean(acceptanceBlockedReason))
                 }

--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -49,16 +49,12 @@ export function ApplicationAdmissionProfile({
         <p className="text-sm font-medium">Geburtsdatum</p>
         <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
       </div>
-      {isEligible ? (
-        <p className="text-sm text-green-700">
-          Die Altersvoraussetzung ist erfüllt.
-        </p>
-      ) : (
+      {!isEligible ? (
         <p className="text-sm text-destructive">
           Bei der Aufnahme muss die Person mindestens 16 und noch nicht 25 Jahre
           alt sein.
         </p>
-      )}
+      ) : null}
       {canSync && !isSigned ? (
         <ProfileSearch
           candidates={candidates}

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -83,14 +83,7 @@ export function ApplicationAdmissionRequirements({
 
   return (
     <section className="space-y-4 border-t pt-5">
-      <div className="space-y-1">
-        <h3 className="text-xl font-semibold">Member-Profil</h3>
-        {!hasProfile ? (
-          <p className="text-sm text-muted-foreground">
-            Für die Zusage erforderlich
-          </p>
-        ) : null}
-      </div>
+      <h3 className="text-xl font-semibold">Member-Profil *</h3>
       <ApplicationAdmissionProfile
         canSync={isEditable}
         candidates={searchMemberPlatformProfiles.data ?? null}

--- a/app/lib/server/applications/applications.test.ts
+++ b/app/lib/server/applications/applications.test.ts
@@ -260,6 +260,17 @@ test("rejects an owner from another organization", async () => {
 });
 
 test("enforces allowed non-decision transitions and records them", async () => {
+  await (
+    await applications()
+  ).updateOne(
+    { _id: applicationId },
+    {
+      $set: {
+        memberPlatformUserId: "platform-alex",
+        dateOfBirth: "2004-01-01",
+      },
+    },
+  );
   await setApplicationStatus({ applicationId, status: "interview" });
 
   const stored = await (await applications()).findOne({ _id: applicationId });
@@ -272,6 +283,15 @@ test("enforces allowed non-decision transitions and records them", async () => {
   await expect(
     setApplicationStatus({ applicationId, status: "review" }),
   ).rejects.toThrow("nicht zulässig");
+});
+
+test("requires a member-platform profile before an interview", async () => {
+  await expect(
+    setApplicationStatus({ applicationId, status: "interview" }),
+  ).rejects.toThrow("Member-Plattform-Profil");
+  expect(
+    await (await applications()).findOne({ _id: applicationId }),
+  ).toMatchObject({ status: "received" });
 });
 
 test("requires acceptance and rejection to use the email action", async () => {

--- a/app/lib/server/applications/status.ts
+++ b/app/lib/server/applications/status.ts
@@ -40,6 +40,14 @@ export async function setApplicationStatus(input: {
   ) {
     throw new Error("Dieser Statuswechsel ist nicht zulässig");
   }
+  if (
+    status === "interview" &&
+    (!application.memberPlatformUserId || !application.dateOfBirth)
+  ) {
+    throw new Error(
+      "Vor dem Interview muss ein Member-Plattform-Profil verknüpft sein",
+    );
+  }
 
   const entry = createApplicationHistoryEntry(
     user._id,


### PR DESCRIPTION
## summary

- move the required member profile assignment below the timeline using existing YBase sections and controls
- disable interview progression in the UI and server until a valid profile is linked, and remove redundant positive age copy

## validation

- `pnpm exec prettier --check app/components/Applications/ApplicationAdmissionProfile.tsx app/components/Applications/ApplicationAdmissionRequirements.tsx app/components/Applications/ApplicationActionFooter.tsx app/(protected)/applications/[id]/ApplicationReview.tsx app/(protected)/applications/[id]/loading.tsx app/lib/server/applications/status.ts app/lib/server/applications/applications.test.ts`
- `pnpm exec biome lint app/components/Applications/ApplicationAdmissionProfile.tsx app/components/Applications/ApplicationAdmissionRequirements.tsx app/components/Applications/ApplicationActionFooter.tsx app/(protected)/applications/[id]/ApplicationReview.tsx app/(protected)/applications/[id]/loading.tsx app/lib/server/applications/status.ts app/lib/server/applications/applications.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run app/lib/server/applications/applications.test.ts app/lib/applications/admissionEligibility.test.ts`