### PR TITLE
fix(recruiting): auto-search and retain member profiles

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.test.ts
+++ b/app/components/Applications/ApplicationAdmissionProfile.test.ts
@@ -1,0 +1,87 @@
+import { createElement, type ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test, vi } from "vitest";
+
+vi.mock("@/components/ui/button", async () => {
+  const { createElement: createButtonElement } = await import("react");
+  return {
+    Button: ({
+      asChild: _asChild,
+      size: _size,
+      variant: _variant,
+      ...props
+    }: ComponentProps<"button"> & {
+      asChild?: boolean;
+      size?: string;
+      variant?: string;
+    }) => createButtonElement("button", props),
+  };
+});
+
+vi.mock("@/components/ui/skeleton", async () => {
+  const { createElement: createSkeletonElement } = await import("react");
+  return {
+    Skeleton: (props: ComponentProps<"div">) =>
+      createSkeletonElement("div", { "data-slot": "skeleton", ...props }),
+  };
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...values: unknown[]) =>
+    values.filter((value) => typeof value === "string").join(" "),
+}));
+
+import { ApplicationAdmissionProfile } from "./ApplicationAdmissionProfile";
+
+const candidate = {
+  id: "platform-alex",
+  name: "Alex Beispiel",
+  email: "alex@example.com",
+  dateOfBirth: "2004-01-01",
+};
+
+test("shows a skeleton while automatically searching for profiles", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ApplicationAdmissionProfile, {
+      canSync: true,
+      candidates: null,
+      hasProfile: false,
+      isEligible: false,
+      isPending: true,
+      isSearching: true,
+      isSigned: false,
+      searchError: false,
+      onSearch: vi.fn(),
+      onSelect: vi.fn(),
+    }),
+  );
+
+  expect(markup).toContain('aria-busy="true"');
+  expect(markup).toContain('data-slot="skeleton"');
+  expect(markup).toContain("Member-Profile werden gesucht");
+  expect(markup).not.toContain("Member-Profile suchen</button>");
+});
+
+test("keeps the linked profile visibly selected after a step change", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ApplicationAdmissionProfile, {
+      canSync: true,
+      candidates: [candidate],
+      dateOfBirth: candidate.dateOfBirth,
+      hasProfile: true,
+      isEligible: true,
+      isPending: false,
+      isSearching: false,
+      isSigned: false,
+      searchError: false,
+      selectedProfileId: candidate.id,
+      onSearch: vi.fn(),
+      onSelect: vi.fn(),
+    }),
+  );
+
+  expect(markup).toContain("Member-Profil zugeordnet");
+  expect(markup).toContain("Alex Beispiel");
+  expect(markup).toContain("Zugeordnet");
+  expect(markup).toContain("01.01.2004");
+});

