### PR TITLE
fix(reimbursements): delete mileage reimbursements without receipts

### DIFF
--- a/app/lib/server/reimbursements/deletion.ts
+++ b/app/lib/server/reimbursements/deletion.ts
@@ -15,7 +15,9 @@ async function cleanupReimbursement(reimbursement: Reimbursement) {
     .toArray();
 
   for (const receipt of receiptList) {
-    await deleteObject(receipt.fileStorageId);
+    if (receipt.fileStorageId) {
+      await deleteObject(receipt.fileStorageId);
+    }
     await (await receipts()).deleteOne({ _id: receipt._id });
   }
   if (reimbursement.type === "travel") {

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -895,6 +895,45 @@ test("deleteReimbursement removes receipts and deletes the stored files", async 
   expect(deleteObject).toHaveBeenCalledWith("sig-key");
 });
 
+test("deleteReimbursement removes a mileage reimbursement without a receipt file", async () => {
+  const input = reimbursementInput();
+  const id = await createTravelReimbursement({
+    ...input,
+    amount: 1.5,
+    startDate: "2026-05-15",
+    startTime: "08:00",
+    endDate: "2026-05-15",
+    endTime: "18:00",
+    destination: "Berlin",
+    purpose: "Testfahrt",
+    isInternational: false,
+    receipts: [
+      {
+        costType: "car",
+        receiptDate: "2026-05-15",
+        companyName: "Privater PKW",
+        description: "",
+        netAmount: 1.5,
+        taxRate: 0,
+        grossAmount: 1.5,
+        kilometers: 5,
+      },
+    ],
+  });
+
+  await deleteReimbursement({ reimbursementId: id });
+
+  expect(await (await reimbursements()).findOne({ _id: id })).toBeNull();
+  expect(
+    await (await receipts()).find({ reimbursementId: id }).toArray(),
+  ).toHaveLength(0);
+  expect(
+    await (await travelDetails()).findOne({ reimbursementId: id }),
+  ).toBeNull();
+  expect(deleteObject).not.toHaveBeenCalledWith("");
+  expect(deleteObject).toHaveBeenCalledWith("sig-key");
+});
+
 test("finance can delete another member's reimbursement", async () => {
   const reimbursementId = newId();
   await (


### PR DESCRIPTION
## summary

- skip object storage deletion for mileage items without receipt uploads
- add regression coverage for a 1.50 EUR mileage reimbursement

## validation

- `pnpm vitest run app/lib/server/reimbursements/reimbursements.test.ts` (38 tests passed)
- `pnpm test -- --run app/lib/server/reimbursements/reimbursements.test.ts` (614 tests passed)
- `pnpm exec biome lint app/lib/server/reimbursements/deletion.ts app/lib/server/reimbursements/reimbursements.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (passed with 3 pre-existing warnings)
- `pnpm lint:lines` (fails on 2 pre-existing files already over 200 lines on `origin/main`)
- `git diff --check`