### PR TITLE
fix(onboarding): remove redundant profile setup step

### DIFF
--- a/app/(protected)/OnboardingNotice.tsx
+++ b/app/(protected)/OnboardingNotice.tsx
@@ -61,6 +61,11 @@ function OnboardingStep({ state, title, description }: StepProps) {
 export function OnboardingNotice({ onboardingStatus }: Props) {
   const isOnboardingComplete = onboardingStatus === "completed";
   const isOnboardingStarted = onboardingStatus === "in_progress";
+  const title = isOnboardingComplete
+    ? "Deine Unterlagen werden geprüft"
+    : isOnboardingStarted
+      ? "Onboarding abschließen"
+      : "Dein Onboarding wird vorbereitet";
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
@@ -69,10 +74,11 @@ export function OnboardingNotice({ onboardingStatus }: Props) {
           <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
             <ClipboardCheck aria-hidden="true" className="size-6" />
           </div>
-          <CardTitle className="text-2xl">Dein Onboarding läuft</CardTitle>
+          <CardTitle className="text-2xl">{title}</CardTitle>
           <CardDescription className="text-base leading-relaxed">
-            Sobald deine Aufgaben abgeschlossen und von People &amp; Culture
-            freigegeben wurden, kannst du YBase vollständig nutzen.
+            Schließe die erforderlichen Unterlagen ab. Nach der Prüfung durch
+            People &amp; Culture wird dein vollständiger YBase-Zugang
+            freigeschaltet.
           </CardDescription>
         </CardHeader>
 
@@ -80,18 +86,18 @@ export function OnboardingNotice({ onboardingStatus }: Props) {
           <ol className="space-y-6" aria-label="Onboarding-Fortschritt">
             <OnboardingStep
               state="completed"
-              title="Registrierung abgeschlossen"
-              description="Dein Teammitglied-Profil wurde angelegt."
+              title="YBase-Zugang eingerichtet"
+              description="Dein Konto wurde angelegt und mit deinem Member-Profil verknüpft."
             />
             <OnboardingStep
               state={isOnboardingComplete ? "completed" : "current"}
-              title="Onboarding-Aufgaben erledigen"
+              title="Unterlagen ausfüllen und bestätigen"
               description={
                 isOnboardingComplete
-                  ? "Alle hinterlegten Aufgaben wurden als abgeschlossen markiert."
+                  ? "Alle erforderlichen Unterlagen wurden abgeschlossen."
                   : isOnboardingStarted
-                    ? "Deine Aufgaben sind in Bearbeitung. Dazu gehört z. B. das Formular zur Teilnahme am Verein."
-                    : "People & Culture stellt dir die Aufgaben bereit, darunter das Formular zur Teilnahme am Verein."
+                    ? "Schließe die dir zugesandten Unterlagen ab, darunter die Datenschutzhinweise und weitere erforderliche Erklärungen."
+                    : "People & Culture stellt dir die erforderlichen Unterlagen bereit."
               }
             />
             <OnboardingStep
@@ -99,8 +105,8 @@ export function OnboardingNotice({ onboardingStatus }: Props) {
               title="Freigabe durch People & Culture"
               description={
                 isOnboardingComplete
-                  ? "Deine Angaben werden geprüft. Nach der Freigabe kannst du unter anderem Erstattungen einreichen."
-                  : "Die Prüfung beginnt, sobald deine Onboarding-Aufgaben abgeschlossen sind."
+                  ? "People & Culture prüft deine Angaben und schaltet anschließend deinen vollständigen Zugang frei."
+                  : "Die Prüfung beginnt, sobald du alle erforderlichen Unterlagen abgeschlossen hast."
               }
             />
           </ol>

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -24,7 +24,10 @@ export default async function ProtectedLayout({
   let content: ReactNode;
   if (isUnavailableMemberStatus(member.memberStatus)) {
     content = <OffboardedNotice />;
-  } else if (member.publicProfileSetupRequired === true) {
+  } else if (
+    member.publicProfileSetupRequired === true &&
+    !member.memberPlatformUserId
+  ) {
     content = (
       <PublicProfileSetup
         canUseGooglePhoto={

--- a/app/lib/server/applications/decision.test.ts
+++ b/app/lib/server/applications/decision.test.ts
@@ -179,7 +179,8 @@ test("sends acceptance, Workspace access, and onboarding instructions in order",
       action: "application.status_change",
     }),
   ).toMatchObject({ action: "application.status_change" });
-  expect(await (await users()).findOne({ applicationId })).toMatchObject({
+  const onboardingMember = await (await users()).findOne({ applicationId });
+  expect(onboardingMember).toMatchObject({
     _id: stored?.onboardingUserId,
     name: "Alex Beispiel",
     email: yfnEmail,
@@ -194,6 +195,7 @@ test("sends acceptance, Workspace access, and onboarding instructions in order",
     memberStatus: "onboarding",
     teamOnboardingStatus: "in_progress",
   });
+  expect(onboardingMember).not.toHaveProperty("publicProfileSetupRequired");
 });
 
 test("blocks acceptance before external side effects without a member-platform snapshot", async () => {

--- a/app/lib/server/applications/memberProvisioning.ts
+++ b/app/lib/server/applications/memberProvisioning.ts
@@ -86,7 +86,6 @@ export async function createAcceptedApplicantMember(
     applicationId: input.application._id,
     memberStatus: "onboarding",
     teamOnboardingStatus: "in_progress",
-    publicProfileSetupRequired: true,
     registeredAt: now,
   };
 


### PR DESCRIPTION
## summary

- skip duplicate YBase profile photo setup when a required member-platform profile is already linked
- clarify that onboarding access depends on completing documents and People & Culture approval

## validation

- `pnpm exec prettier --check app/(protected)/OnboardingNotice.tsx app/(protected)/layout.tsx app/lib/server/applications/memberProvisioning.ts app/lib/server/applications/decision.test.ts`
- `pnpm exec biome lint app/(protected)/layout.tsx app/(protected)/OnboardingNotice.tsx app/lib/server/applications/memberProvisioning.ts app/lib/server/applications/decision.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/server/applications/decision.test.ts`
- `pnpm exec vitest run app/lib/server/users/users.test.ts app/lib/auth/config.test.ts app/lib/server/memberPlatform/linking.test.ts`
- `pnpm build`