### PR TITLE
feat(reimbursements): add selectable car mileage rates

### DIFF
--- a/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
+++ b/app/(protected)/reimbursements/[id]/_components/ReceiptCard.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
 import { formatDate } from "@/lib/formatters/formatDate";
-import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
+import { getCarAllowanceRate } from "@/lib/travel-costs";
 import { ExternalLink, FileText } from "lucide-react";
 import { COST_TYPE_LABELS } from "./constants";
 import type { ReceiptWithUrl } from "./types";
@@ -77,7 +77,7 @@ export function ReceiptCard({ receipt }: { receipt: ReceiptWithUrl }) {
             {receipt.kilometers && (
               <span className="text-sm text-muted-foreground">
                 {receipt.kilometers} km ×{" "}
-                {formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}
+                {formatCurrency(getCarAllowanceRate(receipt))}
               </span>
             )}
           </div>

--- a/app/(public)/_lib/reimbursements.ts
+++ b/app/(public)/_lib/reimbursements.ts
@@ -1,3 +1,4 @@
+import type { CarAllowanceRate } from "@/lib/travel-costs";
 import { CONNECTION_ERROR, postJson } from "./http";
 
 export type ReimbursementLink =
@@ -55,6 +56,7 @@ export type ReimbursementLink =
             | "accommodation"
             | "incidental";
           kilometers?: number;
+          mileageRate?: CarAllowanceRate;
         }>;
       };
     };

--- a/app/(public)/erstattung/[id]/_components/PublicReimbursementSummary.tsx
+++ b/app/(public)/erstattung/[id]/_components/PublicReimbursementSummary.tsx
@@ -4,7 +4,7 @@ import { Loader2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
-import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
+import { getCarAllowanceRate } from "@/lib/travel-costs";
 import type { CostType, Receipt, TravelReceipt } from "./types";
 
 type Props = {
@@ -35,7 +35,7 @@ export function PublicReimbursementSummary(props: Props) {
           title: props.costLabels[receipt.costType],
           detail:
             receipt.costType === "car"
-              ? `${receipt.kilometers ?? 0} km × ${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}`
+              ? `${receipt.kilometers ?? 0} km × ${formatCurrency(getCarAllowanceRate(receipt))}`
               : receipt.description,
           key: receipt.clientId,
         }))

--- a/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
+++ b/app/(public)/erstattung/[id]/_components/TravelReceiptCard.tsx
@@ -2,6 +2,7 @@
 
 import { ReceiptUploadExternal } from "@/components/Reimbursements/ReceiptUploadExternal";
 import { InvoiceOrganizationHint } from "@/components/Reimbursements/InvoiceOrganizationHint";
+import { CarMileageRateSelect } from "@/components/Reimbursements/CarMileageRateSelect";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,7 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Trash2 } from "lucide-react";
-import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
+import { calculateCarAllowance, getCarAllowanceRate } from "@/lib/travel-costs";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
 import type { TravelReceipt } from "./types";
 
