### PR TITLE
fix(recruiting): require future job deadlines

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useMembers } from "@/lib/client/members/hooks/useMembers";
 import { useTeamDirectory } from "@/lib/client/teams/hooks/useTeamDirectory";
+import { berlinTomorrow } from "@/lib/jobPostings/deadline";
 import type { JobPostingFormValues } from "@/lib/jobPostings/form";
 
 interface Props {
@@ -82,6 +83,7 @@ export function JobPostingBasicFields({ values, onChange }: Props) {
           <Input
             id="jp-deadline"
             type="date"
+            min={berlinTomorrow()}
             value={values.deadline}
             onChange={(e) => onChange({ deadline: e.target.value })}
           />

--- a/app/lib/jobPostings/deadline.test.ts
+++ b/app/lib/jobPostings/deadline.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
-import { berlinToday, isDeadlinePassed } from "./deadline";
+import {
+  berlinToday,
+  berlinTomorrow,
+  isDeadlineInFuture,
+  isDeadlinePassed,
+} from "./deadline";
 
 test("berlinToday formats as YYYY-MM-DD in Europe/Berlin", () => {
   expect(berlinToday(new Date("2026-07-14T10:00:00Z"))).toBe("2026-07-14");
@@ -8,6 +13,21 @@ test("berlinToday formats as YYYY-MM-DD in Europe/Berlin", () => {
 test("berlinToday rolls into the next day using the Berlin offset", () => {
   // 23:30 UTC in July is already 01:30 the next day in Berlin (CEST, +2).
   expect(berlinToday(new Date("2026-07-14T23:30:00Z"))).toBe("2026-07-15");
+});
+
+test("berlinTomorrow returns the next Berlin calendar day", () => {
+  expect(berlinTomorrow(new Date("2026-03-28T23:30:00Z"))).toBe("2026-03-30");
+  expect(berlinTomorrow(new Date("2026-10-24T23:30:00Z"))).toBe("2026-10-26");
+});
+
+test("isDeadlineInFuture accepts empty and future deadlines", () => {
+  expect(isDeadlineInFuture(undefined, "2026-07-14")).toBe(true);
+  expect(isDeadlineInFuture("", "2026-07-14")).toBe(true);
+  expect(isDeadlineInFuture("2026-07-15", "2026-07-14")).toBe(true);
+  expect(isDeadlineInFuture("2026-07-14", "2026-07-14")).toBe(false);
+  expect(isDeadlineInFuture("2026-07-13", "2026-07-14")).toBe(false);
+  expect(isDeadlineInFuture("2026-02-30", "2026-01-01")).toBe(false);
+  expect(isDeadlineInFuture("keine-frist", "2026-07-14")).toBe(false);
 });
 
 test("isDeadlinePassed is false without a deadline", () => {

--- a/app/lib/jobPostings/deadline.ts
+++ b/app/lib/jobPostings/deadline.ts
@@ -6,6 +6,24 @@ export function berlinToday(now: Date = new Date()): string {
   return BERLIN_DATE.format(now);
 }
 
+export function berlinTomorrow(now: Date = new Date()): string {
+  const [year, month, day] = berlinToday(now).split("-").map(Number);
+  const tomorrow = new Date(Date.UTC(year, month - 1, day + 1));
+  return tomorrow.toISOString().slice(0, 10);
+}
+
+export function isDeadlineInFuture(
+  deadline: string | undefined,
+  today: string = berlinToday(),
+): boolean {
+  if (!deadline) return true;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(deadline)) return false;
+  const [year, month, day] = deadline.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const isCalendarDate = date.toISOString().slice(0, 10) === deadline;
+  return isCalendarDate && deadline > today;
+}
+
 export function isDeadlinePassed(
   deadline: string | undefined,
   today: string = berlinToday(),

--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -7,6 +7,7 @@ import { jobPostings, teams, users } from "../../db/collections";
 import type { JobPostingUrgency } from "../../db/types";
 import { newId } from "../../db/ids";
 import { DEFAULT_JOB_POSTING_BENEFITS } from "../../jobPostings/benefits";
+import { isDeadlineInFuture } from "../../jobPostings/deadline";
 import { JOB_POSTING_TIME_COMMITMENTS } from "../../jobPostings/timeCommitment";
 import { UNAVAILABLE_MEMBER_STATUSES } from "../../members/status";
 import { addLog } from "../logs";
@@ -118,6 +119,9 @@ export async function updateJobPosting(
   const { jobPostingId, ...content } = z
     .object({ jobPostingId: z.string(), ...contentSchema.shape })
     .parse(input);
+  if (!isDeadlineInFuture(content.deadline)) {
+    throw new Error("Die Frist muss in der Zukunft liegen");
+  }
 
   const posting = await requireOwnedJobPosting(
     jobPostingId,

--- a/app/lib/server/jobPostings/jobPostings.test.ts
+++ b/app/lib/server/jobPostings/jobPostings.test.ts
@@ -19,6 +19,7 @@ import { departments, jobPostings, teams, users } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { User } from "../../db/types";
 import { DEFAULT_JOB_POSTING_BENEFITS } from "../../jobPostings/benefits";
+import { berlinToday } from "../../jobPostings/deadline";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { createJobPostingDraft, updateJobPosting } from "./actions";
@@ -254,6 +255,57 @@ test("updateJobPosting can edit content while published", async () => {
     }),
     expect.objectContaining({ _id: userA, organizationId: orgA }),
   );
+});
+
+test("updateJobPosting only accepts empty or future deadlines", async () => {
+  const id = await createJobPostingDraft({
+    title: "T",
+    teamId: teamA,
+    tallyTemplateFormId: "template-1",
+  });
+
+  await expect(
+    updateJobPosting({
+      jobPostingId: id,
+      title: "T",
+      teamId: teamA,
+      deadline: berlinToday(),
+    }),
+  ).rejects.toThrow("Die Frist muss in der Zukunft liegen");
+
+  await expect(
+    updateJobPosting({
+      jobPostingId: id,
+      title: "T",
+      teamId: teamA,
+      deadline: "2000-01-01",
+    }),
+  ).rejects.toThrow("Die Frist muss in der Zukunft liegen");
+
+  await expect(
+    updateJobPosting({
+      jobPostingId: id,
+      title: "T",
+      teamId: teamA,
+      deadline: "keine-frist",
+    }),
+  ).rejects.toThrow("Die Frist muss in der Zukunft liegen");
+
+  await updateJobPosting({
+    jobPostingId: id,
+    title: "T",
+    teamId: teamA,
+    deadline: "2999-12-31",
+  });
+  expect((await getJobPostingById(id)).deadline).toBe("2999-12-31");
+
+  await updateJobPosting({
+    jobPostingId: id,
+    title: "T",
+    teamId: teamA,
+    deadline: "",
+  });
+  expect((await getJobPostingById(id)).deadline).toBe("");
 });
 
 test("updateJobPosting changes the urgency", async () => {

--- a/app/lib/server/jobPostings/lifecycle.test.ts
+++ b/app/lib/server/jobPostings/lifecycle.test.ts
@@ -12,6 +12,7 @@ import { newId } from "../../db/ids";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import type { JobPosting } from "../../db/types";
+import { berlinToday } from "../../jobPostings/deadline";
 import { createConfiguredTallyClient } from "../tally/client";
 import {
   archiveJobPosting,
@@ -133,7 +134,18 @@ test("reopenJobPosting reopens and reopens the Tally form", async () => {
 test("reopenJobPosting refuses an expired posting until the deadline is renewed", async () => {
   const id = await insertPosting(orgA, { status: "closed", deadline: PAST });
   await expect(reopenJobPosting({ jobPostingId: id })).rejects.toThrow(
-    "Vergangenheit",
+    "Zukunft",
+  );
+  expect((await read(id)).status).toBe("closed");
+});
+
+test("reopenJobPosting refuses a deadline on the current day", async () => {
+  const id = await insertPosting(orgA, {
+    status: "closed",
+    deadline: berlinToday(),
+  });
+  await expect(reopenJobPosting({ jobPostingId: id })).rejects.toThrow(
+    "Zukunft",
   );
   expect((await read(id)).status).toBe("closed");
 });

--- a/app/lib/server/jobPostings/lifecycle.ts
+++ b/app/lib/server/jobPostings/lifecycle.ts
@@ -3,7 +3,7 @@
 import { z } from "zod";
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
-import { berlinToday, isDeadlinePassed } from "../../jobPostings/deadline";
+import { isDeadlineInFuture } from "../../jobPostings/deadline";
 import { statusMeansClosed } from "../../jobPostings/status";
 import { requireOwnedJobPosting } from "./access";
 import { applyStatusTransition, syncTallyClosed } from "./tallySync";
@@ -48,8 +48,8 @@ export async function reopenJobPosting(input: {
       "Nur geschlossene Ausschreibungen können wieder geöffnet werden",
     );
   }
-  if (isDeadlinePassed(posting.deadline, berlinToday())) {
-    throw new Error("Die Frist liegt in der Vergangenheit");
+  if (!isDeadlineInFuture(posting.deadline)) {
+    throw new Error("Die Frist muss in der Zukunft liegen");
   }
   const result = await applyStatusTransition({
     posting,

--- a/app/lib/server/jobPostings/tallyForm.test.ts
+++ b/app/lib/server/jobPostings/tallyForm.test.ts
@@ -11,6 +11,7 @@ import { requirePermission } from "../../auth/session";
 import { jobPostings, logs } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { JobPosting } from "../../db/types";
+import { berlinToday } from "../../jobPostings/deadline";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { createConfiguredTallyClient } from "../tally/client";
@@ -335,10 +336,11 @@ test("publishing syncs the title and preserves other manual Tally changes", asyn
   });
 });
 
-test("returns errors for incomplete or expired drafts before calling Tally", async () => {
+test("returns errors for incomplete or non-future drafts before calling Tally", async () => {
   const client = useClient(fakeClient());
   const incomplete = await insertDraft(orgA, { title: "" });
   const expired = await insertDraft(orgA, { deadline: "2000-01-01" });
+  const dueToday = await insertDraft(orgA, { deadline: berlinToday() });
 
   await expect(
     generateTallyForm({ jobPostingId: incomplete }),
@@ -348,7 +350,11 @@ test("returns errors for incomplete or expired drafts before calling Tally", asy
   });
   await expect(generateTallyForm({ jobPostingId: expired })).resolves.toEqual({
     ok: false,
-    error: "Die Frist liegt in der Vergangenheit",
+    error: "Die Frist muss in der Zukunft liegen",
+  });
+  await expect(generateTallyForm({ jobPostingId: dueToday })).resolves.toEqual({
+    ok: false,
+    error: "Die Frist muss in der Zukunft liegen",
   });
   expect(client.getForm).not.toHaveBeenCalled();
 });

--- a/app/lib/server/jobPostings/tallyForm.ts
+++ b/app/lib/server/jobPostings/tallyForm.ts
@@ -5,7 +5,7 @@ import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
 import { jobPostings } from "../../db/collections";
 import type { JobPosting } from "../../db/types";
-import { berlinToday, isDeadlinePassed } from "../../jobPostings/deadline";
+import { isDeadlineInFuture } from "../../jobPostings/deadline";
 import { addLog } from "../logs";
 import { createConfiguredTallyClient } from "../tally/client";
 import {
@@ -23,8 +23,8 @@ function assertPublishable(posting: JobPosting): void {
       "Titel und Team sind vor der Veröffentlichung erforderlich",
     );
   }
-  if (isDeadlinePassed(posting.deadline, berlinToday())) {
-    throw new Error("Die Frist liegt in der Vergangenheit");
+  if (!isDeadlineInFuture(posting.deadline)) {
+    throw new Error("Die Frist muss in der Zukunft liegen");
   }
 }
 


### PR DESCRIPTION
## summary

- restrict the existing YBase deadline field to dates from tomorrow onward while keeping deadlines optional
- validate deadlines when saving, publishing, and reopening job postings so expired postings cannot disappear from the member feed after an edit

## validation

- `pnpm exec prettier --check app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx app/lib/jobPostings/deadline.ts app/lib/jobPostings/deadline.test.ts app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts app/lib/server/jobPostings/lifecycle.ts app/lib/server/jobPostings/lifecycle.test.ts app/lib/server/jobPostings/tallyForm.ts app/lib/server/jobPostings/tallyForm.test.ts`
- `pnpm exec biome lint app/(protected)/recruiting/[id]/JobPostingBasicFields.tsx app/lib/jobPostings/deadline.ts app/lib/jobPostings/deadline.test.ts app/lib/server/jobPostings/actions.ts app/lib/server/jobPostings/jobPostings.test.ts app/lib/server/jobPostings/lifecycle.ts app/lib/server/jobPostings/lifecycle.test.ts app/lib/server/jobPostings/tallyForm.ts app/lib/server/jobPostings/tallyForm.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run app/lib/jobPostings/deadline.test.ts app/lib/server/jobPostings/jobPostings.test.ts app/lib/server/jobPostings/lifecycle.test.ts app/lib/server/jobPostings/tallyForm.test.ts`
- `git diff --check`