--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -1,6 +1,6 @@
-import { Loader2, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { CheckCircle2 } from "lucide-react";
 import type { ApplicationMemberPlatformCandidate } from "@/lib/server/applications/memberPlatformCandidates";
+import { ApplicationAdmissionProfileSearch } from "./ApplicationAdmissionProfileSearch";
 import { formatFieldValue } from "./applicationPresentation";
 
 interface ApplicationAdmissionProfileProps {
@@ -12,6 +12,8 @@ interface ApplicationAdmissionProfileProps {
   isPending: boolean;
   isSigned: boolean;
   isSearching: boolean;
+  searchError: boolean;
+  selectedProfileId?: string;
   selectingProfileId?: string;
   onSearch: () => void;
   onSelect: (profileId: string) => void;
@@ -26,16 +28,20 @@ export function ApplicationAdmissionProfile({
   isPending,
   isSigned,
   isSearching,
+  searchError,
+  selectedProfileId,
   selectingProfileId,
   onSearch,
   onSelect,
 }: ApplicationAdmissionProfileProps) {
   if (!hasProfile || !dateOfBirth) {
     return canSync ? (
-      <ProfileSearch
+      <ApplicationAdmissionProfileSearch
         candidates={candidates}
         isPending={isPending}
         isSearching={isSearching}
+        searchError={searchError}
+        selectedProfileId={selectedProfileId}
         selectingProfileId={selectingProfileId}
         onSearch={onSearch}
         onSelect={onSelect}
@@ -45,9 +51,15 @@ export function ApplicationAdmissionProfile({
 
   return (
     <div className="space-y-4">
-      <div className="space-y-1">
-        <p className="text-sm font-medium">Geburtsdatum</p>
-        <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
+      <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+        <p className="flex items-center gap-2 font-semibold text-green-700">
+          <CheckCircle2 aria-hidden="true" className="size-4" />
+          Member-Profil zugeordnet
+        </p>
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Geburtsdatum</p>
+          <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
+        </div>
       </div>
       {!isEligible ? (
         <p className="text-sm text-destructive">
@@ -56,118 +68,17 @@ export function ApplicationAdmissionProfile({
         </p>
       ) : null}
       {canSync && !isSigned ? (
-        <ProfileSearch
+        <ApplicationAdmissionProfileSearch
           candidates={candidates}
           isPending={isPending}
           isSearching={isSearching}
+          searchError={searchError}
+          selectedProfileId={selectedProfileId}
           selectingProfileId={selectingProfileId}
           onSearch={onSearch}
           onSelect={onSelect}
         />
       ) : null}
-    </div>
-  );
-}
-
-function ProfileSearch({
-  candidates,
-  isPending,
-  isSearching,
-  selectingProfileId,
-  onSearch,
-  onSelect,
-}: {
-  candidates: ApplicationMemberPlatformCandidate[] | null;
-  isPending: boolean;
-  isSearching: boolean;
-  selectingProfileId?: string;
-  onSearch: () => void;
-  onSelect: (profileId: string) => void;
-}) {
-  if (candidates === null) {
-    return (
-      <Button
-        type="button"
-        variant="outline"
-        size="member"
-        className="w-full"
-        disabled={isPending}
-        aria-busy={isSearching}
-        onClick={onSearch}
-      >
-        <RefreshCw
-          aria-hidden="true"
-          className={isSearching ? "size-4 animate-spin" : "size-4"}
-        />
-        Member-Profile suchen
-      </Button>
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium">
-          {candidates.length > 0
-            ? "Passendes Profil auswählen"
-            : "Keine Treffer"}
-        </p>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={isPending}
-          aria-busy={isSearching}
-          onClick={onSearch}
-        >
-          <RefreshCw
-            aria-hidden="true"
-            className={isSearching ? "size-3.5 animate-spin" : "size-3.5"}
-          />
-          Aktualisieren
-        </Button>
-      </div>
-
-      {candidates.length > 0 ? (
-        <ul className="divide-y border-y">
-          {candidates.map((candidate) => (
-            <li key={candidate.id}>
-              <Button
-                type="button"
-                variant="ghost"
-                size="member"
-                className="h-auto w-full justify-between whitespace-normal rounded-none px-2 py-3 text-left hover:bg-muted/50"
-                disabled={isPending}
-                aria-label={`${candidate.name} als Member-Profil zuordnen`}
-                onClick={() => onSelect(candidate.id)}
-              >
-                <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-                  <span className="font-semibold">{candidate.name}</span>
-                  {candidate.email ? (
-                    <span className="break-all text-xs font-normal text-muted-foreground">
-                      {candidate.email}
-                    </span>
-                  ) : null}
-                  <span className="text-xs font-normal text-muted-foreground">
-                    Geburtsdatum:{" "}
-                    {formatFieldValue(candidate.dateOfBirth, "INPUT_DATE")}
-                  </span>
-                </span>
-                {selectingProfileId === candidate.id ? (
-                  <Loader2 aria-hidden="true" className="size-4 animate-spin" />
-                ) : (
-                  <span className="text-sm font-semibold">Zuordnen</span>
-                )}
-              </Button>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          Kein aktives Member-Profil gefunden. Vor der Aufnahme muss die Person
-          eines erstellen.
-        </p>
-      )}
     </div>
   );
 }

--- a/app/components/Applications/ApplicationAdmissionProfileSearch.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfileSearch.tsx
@@ -1,0 +1,169 @@
+import { CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ApplicationMemberPlatformCandidate } from "@/lib/server/applications/memberPlatformCandidates";
+import { cn } from "@/lib/utils";
+import { formatFieldValue } from "./applicationPresentation";
+
+const PROFILE_SKELETON_ROWS = ["first", "second"];
+
+interface ApplicationAdmissionProfileSearchProps {
+  candidates: ApplicationMemberPlatformCandidate[] | null;
+  isPending: boolean;
+  isSearching: boolean;
+  searchError: boolean;
+  selectedProfileId?: string;
+  selectingProfileId?: string;
+  onSearch: () => void;
+  onSelect: (profileId: string) => void;
+}
+
+export function ApplicationAdmissionProfileSearch({
+  candidates,
+  isPending,
+  isSearching,
+  searchError,
+  selectedProfileId,
+  selectingProfileId,
+  onSearch,
+  onSelect,
+}: ApplicationAdmissionProfileSearchProps) {
+  if (candidates === null) {
+    if (isSearching) {
+      return (
+        <div className="space-y-3" aria-busy="true">
+          <span className="sr-only">Member-Profile werden gesucht</span>
+          <div aria-hidden="true" className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-8 w-24" />
+            </div>
+            <div className="divide-y border-y">
+              {PROFILE_SKELETON_ROWS.map((row) => (
+                <div
+                  key={row}
+                  className="flex items-center justify-between gap-4 px-2 py-3"
+                >
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-3 w-44 max-w-full" />
+                    <Skeleton className="h-3 w-28" />
+                  </div>
+                  <Skeleton className="h-4 w-16" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (!searchError) return null;
+
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-destructive" role="alert">
+          Member-Profile konnten nicht geladen werden.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="member"
+          className="w-full"
+          disabled={isPending}
+          onClick={onSearch}
+        >
+          <RefreshCw aria-hidden="true" className="size-4" />
+          Erneut versuchen
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium">
+          {candidates.length > 0
+            ? selectedProfileId
+              ? "Member-Profil ändern"
+              : "Passendes Profil auswählen"
+            : "Keine Treffer"}
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          aria-busy={isSearching}
+          onClick={onSearch}
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={isSearching ? "size-3.5 animate-spin" : "size-3.5"}
+          />
+          Aktualisieren
+        </Button>
+      </div>
+
+      {candidates.length > 0 ? (
+        <ul className="divide-y border-y">
+          {candidates.map((candidate) => {
+            const isSelected = candidate.id === selectedProfileId;
+            return (
+              <li key={candidate.id}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="member"
+                  className={cn(
+                    "h-auto w-full justify-between whitespace-normal rounded-none px-2 py-3 text-left hover:bg-muted/50",
+                    isSelected && "bg-muted/50 disabled:opacity-100",
+                  )}
+                  disabled={isPending || isSelected}
+                  aria-label={
+                    isSelected
+                      ? `${candidate.name} ist als Member-Profil zugeordnet`
+                      : `${candidate.name} als Member-Profil zuordnen`
+                  }
+                  onClick={() => onSelect(candidate.id)}
+                >
+                  <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+                    <span className="font-semibold">{candidate.name}</span>
+                    {candidate.email ? (
+                      <span className="break-all text-xs font-normal text-muted-foreground">
+                        {candidate.email}
+                      </span>
+                    ) : null}
+                    <span className="text-xs font-normal text-muted-foreground">
+                      Geburtsdatum:{" "}
+                      {formatFieldValue(candidate.dateOfBirth, "INPUT_DATE")}
+                    </span>
+                  </span>
+                  {selectingProfileId === candidate.id ? (
+                    <Loader2
+                      aria-hidden="true"
+                      className="size-4 animate-spin"
+                    />
+                  ) : isSelected ? (
+                    <span className="flex items-center gap-1 text-sm font-semibold text-green-700">
+                      <CheckCircle2 aria-hidden="true" className="size-4" />
+                      Zugeordnet
+                    </span>
+                  ) : (
+                    <span className="text-sm font-semibold">Zuordnen</span>
+                  )}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Kein aktives Member-Profil gefunden. Vor der Aufnahme muss die Person
+          eines erstellen.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useApplicationMemberPlatformProfiles } from "@/lib/client/applications/hooks/useApplicationMemberPlatformProfiles";
 import { useApplicationMutations } from "@/lib/client/applications/hooks/useApplicationMutations";
 import type { ApplicationWithFiles } from "@/lib/db/types";
 import { ageOnDate } from "@/lib/members/legalDates";
@@ -18,11 +19,8 @@ export function ApplicationAdmissionRequirements({
 }: {
   application: ApplicationWithFiles;
 }) {
-  const {
-    searchMemberPlatformProfiles,
-    selectMemberPlatformProfile,
-    requestGuardianConsent,
-  } = useApplicationMutations();
+  const { selectMemberPlatformProfile, requestGuardianConsent } =
+    useApplicationMutations();
   const [representativeName, setRepresentativeName] = useState(
     application.guardianConsent?.representativeName ?? "",
   );
@@ -35,22 +33,16 @@ export function ApplicationAdmissionRequirements({
   const isMinor = age !== null && age < 18;
   const isEligible = age !== null && age >= 16 && age < 25;
   const consent = application.guardianConsent;
+  const isEditable = EDITABLE_STATUSES.has(application.status);
+  const memberProfiles = useApplicationMemberPlatformProfiles(
+    application._id,
+    isEditable && !consent?.signedAt,
+  );
   const pending =
-    searchMemberPlatformProfiles.isPending ||
+    memberProfiles.isSearching ||
     selectMemberPlatformProfile.isPending ||
     requestGuardianConsent.isPending;
-  const isEditable = EDITABLE_STATUSES.has(application.status);
   if (application.status === "rejected") return null;
-
-  async function searchProfiles() {
-    try {
-      await searchMemberPlatformProfiles.mutateAsync({
-        applicationId: application._id,
-      });
-    } catch {
-      toast.error("Member-Profile konnten nicht geladen werden.");
-    }
-  }
 
   async function selectProfile(profileId: string) {
     try {
@@ -86,19 +78,21 @@ export function ApplicationAdmissionRequirements({
       <h3 className="text-xl font-semibold">Member-Profil *</h3>
       <ApplicationAdmissionProfile
         canSync={isEditable}
-        candidates={searchMemberPlatformProfiles.data ?? null}
+        candidates={memberProfiles.candidates}
         dateOfBirth={dateOfBirth}
         hasProfile={hasProfile}
         isEligible={isEligible}
         isPending={pending}
         isSigned={Boolean(consent?.signedAt)}
-        isSearching={searchMemberPlatformProfiles.isPending}
+        isSearching={memberProfiles.isSearching}
+        searchError={memberProfiles.isError}
+        selectedProfileId={application.memberPlatformUserId}
         selectingProfileId={
           selectMemberPlatformProfile.isPending
             ? selectMemberPlatformProfile.variables?.profileId
             : undefined
         }
-        onSearch={searchProfiles}
+        onSearch={() => void memberProfiles.refetch()}
         onSelect={selectProfile}
       />
       {hasProfile && isEligible && isMinor ? (

--- a/app/lib/client/applications/hooks/useApplicationMemberPlatformProfiles.ts
+++ b/app/lib/client/applications/hooks/useApplicationMemberPlatformProfiles.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { searchApplicationMemberPlatformProfilesAction } from "@/lib/server/applications/admissionRequirementsAction";
+import type { ApplicationMemberPlatformCandidate } from "@/lib/server/applications/memberPlatformCandidates";
+
+export function useApplicationMemberPlatformProfiles(
+  applicationId: string,
+  enabled: boolean,
+) {
+  const result = useQuery<ApplicationMemberPlatformCandidate[]>({
+    queryKey: ["application-member-platform-profiles", applicationId],
+    queryFn: async () => {
+      const response = await searchApplicationMemberPlatformProfilesAction({
+        applicationId,
+      });
+      if (!response.ok) {
+        throw new Error("Member-Profile konnten nicht geladen werden.");
+      }
+      return response.candidates;
+    },
+    enabled,
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  return {
+    candidates: result.data ?? null,
+    isError: result.isError,
+    isSearching: result.isFetching,
+    refetch: result.refetch,
+  };
+}

--- a/app/lib/client/applications/hooks/useApplicationMutations.ts
+++ b/app/lib/client/applications/hooks/useApplicationMutations.ts
@@ -1,10 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { submitApplicationDecision } from "@/lib/server/applications/decisionAction";
 import { requestGuardianConsent } from "@/lib/server/applications/admissionRequirements";
-import {
-  searchApplicationMemberPlatformProfilesAction,
-  selectApplicationMemberPlatformProfileAction,
-} from "@/lib/server/applications/admissionRequirementsAction";
+import { selectApplicationMemberPlatformProfileAction } from "@/lib/server/applications/admissionRequirementsAction";
+import { submitApplicationDecision } from "@/lib/server/applications/decisionAction";
 import { setApplicationStatus } from "@/lib/server/applications/status";
 
 export function useApplicationMutations() {
@@ -29,19 +26,6 @@ export function useApplicationMutations() {
         if (input.decision === "accepted") {
           queryClient.invalidateQueries({ queryKey: ["members"] });
         }
-      },
-    }),
-    searchMemberPlatformProfiles: useMutation({
-      mutationFn: async (
-        input: Parameters<
-          typeof searchApplicationMemberPlatformProfilesAction
-        >[0],
-      ) => {
-        const result =
-          await searchApplicationMemberPlatformProfilesAction(input);
-        if (!result.ok)
-          throw new Error("Member-Profile konnten nicht geladen werden.");
-        return result.candidates;
       },
     }),
     selectMemberPlatformProfile: useMutation({

--- a/app/lib/server/applications/applications.test.ts
+++ b/app/lib/server/applications/applications.test.ts
@@ -274,7 +274,11 @@ test("enforces allowed non-decision transitions and records them", async () => {
   await setApplicationStatus({ applicationId, status: "interview" });
 
   const stored = await (await applications()).findOne({ _id: applicationId });
-  expect(stored?.status).toBe("interview");
+  expect(stored).toMatchObject({
+    status: "interview",
+    memberPlatformUserId: "platform-alex",
+    dateOfBirth: "2004-01-01",
+  });
   expect(stored?.history).toHaveLength(1);
   expect(stored?.history?.at(-1)).toMatchObject({
     fromStatus: "received",


### PR DESCRIPTION
## summary

- search member-platform candidates automatically and cache results across application status refreshes
- keep the linked profile visibly selected with accessible skeleton and error states
- cover the profile display and interview-transition persistence regressions

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec vitest run app/components/Applications/ApplicationAdmissionProfile.test.ts app/lib/server/applications/applications.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