@@ -33,6 +34,8 @@ type Props = {
 export function TravelReceiptCard(props: Props) {
   const { receipt } = props;
   const isCar = receipt.costType === "car";
+  const mileageRate = getCarAllowanceRate(receipt);
+  const mileageRateInputId = `${receipt.clientId}-mileage-rate`;
 
   return (
     <fieldset className="@container min-w-0 border rounded-lg p-4 space-y-4">
@@ -40,7 +43,7 @@ export function TravelReceiptCard(props: Props) {
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {isCar
-            ? `${props.title} (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
+            ? `${props.title} (${formatCurrency(mileageRate)}/km)`
             : props.title}
         </h3>
         <Button
@@ -84,6 +87,12 @@ export function TravelReceiptCard(props: Props) {
 
         {isCar ? (
           <>
+            <CarMileageRateSelect
+              id={mileageRateInputId}
+              kilometers={receipt.kilometers}
+              mileageRate={mileageRate}
+              onUpdate={props.onUpdate}
+            />
             <div>
               <Label>Kilometer *</Label>
               <Input
@@ -95,10 +104,7 @@ export function TravelReceiptCard(props: Props) {
                     0,
                     Math.floor(parseFloat(e.target.value) || 0),
                   );
-                  const amount =
-                    Math.round(
-                      kilometers * CAR_ALLOWANCE_RATE_EUR_PER_KM * 100,
-                    ) / 100;
+                  const amount = calculateCarAllowance(kilometers, mileageRate);
                   props.onUpdate({
                     kilometers,
                     grossAmount: amount,

--- a/app/(public)/erstattung/[id]/_components/types.ts
+++ b/app/(public)/erstattung/[id]/_components/types.ts
@@ -1,5 +1,5 @@
 import type { MealAllowance } from "@/lib/db/types";
-import type { CostType } from "@/lib/travel-costs";
+import type { CarAllowanceRate, CostType } from "@/lib/travel-costs";
 
 export type { CostType };
 
@@ -18,6 +18,7 @@ export type TravelReceipt = Receipt & {
   clientId: string;
   costType: CostType;
   kilometers?: number;
+  mileageRate?: CarAllowanceRate;
 };
 
 export type ExternalReimbursementPageUIProps = {

--- a/app/(public)/erstattung/[id]/_components/useReceipts.ts
+++ b/app/(public)/erstattung/[id]/_components/useReceipts.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { toNet } from "@/lib/bank-utils";
-import { type CostType, DEFAULT_TAX_RATES } from "@/lib/travel-costs";
+import {
+  CAR_ALLOWANCE_RATE_EUR_PER_KM,
+  type CostType,
+  DEFAULT_TAX_RATES,
+} from "@/lib/travel-costs";
 import { createClientReceiptId } from "@/lib/travelReceiptForm";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -68,6 +72,8 @@ export function useReceipts(startDate: string) {
         grossAmount: 0,
         fileStorageId: "",
         kilometers: costType === "car" ? 0 : undefined,
+        mileageRate:
+          costType === "car" ? CAR_ALLOWANCE_RATE_EUR_PER_KM : undefined,
       },
     ]);
   };

--- a/app/components/Reimbursements/CarMileageRateSelect.tsx
+++ b/app/components/Reimbursements/CarMileageRateSelect.tsx
@@ -1,0 +1,63 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  calculateCarAllowance,
+  CAR_ALLOWANCE_RATES_EUR_PER_KM,
+  type CarAllowanceRate,
+} from "@/lib/travel-costs";
+
+type Props = {
+  id: string;
+  kilometers?: number;
+  mileageRate: CarAllowanceRate;
+  onUpdate: (updates: {
+    mileageRate: CarAllowanceRate;
+    grossAmount: number;
+    netAmount: number;
+  }) => void;
+};
+
+export function CarMileageRateSelect({
+  id,
+  kilometers,
+  mileageRate,
+  onUpdate,
+}: Props) {
+  return (
+    <div>
+      <Label htmlFor={id}>Kosten pro Kilometer *</Label>
+      <Select
+        value={String(mileageRate)}
+        onValueChange={(value) => {
+          const nextMileageRate = Number(value) as CarAllowanceRate;
+          const amount = calculateCarAllowance(
+            kilometers ?? 0,
+            nextMileageRate,
+          );
+          onUpdate({
+            mileageRate: nextMileageRate,
+            grossAmount: amount,
+            netAmount: amount,
+          });
+        }}
+      >
+        <SelectTrigger id={id}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {CAR_ALLOWANCE_RATES_EUR_PER_KM.map((rate) => (
+            <SelectItem key={rate} value={String(rate)}>
+              {Math.round(rate * 100)} ct/km
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/app/components/Reimbursements/travelForm/ReceiptCard.tsx
+++ b/app/components/Reimbursements/travelForm/ReceiptCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CarMileageRateSelect } from "@/components/Reimbursements/CarMileageRateSelect";
 import { ReceiptUpload } from "@/components/Reimbursements/ReceiptUpload";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,7 +14,7 @@ import {
 } from "@/components/ui/select";
 import { toNet } from "@/lib/bank-utils";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
-import { CAR_ALLOWANCE_RATE_EUR_PER_KM } from "@/lib/travel-costs";
+import { calculateCarAllowance, getCarAllowanceRate } from "@/lib/travel-costs";
 import { Trash2 } from "lucide-react";
 import { InvoiceOrganizationHint } from "../InvoiceOrganizationHint";
 import { PLACEHOLDERS } from "./constants";
@@ -34,13 +35,16 @@ export function ReceiptCard({
   onUpdate,
   organizationName,
 }: Props) {
+  const mileageRate = getCarAllowanceRate(receipt);
+  const mileageRateInputId = `${receipt.clientId}-mileage-rate`;
+
   return (
     <fieldset className="@container min-w-0 border rounded-lg p-4 space-y-4">
       <legend className="sr-only">{title}</legend>
       <div className="flex justify-between items-center">
         <h3 className="font-medium">
           {receipt.costType === "car"
-            ? `${title} (${formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}/km)`
+            ? `${title} (${formatCurrency(mileageRate)}/km)`
             : title}
         </h3>
         <Button
@@ -85,6 +89,12 @@ export function ReceiptCard({
         ) : null}
         {receipt.costType === "car" ? (
           <>
+            <CarMileageRateSelect
+              id={mileageRateInputId}
+              kilometers={receipt.kilometers}
+              mileageRate={mileageRate}
+              onUpdate={onUpdate}
+            />
             <div>
               <Label>Kilometer *</Label>
               <Input
@@ -96,8 +106,7 @@ export function ReceiptCard({
                     0,
                     Math.floor(parseFloat(e.target.value) || 0),
                   );
-                  const amount =
-                    Math.round(km * CAR_ALLOWANCE_RATE_EUR_PER_KM * 100) / 100;
+                  const amount = calculateCarAllowance(km, mileageRate);
                   onUpdate({
                     kilometers: km,
                     grossAmount: amount,

--- a/app/components/Reimbursements/travelForm/SummarySection.tsx
+++ b/app/components/Reimbursements/travelForm/SummarySection.tsx
@@ -3,10 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { formatCurrency } from "@/lib/formatters/formatCurrency";
-import {
-  CAR_ALLOWANCE_RATE_EUR_PER_KM,
-  COST_LABELS as LABELS,
-} from "@/lib/travel-costs";
+import { COST_LABELS as LABELS, getCarAllowanceRate } from "@/lib/travel-costs";
 import { getTravelReceiptLabel } from "@/lib/travelReceiptForm";
 import { Loader2 } from "lucide-react";
 import type { Receipt } from "./types";
@@ -64,7 +61,7 @@ export function SummarySection({
                     {receipt.costType === "car" && (
                       <div className="text-sm text-muted-foreground">
                         {receipt.kilometers} km ×{" "}
-                        {formatCurrency(CAR_ALLOWANCE_RATE_EUR_PER_KM)}
+                        {formatCurrency(getCarAllowanceRate(receipt))}
                       </div>
                     )}
                   </div>

--- a/app/components/Reimbursements/travelForm/useTravelForm.ts
+++ b/app/components/Reimbursements/travelForm/useTravelForm.ts
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import { getBankDetailsError } from "@/lib/bank-utils";
 import { createTravelReimbursement } from "@/lib/server/reimbursements/creation";
 import {
+  CAR_ALLOWANCE_RATE_EUR_PER_KM,
   type CostType,
   createMealAllowance,
   DEFAULT_TAX_RATES,
@@ -60,6 +61,7 @@ export function useTravelForm(defaultBankDetails: BankDetails) {
         grossAmount: 0,
         fileStorageId: "",
         kilometers: type === "car" ? 0 : undefined,
+        mileageRate: type === "car" ? CAR_ALLOWANCE_RATE_EUR_PER_KM : undefined,
       },
     ]);
   };

--- a/app/lib/db/reimbursement.ts
+++ b/app/lib/db/reimbursement.ts
@@ -1,4 +1,4 @@
-import type { CostType, MealAllowance } from "./travelTypes";
+import type { CarAllowanceRate, CostType, MealAllowance } from "./travelTypes";
 
 export type ReimbursementType = "expense" | "travel";
 export type ReviewStatus =
@@ -71,4 +71,5 @@ export interface Receipt {
   fileStorageId: string;
   costType?: CostType;
   kilometers?: number;
+  mileageRate?: CarAllowanceRate;
 }

--- a/app/lib/db/travelTypes.ts
+++ b/app/lib/db/travelTypes.ts
@@ -7,6 +7,8 @@ export type CostType =
   | "accommodation"
   | "incidental";
 
+export type CarAllowanceRate = 0.3 | 0.15;
+
 export type MealAllowanceLine = { days: number; rate: number };
 
 export type MealAllowance = {

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -17,7 +17,12 @@ export type {
   ReviewStatus,
   TravelDetails,
 } from "./reimbursement";
-export type { CostType, MealAllowance, MealAllowanceLine } from "./travelTypes";
+export type {
+  CarAllowanceRate,
+  CostType,
+  MealAllowance,
+  MealAllowanceLine,
+} from "./travelTypes";
 export type { SignatureToken } from "./signature";
 export type { UploadContextType, UploadOwnership } from "./upload";
 export type * from "./membership";

--- a/app/lib/fileHandlers/reimbursementPdf/data.ts
+++ b/app/lib/fileHandlers/reimbursementPdf/data.ts
@@ -2,6 +2,8 @@ import {
   COST_LABELS,
   getMealAllowanceTotal,
   getMealAllowanceWithLegacyFallback,
+  getCarAllowanceRate,
+  type CarAllowanceRate,
   type CostType,
 } from "@/lib/travel-costs";
 import type { MealAllowance } from "@/lib/db/types";
@@ -55,6 +57,7 @@ export type ReceiptInput = {
   grossAmount?: number;
   costType?: CostType;
   kilometers?: number;
+  mileageRate?: CarAllowanceRate;
   fileUrl?: string | null;
 };
 
@@ -102,7 +105,9 @@ function receiptDescription(receipt: ReceiptInput): string {
   const costLabel = receipt.costType ? COST_LABELS[receipt.costType] : "";
   const parts = [costLabel, receipt.description].filter(Boolean);
   if (receipt.costType === "car" && receipt.kilometers) {
-    parts.push(`${receipt.kilometers} km × 0,30 €`);
+    parts.push(
+      `${receipt.kilometers} km × ${getCarAllowanceRate(receipt).toFixed(2).replace(".", ",")} €`,
+    );
   }
   return parts.join(" – ");
 }

--- a/app/lib/fileHandlers/travelReimbursementPdf/data.test.ts
+++ b/app/lib/fileHandlers/travelReimbursementPdf/data.test.ts
@@ -64,6 +64,23 @@ test("maps domestic travel data and aggregates supported cost types", () => {
   });
 });
 
+test("uses the selected 15 cent mileage rate", () => {
+  const data = buildTravelPdfData(reimbursement({ amount: 15 }), [
+    {
+      costType: "car",
+      kilometers: 100,
+      mileageRate: 0.15,
+      grossAmount: 15,
+    },
+  ]);
+
+  expect(data.fields).toMatchObject({
+    privateCarKilometers: "100",
+    mileageRate: "0,15 €",
+    privateCarCost: "15,00 €",
+  });
+});
+
 test("uses the international allowance fields and account holder fallback", () => {
   const data = buildTravelPdfData(
     reimbursement({

--- a/app/lib/fileHandlers/travelReimbursementPdf/data.ts
+++ b/app/lib/fileHandlers/travelReimbursementPdf/data.ts
@@ -6,7 +6,7 @@ import type {
   ReimbursementInput,
 } from "../reimbursementPdf/data";
 import {
-  CAR_ALLOWANCE_RATE_EUR_PER_KM,
+  getCarAllowanceRate,
   getMealAllowanceWithLegacyFallback,
 } from "../../travel-costs";
 import type { TravelMode, TravelPdfData, TravelPdfField } from "./types";
@@ -77,9 +77,13 @@ export function buildTravelPdfData(
     0,
   );
   if (carReceipts.length > 0) {
+    const mileageRates = new Set(carReceipts.map(getCarAllowanceRate));
     modes.add("car");
     fields.privateCarKilometers = number(carKilometers);
-    fields.mileageRate = euro(CAR_ALLOWANCE_RATE_EUR_PER_KM);
+    fields.mileageRate =
+      mileageRates.size === 1
+        ? euro(mileageRates.values().next().value ?? 0)
+        : "verschieden";
     addMoneyField(fields, "privateCarCost", carTotal);
   }
 

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -375,6 +375,43 @@ test("creates a kilometer allowance without requiring a receipt file", async () 
   });
 });
 
+test("creates a kilometer allowance with the 15 cent rate", async () => {
+  const input = reimbursementInput();
+  const id = await createTravelReimbursement({
+    ...input,
+    amount: 15,
+    startDate: "2026-05-15",
+    startTime: "08:00",
+    endDate: "2026-05-15",
+    endTime: "18:00",
+    destination: "Berlin",
+    purpose: "Workshop",
+    isInternational: false,
+    receipts: [
+      {
+        costType: "car",
+        receiptDate: "2026-05-15",
+        companyName: "Privater PKW",
+        description: "",
+        netAmount: 15,
+        taxRate: 0,
+        grossAmount: 15,
+        kilometers: 100,
+        mileageRate: 0.15,
+      },
+    ],
+  });
+
+  const receipt = await (await receipts()).findOne({ reimbursementId: id });
+  expect(receipt).toMatchObject({
+    costType: "car",
+    kilometers: 100,
+    mileageRate: 0.15,
+    grossAmount: 15,
+    fileStorageId: "",
+  });
+});
+
 test("creating an emailed submission request sends the request template", async () => {
   const id = await createReimbursementLink({
     projectId: projectA,

--- a/app/lib/server/reimbursements/schemas.ts
+++ b/app/lib/server/reimbursements/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import {
+  calculateCarAllowance,
+  CAR_ALLOWANCE_RATE_EUR_PER_KM,
+} from "../../travel-costs";
+import {
   getTravelDateRangeError,
   TRAVEL_DATE_RANGE_ERROR,
 } from "../../travelDates";
@@ -32,6 +36,7 @@ export const travelReceiptSchema = z
       "incidental",
     ]),
     kilometers: z.number().optional(),
+    mileageRate: z.union([z.literal(0.3), z.literal(0.15)]).optional(),
   })
   .superRefine((receipt, context) => {
     if (receipt.costType === "car") {
@@ -43,7 +48,10 @@ export const travelReceiptSchema = z
           message: "Kilometer erforderlich",
         });
       }
-      const expected = Math.round(kilometers * 30) / 100;
+      const expected = calculateCarAllowance(
+        kilometers,
+        receipt.mileageRate ?? CAR_ALLOWANCE_RATE_EUR_PER_KM,
+      );
       if (receipt.grossAmount !== expected || receipt.netAmount !== expected) {
         context.addIssue({
           code: "custom",

--- a/app/lib/travel-costs.test.ts
+++ b/app/lib/travel-costs.test.ts
@@ -1,8 +1,17 @@
 import { expect, test } from "vitest";
 import {
+  calculateCarAllowance,
   changeMealAllowanceCountry,
   createMealAllowance,
+  getCarAllowanceRate,
 } from "./travel-costs";
+
+test("calculates both selectable car allowance rates", () => {
+  expect(calculateCarAllowance(100, 0.3)).toBe(30);
+  expect(calculateCarAllowance(100, 0.15)).toBe(15);
+  expect(getCarAllowanceRate({})).toBe(0.3);
+  expect(getCarAllowanceRate({ mileageRate: 0.15 })).toBe(0.15);
+});
 
 test("keeps meal days when switching travel country", () => {
   const domestic = createMealAllowance();

--- a/app/lib/travel-costs.ts
+++ b/app/lib/travel-costs.ts
@@ -1,6 +1,6 @@
-import type { CostType, MealAllowance } from "@/lib/db/types";
+import type { CarAllowanceRate, CostType, MealAllowance } from "@/lib/db/types";
 
-export type { CostType };
+export type { CarAllowanceRate, CostType };
 
 export const COST_LABELS: Record<CostType, string> = {
   car: "PKW",
@@ -24,7 +24,24 @@ export const DEFAULT_TAX_RATES: Record<CostType, number> = {
 
 export const COST_TYPES = Object.keys(COST_LABELS) as CostType[];
 
-export const CAR_ALLOWANCE_RATE_EUR_PER_KM = 0.3;
+export const CAR_ALLOWANCE_RATES_EUR_PER_KM = [
+  0.3, 0.15,
+] as const satisfies readonly CarAllowanceRate[];
+
+export const CAR_ALLOWANCE_RATE_EUR_PER_KM = CAR_ALLOWANCE_RATES_EUR_PER_KM[0];
+
+export function getCarAllowanceRate(receipt: {
+  mileageRate?: CarAllowanceRate;
+}): CarAllowanceRate {
+  return receipt.mileageRate ?? CAR_ALLOWANCE_RATE_EUR_PER_KM;
+}
+
+export function calculateCarAllowance(
+  kilometers: number,
+  mileageRate: CarAllowanceRate,
+): number {
+  return Math.round(kilometers * mileageRate * 100) / 100;
+}
 
 export const MEAL_ALLOWANCE_PARTIAL_DAY_EUR = 14;
 export const MEAL_ALLOWANCE_FULL_DAY_EUR = 28;


### PR DESCRIPTION
## summary

- let internal and public travel reimbursement forms select 30 or 15 cents per car kilometer
- persist and validate the selected rate while keeping 30 cents as the fallback for existing records
- show the selected rate in summaries and generated reimbursement PDFs

## validation

- `pnpm exec vitest run app/lib/travel-costs.test.ts app/lib/fileHandlers/travelReimbursementPdf/data.test.ts app/lib/server/reimbursements/reimbursements.test.ts`
- `pnpm exec tsc --noEmit`
- focused `pnpm exec biome lint` on all changed files
- focused `pnpm exec prettier --check` on changed files
- `pnpm build`