### PR TITLE
fix(recruiting): remove duplicate admission age error

### DIFF
--- a/app/components/Applications/ApplicationAdmissionProfile.test.ts
+++ b/app/components/Applications/ApplicationAdmissionProfile.test.ts
@@ -46,7 +46,6 @@ test("shows a skeleton while automatically searching for profiles", () => {
       canSync: true,
       candidates: null,
       hasProfile: false,
-      isEligible: false,
       isPending: true,
       isSearching: true,
       isSigned: false,
@@ -69,7 +68,6 @@ test("keeps the linked profile visibly selected after a step change", () => {
       candidates: [candidate],
       dateOfBirth: candidate.dateOfBirth,
       hasProfile: true,
-      isEligible: true,
       isPending: false,
       isSearching: false,
       isSigned: false,
@@ -84,4 +82,25 @@ test("keeps the linked profile visibly selected after a step change", () => {
   expect(markup).toContain("Alex Beispiel");
   expect(markup).toContain("Zugeordnet");
   expect(markup).toContain("01.01.2004");
+});
+
+test("does not duplicate the decision-level age error in the profile", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ApplicationAdmissionProfile, {
+      canSync: true,
+      candidates: [candidate],
+      dateOfBirth: "2000-01-01",
+      hasProfile: true,
+      isPending: false,
+      isSearching: false,
+      isSigned: false,
+      searchError: false,
+      selectedProfileId: candidate.id,
+      onSearch: vi.fn(),
+      onSelect: vi.fn(),
+    }),
+  );
+
+  expect(markup).toContain("01.01.2000");
+  expect(markup).not.toContain("Bei der Aufnahme muss die Person");
 });

--- a/app/components/Applications/ApplicationAdmissionProfile.tsx
+++ b/app/components/Applications/ApplicationAdmissionProfile.tsx
@@ -6,7 +6,6 @@ import { formatFieldValue } from "./applicationPresentation";
 interface ApplicationAdmissionProfileProps {
   dateOfBirth?: string;
   hasProfile: boolean;
-  isEligible: boolean;
   canSync: boolean;
   candidates: ApplicationMemberPlatformCandidate[] | null;
   isPending: boolean;
@@ -22,7 +21,6 @@ interface ApplicationAdmissionProfileProps {
 export function ApplicationAdmissionProfile({
   dateOfBirth,
   hasProfile,
-  isEligible,
   canSync,
   candidates,
   isPending,
@@ -61,12 +59,6 @@ export function ApplicationAdmissionProfile({
           <span>{formatFieldValue(dateOfBirth, "INPUT_DATE")}</span>
         </div>
       </div>
-      {!isEligible ? (
-        <p className="text-sm text-destructive">
-          Bei der Aufnahme muss die Person mindestens 16 und noch nicht 25 Jahre
-          alt sein.
-        </p>
-      ) : null}
       {canSync && !isSigned ? (
         <ApplicationAdmissionProfileSearch
           candidates={candidates}

--- a/app/components/Applications/ApplicationAdmissionRequirements.tsx
+++ b/app/components/Applications/ApplicationAdmissionRequirements.tsx
@@ -81,7 +81,6 @@ export function ApplicationAdmissionRequirements({
         candidates={memberProfiles.candidates}
         dateOfBirth={dateOfBirth}
         hasProfile={hasProfile}
-        isEligible={isEligible}
         isPending={pending}
         isSigned={Boolean(consent?.signedAt)}
         isSearching={memberProfiles.isSearching}


### PR DESCRIPTION
## summary

- remove the duplicate age warning from the linked member profile while keeping the decision-level validation
- remove the unused eligibility prop and cover the regression

## validation

- `pnpm vitest run app/components/Applications/ApplicationAdmissionProfile.test.ts`
- `pnpm test -- app/components/Applications/ApplicationAdmissionProfile.test.ts` (617 tests passed)
- `pnpm exec biome lint <changed files>`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `pnpm exec biome check <changed files>` reported the repository's Biome formatter differing from its configured Prettier style; the project lint and Prettier checks pass