### PR TITLE
fix(recruiting): prevent duplicate member profile acceptance

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -51,14 +51,14 @@ export function ApplicationAdmissionProfile({
 
   return (
     <div className="space-y-4">
-      <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-        <p className="flex items-center gap-2 font-semibold text-green-700">
+      <div className="space-y-3 border-y py-3">
+        <p className="flex items-center gap-2 font-medium">
           <CheckCircle2 aria-hidden="true" className="size-4" />
           Member-Profil zugeordnet
         </p>
-        <div className="space-y-1">
-          <p className="text-sm font-medium">Geburtsdatum</p>
-          <p>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</p>
+        <div className="flex items-baseline justify-between gap-4 text-sm">
+          <span className="text-muted-foreground">Geburtsdatum</span>
+          <span>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</span>
         </div>
       </div>
       {!isEligible ? (

--- a/app/components/Applications/ApplicationAdmissionProfileSearch.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfileSearch.tsx
@@ -117,8 +117,8 @@ export function ApplicationAdmissionProfileSearch({
                   variant="ghost"
                   size="member"
                   className={cn(
-                    "h-auto w-full justify-between whitespace-normal rounded-none px-2 py-3 text-left hover:bg-muted/50",
-                    isSelected && "bg-muted/50 disabled:opacity-100",
+                    "h-auto w-full justify-between whitespace-normal rounded-none px-2 py-3 text-left",
+                    isSelected && "disabled:opacity-100",
                   )}
                   disabled={isPending || isSelected}
                   aria-label={
@@ -146,7 +146,7 @@ export function ApplicationAdmissionProfileSearch({
                       className="size-4 animate-spin"
                     />
                   ) : isSelected ? (
-                    <span className="flex items-center gap-1 text-sm font-semibold text-green-700">
+                    <span className="flex items-center gap-1 text-sm font-semibold">
                       <CheckCircle2 aria-hidden="true" className="size-4" />
                       Zugeordnet
                     </span>

--- a/app/lib/server/applications/decision.test.ts
+++ b/app/lib/server/applications/decision.test.ts
@@ -28,6 +28,7 @@ import { YFN_ORGANIZATION } from "../../organization";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { sendApplicationDecision } from "./decision";
+import { submitApplicationDecision } from "./decisionAction";
 import {
   requireWorkspaceAccountReadyTemplateId,
   sendUserStateEmail,
@@ -222,7 +223,7 @@ test("blocks acceptance before external side effects without a member-platform s
   expect(sendMail).not.toHaveBeenCalled();
 });
 
-test("does not send credentials when the onboarding profile cannot be linked", async () => {
+test("rejects an already linked member profile before external side effects", async () => {
   await (
     await users()
   ).createIndex({ memberPlatformUserId: 1 }, { unique: true, sparse: true });
@@ -242,22 +243,23 @@ test("does not send credentials when the onboarding profile cannot be linked", a
   });
 
   await expect(
-    sendApplicationDecision({
+    submitApplicationDecision({
       applicationId,
       decision: "accepted",
       yfnEmail,
       subject: "Zusage",
       message: "Willkommen!",
     }),
-  ).rejects.toThrow("nicht eindeutig");
+  ).resolves.toEqual({
+    ok: false,
+    error: "Das Member-Profil ist bereits mit einem YBase-Nutzer verknüpft.",
+  });
 
+  expect(provisionWorkspaceUser).not.toHaveBeenCalled();
   expect(sendMail).not.toHaveBeenCalled();
   expect(
     await (await applications()).findOne({ _id: applicationId }),
-  ).toMatchObject({
-    status: "review",
-    workspaceProvisioningStatus: "provisioned",
-  });
+  ).not.toHaveProperty("workspaceProvisioningStatus");
 });
 
 test("sends a rejection with its dedicated template and then rejects", async () => {

--- a/app/lib/server/applications/decisionAction.ts
+++ b/app/lib/server/applications/decisionAction.ts
@@ -17,6 +17,8 @@ const DISPLAYABLE_DECISION_ERRORS = new Set([
   "YBase-URL ist nicht konfiguriert",
   "Diese Workspace-E-Mail ist bereits einer Bewerbung zugeordnet",
   "Diese Workspace-E-Mail gehört bereits zu einem YBase-Profil",
+  "Das Member-Profil ist bereits mit einem YBase-Nutzer verknüpft.",
+  "Das Mitglied konnte nicht eindeutig mit der Bewerbung verknüpft werden.",
   "Diese Workspace-E-Mail ist bereits vergeben",
   "Das Workspace-Konto verwendet eine andere E-Mail",
   "Google-Workspace-Integration ist nicht konfiguriert",

--- a/app/lib/server/applications/decisionDelivery.ts
+++ b/app/lib/server/applications/decisionDelivery.ts
@@ -8,6 +8,7 @@ import {
   requireWorkspaceAccountReadyTemplateId,
   sendWorkspaceAccountReadyEmail,
 } from "../users/email";
+import { assertAcceptedApplicantMemberAvailable } from "./memberProvisioning";
 import {
   recordWorkspaceDeliveryFailure,
   recordWorkspaceProvisioned,
@@ -38,6 +39,10 @@ export async function prepareAcceptance(input: {
   workspaceUserId: string;
   workspaceAccess: WorkspaceAccessDetails;
 }> {
+  await assertAcceptedApplicantMemberAvailable({
+    application: input.application,
+    email: input.yfnEmail,
+  });
   requireWorkspaceAccountReadyTemplateId();
   const loginUrl = ybaseLoginUrl();
   const reservation = await reserveWorkspaceProvisioning({

--- a/app/lib/server/applications/memberProvisioning.ts
+++ b/app/lib/server/applications/memberProvisioning.ts
@@ -12,6 +12,37 @@ interface AcceptedApplicantMemberInput {
   teamId: string;
 }
 
+export async function assertAcceptedApplicantMemberAvailable(input: {
+  application: Application;
+  email: string;
+}): Promise<void> {
+  const userCollection = await users();
+  const [existingByEmail, existingByMemberProfile] = await Promise.all([
+    userCollection.findOne({ email: normalizeYfnEmail(input.email) }),
+    input.application.memberPlatformUserId
+      ? userCollection.findOne({
+          memberPlatformUserId: input.application.memberPlatformUserId,
+        })
+      : undefined,
+  ]);
+  if (
+    existingByMemberProfile &&
+    existingByMemberProfile.applicationId !== input.application._id
+  ) {
+    throw new Error(
+      "Das Member-Profil ist bereits mit einem YBase-Nutzer verknüpft.",
+    );
+  }
+  if (
+    existingByEmail &&
+    existingByEmail.applicationId !== input.application._id
+  ) {
+    throw new Error(
+      "Diese Workspace-E-Mail gehört bereits zu einem YBase-Profil",
+    );
+  }
+}
+
 export async function createAcceptedApplicantMember(
   input: AcceptedApplicantMemberInput,
 ): Promise<{ isCreated: boolean; member: User }> {


### PR DESCRIPTION
## summary

- prevent application acceptance when the workspace email or member profile is already linked, before provisioning side effects begin
- surface the actionable conflict and simplify the linked-profile UI with neutral standard styling

## validation

- `pnpm exec prettier --check` (changed files)
- `pnpm exec biome lint` (changed files)
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/server/applications/decision.test.ts app/lib/server/applications/decisionProvisioning.test.ts app/components/Applications/ApplicationAdmissionProfile.test.ts` (14 tests)
- `pnpm lint:lines` fails on pre-existing 212/203-line files that have the same counts on `origin/main`
