### PR TITLE
fix(recruiting): show clear deadline validation errors

### DIFF
--- a/app/(protected)/recruiting/[id]/JobPostingForm.tsx
+++ b/app/(protected)/recruiting/[id]/JobPostingForm.tsx
@@ -10,6 +10,10 @@ import { Button } from "@/components/ui/button";
 import { useJobPostingMutations } from "@/lib/client/jobPostings/hooks/useJobPostingMutations";
 import type { JobPosting } from "@/lib/db/types";
 import {
+  isDeadlineInFuture,
+  JOB_POSTING_DEADLINE_ERROR,
+} from "@/lib/jobPostings/deadline";
+import {
   type JobPostingFormValues,
   toJobPostingForm,
 } from "@/lib/jobPostings/form";
@@ -34,9 +38,14 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
   const patch = (part: Partial<JobPostingFormValues>) =>
     setValues((current) => ({ ...current, ...part }));
 
-  const hasRequiredFields = () => {
+  const validateFields = () => {
     if (!values.title.trim() || !values.teamId) {
       toast.error("Titel und Team sind erforderlich");
+      return false;
+    }
+
+    if (!isDeadlineInFuture(values.deadline)) {
+      toast.error(JOB_POSTING_DEADLINE_ERROR);
       return false;
     }
 
@@ -44,7 +53,7 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
   };
 
   const handleSave = async () => {
-    if (!hasRequiredFields()) return;
+    if (!validateFields()) return;
 
     setActiveAction("save");
     try {
@@ -60,7 +69,7 @@ export function JobPostingForm({ posting }: { posting: JobPosting }) {
   };
 
   const handlePublish = async () => {
-    if (!hasRequiredFields()) return;
+    if (!validateFields()) return;
 
     setActiveAction("publish");
     try {

--- a/app/lib/jobPostings/deadline.ts
+++ b/app/lib/jobPostings/deadline.ts
@@ -2,6 +2,9 @@ const BERLIN_DATE = new Intl.DateTimeFormat("en-CA", {
   timeZone: "Europe/Berlin",
 });
 
+export const JOB_POSTING_DEADLINE_ERROR =
+  "Die Frist muss in der Zukunft liegen";
+
 export function berlinToday(now: Date = new Date()): string {
   return BERLIN_DATE.format(now);
 }

--- a/app/lib/server/jobPostings/actions.ts
+++ b/app/lib/server/jobPostings/actions.ts
@@ -7,7 +7,10 @@ import { jobPostings, teams, users } from "../../db/collections";
 import type { JobPostingUrgency } from "../../db/types";
 import { newId } from "../../db/ids";
 import { DEFAULT_JOB_POSTING_BENEFITS } from "../../jobPostings/benefits";
-import { isDeadlineInFuture } from "../../jobPostings/deadline";
+import {
+  isDeadlineInFuture,
+  JOB_POSTING_DEADLINE_ERROR,
+} from "../../jobPostings/deadline";
 import { JOB_POSTING_TIME_COMMITMENTS } from "../../jobPostings/timeCommitment";
 import { UNAVAILABLE_MEMBER_STATUSES } from "../../members/status";
 import { addLog } from "../logs";
@@ -120,7 +123,7 @@ export async function updateJobPosting(
     .object({ jobPostingId: z.string(), ...contentSchema.shape })
     .parse(input);
   if (!isDeadlineInFuture(content.deadline)) {
-    throw new Error("Die Frist muss in der Zukunft liegen");
+    throw new Error(JOB_POSTING_DEADLINE_ERROR);
   }
 
   const posting = await requireOwnedJobPosting(

--- a/app/lib/server/jobPostings/lifecycle.ts
+++ b/app/lib/server/jobPostings/lifecycle.ts
@@ -3,7 +3,10 @@
 import { z } from "zod";
 import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
-import { isDeadlineInFuture } from "../../jobPostings/deadline";
+import {
+  isDeadlineInFuture,
+  JOB_POSTING_DEADLINE_ERROR,
+} from "../../jobPostings/deadline";
 import { statusMeansClosed } from "../../jobPostings/status";
 import { requireOwnedJobPosting } from "./access";
 import { applyStatusTransition, syncTallyClosed } from "./tallySync";
@@ -49,7 +52,7 @@ export async function reopenJobPosting(input: {
     );
   }
   if (!isDeadlineInFuture(posting.deadline)) {
-    throw new Error("Die Frist muss in der Zukunft liegen");
+    throw new Error(JOB_POSTING_DEADLINE_ERROR);
   }
   const result = await applyStatusTransition({
     posting,

--- a/app/lib/server/jobPostings/tallyForm.ts
+++ b/app/lib/server/jobPostings/tallyForm.ts
@@ -5,7 +5,10 @@ import { USER_PERMISSIONS } from "../../auth/roles";
 import { requirePermission } from "../../auth/session";
 import { jobPostings } from "../../db/collections";
 import type { JobPosting } from "../../db/types";
-import { isDeadlineInFuture } from "../../jobPostings/deadline";
+import {
+  isDeadlineInFuture,
+  JOB_POSTING_DEADLINE_ERROR,
+} from "../../jobPostings/deadline";
 import { addLog } from "../logs";
 import { createConfiguredTallyClient } from "../tally/client";
 import {
@@ -24,7 +27,7 @@ function assertPublishable(posting: JobPosting): void {
     );
   }
   if (!isDeadlineInFuture(posting.deadline)) {
-    throw new Error("Die Frist muss in der Zukunft liegen");
+    throw new Error(JOB_POSTING_DEADLINE_ERROR);
   }
 }
 


### PR DESCRIPTION
## summary

- prevent saving or publishing job postings with non-future deadlines before a server request is made
- reuse one localized validation message across client and server deadline checks

## validation

- passed Prettier, Biome, TypeScript, and 45 targeted Vitest tests
- not run (production build is repo-wide; targeted checks and typecheck passed)