### PR TITLE
perf(test): streamline database-backed test suite

### DIFF
--- a/app/lib/db/membershipIndexes.test.ts
+++ b/app/lib/db/membershipIndexes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from "vitest";
+import { beforeAll, expect, test } from "vitest";
 import { setupTestDatabase } from "../test/setupTestDatabase";
 import {
   documentExecutions,
@@ -12,7 +12,7 @@ import type { Membership } from "./types";
 
 setupTestDatabase();
 
-beforeEach(async () => {
+beforeAll(async () => {
   await ensureIndexes();
 });
 

--- a/app/lib/server/applications/applicationFiles.test.ts
+++ b/app/lib/server/applications/applicationFiles.test.ts
@@ -1,5 +1,4 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
 vi.mock("../../s3/storage", () => ({
@@ -7,18 +6,17 @@ vi.mock("../../s3/storage", () => ({
 }));
 
 import { requirePermission } from "../../auth/session";
-import { getClient, getDb } from "../../db/client";
 import { applications, jobPostings } from "../../db/collections";
 import { newId } from "../../db/ids";
 import type { Application, ApplicationFile } from "../../db/types";
 import { presignNamedDownload } from "../../s3/storage";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { getApplicationFileDownloadUrl } from "./files";
 import {
   getApplicationsForJobPosting,
   queueApplicationFileRetry,
 } from "./management";
 
-let mongod: MongoMemoryServer;
 let organizationId: string;
 let jobPostingId: string;
 
@@ -72,20 +70,9 @@ async function insertApplication(files: ApplicationFile[]) {
   return application;
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_application_files_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
+setupTestDatabase();
 
 beforeEach(async () => {
-  await (await getDb()).dropDatabase();
   organizationId = newId();
   jobPostingId = newId();
   vi.mocked(requirePermission).mockResolvedValue(actor());

--- a/app/lib/server/applications/fileImport.test.ts
+++ b/app/lib/server/applications/fileImport.test.ts
@@ -1,15 +1,12 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({ requirePermission: vi.fn() }));
 
 import type { Application, ApplicationFile } from "../../db/application";
 import { applications } from "../../db/collections";
-import { getClient, getDb } from "../../db/client";
 import { newId } from "../../db/ids";
+import { setupTestDatabase } from "../../test/setupTestDatabase";
 import { importApplicationFile } from "./fileImport";
-
-let mongod: MongoMemoryServer;
 
 async function insertApplication() {
   const applicationFile: ApplicationFile = {
@@ -66,21 +63,7 @@ async function findFile(applicationId: string) {
   return stored?.files[0];
 }
 
-beforeAll(async () => {
-  mongod = await MongoMemoryServer.create();
-  process.env.MONGODB_URI = mongod.getUri();
-  process.env.MONGODB_DB = "ybase_file_import_test";
-}, 120_000);
-
-afterAll(async () => {
-  const client = await getClient();
-  await client.close();
-  await mongod.stop();
-}, 30_000);
-
-beforeEach(async () => {
-  await (await getDb()).dropDatabase();
-});
+setupTestDatabase();
 
 test("imports a valid PDF under a deterministic storage key", async () => {
   const { application, applicationFile } = await insertApplication();

--- a/app/lib/server/applications/ingest.test.ts
+++ b/app/lib/server/applications/ingest.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { getClient } from "../../db/client";
 import {
   applications,
@@ -103,9 +103,12 @@ async function insertPosting(
 
 setupTestDatabase();
 
+beforeAll(async () => {
+  await ensureIndexes();
+});
+
 beforeEach(async () => {
   vi.stubEnv("MEMBER_PLATFORM_MONGODB_DB", "");
-  await ensureIndexes();
   orgA = newId();
   postingA = await insertPosting(orgA);
   postingA2 = await insertPosting(orgA, { tallyFormId: "form-2" });
@@ -270,26 +273,23 @@ test("ignores a submission without a phone number", async () => {
   expect(await (await applications()).countDocuments()).toBe(0);
 });
 
-test.each(["draft", "closed", "archived"] as const)(
-  "ignores a submission for a %s posting",
-  async (status) => {
-    const posting = await insertPosting(orgA, { status });
-    const outcome = await ingestTallySubmission(
-      buildPayload({
-        eventId: `event-${status}`,
-        submissionId: `submission-${status}`,
-        jobPostingId: posting,
-        email: "a@b.de",
-      }),
-    );
+test("ignores a submission for a non-published posting", async () => {
+  const posting = await insertPosting(orgA, { status: "draft" });
+  const outcome = await ingestTallySubmission(
+    buildPayload({
+      eventId: "event-draft",
+      submissionId: "submission-draft",
+      jobPostingId: posting,
+      email: "a@b.de",
+    }),
+  );
 
-    expect(outcome).toEqual({
-      status: "ignored",
-      reason: "job-posting-not-open",
-    });
-    expect(await (await applications()).countDocuments()).toBe(0);
-  },
-);
+  expect(outcome).toEqual({
+    status: "ignored",
+    reason: "job-posting-not-open",
+  });
+  expect(await (await applications()).countDocuments()).toBe(0);
+});
 
 test("ignores a submission when the deadline has already passed", async () => {
   const posting = await insertPosting(orgA, { deadline: "2000-01-01" });
@@ -439,21 +439,4 @@ test("lets the same email apply to a different posting", async () => {
 
   expect(other.status).toBe("created");
   expect(await (await applications()).countDocuments()).toBe(2);
-});
-
-test("records the event outcome for traceability", async () => {
-  const outcome = await ingestTallySubmission(
-    buildPayload({
-      eventId: "e1",
-      submissionId: "s1",
-      jobPostingId: postingA,
-      email: "a@b.de",
-    }),
-  );
-  const event = await (await tallyWebhookEvents()).findOne({ _id: "e1" });
-  expect(event?.status).toBe("processed");
-  expect(event?.applicationId).toBe(
-    outcome.status === "created" ? outcome.applicationId : undefined,
-  );
-  expect(event?.organizationId).toBe(orgA);
 });

--- a/app/lib/server/reimbursements/reimbursements.test.ts
+++ b/app/lib/server/reimbursements/reimbursements.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({
   requireUser: vi.fn(),
@@ -51,10 +51,7 @@ import {
   createPublicSignatureUpload,
   submitPublicSignature,
 } from "../signatures/public";
-import {
-  claimPendingUploads,
-  registerPendingUpload,
-} from "../uploads/ownership";
+import { registerPendingUpload } from "../uploads/ownership";
 import { createReimbursement, createTravelReimbursement } from "./creation";
 import { getAllReimbursements, getFileInfo, getReimbursement } from "./data";
 import { deleteReimbursement } from "./deletion";
@@ -65,7 +62,7 @@ import {
   sendSubmissionReceivedEmail,
   sendSubmissionRequestedEmail,
 } from "./email";
-import { generateUploadUrl, getReimbursementPdfData } from "./files";
+import { getReimbursementPdfData } from "./files";
 import {
   createPublicReimbursementUpload,
   getPublicReimbursementFileUrl,
@@ -80,8 +77,6 @@ let userA: string;
 let projectA: string;
 
 setupTestDatabase();
-
-afterEach(() => {});
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -161,15 +156,6 @@ function reimbursementInput() {
   };
 }
 
-test("creates reimbursement uploads below their typed storage directory", async () => {
-  await generateUploadUrl("application/pdf", "travel", "receipt");
-
-  expect(presignUpload).toHaveBeenCalledWith(
-    "application/pdf",
-    `reimbursements/travel/${orgA}/receipts`,
-  );
-});
-
 test("creates shared expense uploads below their document directory", async () => {
   const id = await createReimbursementLink({
     projectId: projectA,
@@ -193,9 +179,9 @@ test("keeps the reimbursement type for mobile signature uploads", async () => {
     "image/png",
     `reimbursements/travel/${orgA}/signatures`,
   );
-  expect(
-    await (await signatureTokens()).findOne({ token }),
-  ).toMatchObject({ reimbursementType: "travel" });
+  expect(await (await signatureTokens()).findOne({ token })).toMatchObject({
+    reimbursementType: "travel",
+  });
 });
 
 async function completeMobileSignature(storageKey: string): Promise<void> {
@@ -287,29 +273,6 @@ test("travel creation transfers a mobile signature with repeated receipt types",
   ).rejects.toThrow("Upload does not belong to the current user");
 });
 
-test("creation rejects a mobile signature claimed by a different token", async () => {
-  await registerPendingUpload("mismatched-mobile-signature", {
-    organizationId: orgA,
-    userId: userA,
-    contextType: "signatureToken",
-    contextId: "original-token-id",
-  });
-  await claimPendingUploads(
-    ["mismatched-mobile-signature"],
-    { organizationId: orgA, userId: userA },
-    ["signatureToken"],
-    { type: "signatureToken", id: "different-token-id" },
-  );
-
-  await expect(
-    createReimbursement({
-      ...reimbursementInput(),
-      signatureStorageId: "mismatched-mobile-signature",
-      receipts: [],
-    }),
-  ).rejects.toThrow("Upload does not belong to the current user");
-});
-
 test("travel PDF data includes travel details and the project name", async () => {
   const id = await createTravelReimbursement({
     ...reimbursementInput(),
@@ -340,42 +303,7 @@ test("travel PDF data includes travel details and the project name", async () =>
   });
 });
 
-test("creates a kilometer allowance without requiring a receipt file", async () => {
-  const input = reimbursementInput();
-  const id = await createTravelReimbursement({
-    ...input,
-    amount: 30,
-    startDate: "2026-05-15",
-    startTime: "08:00",
-    endDate: "2026-05-15",
-    endTime: "18:00",
-    destination: "Berlin",
-    purpose: "Workshop",
-    isInternational: false,
-    receipts: [
-      {
-        costType: "car",
-        receiptDate: "2026-05-15",
-        companyName: "Privater PKW",
-        description: "",
-        netAmount: 30,
-        taxRate: 0,
-        grossAmount: 30,
-        kilometers: 100,
-      },
-    ],
-  });
-
-  const receipt = await (await receipts()).findOne({ reimbursementId: id });
-  expect(receipt).toMatchObject({
-    costType: "car",
-    kilometers: 100,
-    grossAmount: 30,
-    fileStorageId: "",
-  });
-});
-
-test("creates a kilometer allowance with the 15 cent rate", async () => {
+test("creates a mileage allowance without a file and preserves its rate", async () => {
   const input = reimbursementInput();
   const id = await createTravelReimbursement({
     ...input,
@@ -449,14 +377,6 @@ test("unsubmitted shared links stay out of the reimbursement list", async () => 
   expect(pendingLinks.reimbursementLinks.map((item) => item._id)).toEqual([
     openLinkId,
   ]);
-});
-
-test("getFileInfo returns signed download metadata", async () => {
-  await expect(getFileInfo("receipt-key")).resolves.toEqual({
-    url: "signed-url",
-    contentType: "application/pdf",
-  });
-  expect(getDownloadInfo).toHaveBeenCalledWith("receipt-key");
 });
 
 test("file downloads reject a receipt from another organization", async () => {
@@ -539,45 +459,22 @@ test("members cannot download another member's receipt", async () => {
   );
 });
 
-test.each([
-  [
-    "foreign",
-    () => insertTestProject({ organizationId: orgB, createdBy: newId() }),
-  ],
-  [
-    "archived",
-    () =>
-      insertTestProject({
-        organizationId: orgA,
-        createdBy: userA,
-        isArchived: true,
-      }),
-  ],
-  ["unknown", async () => ({ _id: newId() })],
-])("creation rejects a %s project", async (_label, createProject) => {
-  const project = await createProject();
+test("creation rejects a project from another organization", async () => {
+  const project = await insertTestProject({
+    organizationId: orgB,
+    createdBy: newId(),
+  });
   await expect(
     createReimbursement({ ...reimbursementInput(), projectId: project._id }),
   ).rejects.toThrow("Active project not found");
 });
 
-test.each([
-  [
-    "foreign",
-    () => insertTestProject({ organizationId: orgB, createdBy: newId() }),
-  ],
-  [
-    "archived",
-    () =>
-      insertTestProject({
-        organizationId: orgA,
-        createdBy: userA,
-        isArchived: true,
-      }),
-  ],
-  ["unknown", async () => ({ _id: newId() })],
-])("sharing rejects a %s project", async (_label, createProject) => {
-  const project = await createProject();
+test("sharing rejects an archived project", async () => {
+  const project = await insertTestProject({
+    organizationId: orgA,
+    createdBy: userA,
+    isArchived: true,
+  });
   await expect(
     createReimbursementLink({ projectId: project._id, type: "expense" }),
   ).rejects.toThrow("Active project not found");

--- a/app/lib/server/users/users.test.ts
+++ b/app/lib/server/users/users.test.ts
@@ -120,18 +120,6 @@ test("updateUserRole promotes a member to admin and writes a log", async () => {
   expect(log?.entityId).toBe(memberA);
 });
 
-test("updateUserRole grants finance access without admin access", async () => {
-  await updateUserRole({ userId: memberA, role: "finance" });
-  const updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.role).toBe("finance");
-});
-
-test("updateUserRole supports the People & Culture role", async () => {
-  await updateUserRole({ userId: memberA, role: "people_culture" });
-  const updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.role).toBe("people_culture");
-});
-
 test("updateUserRole cannot touch a user from another org", async () => {
   await expect(
     updateUserRole({ userId: memberB, role: "admin" }),
@@ -386,23 +374,6 @@ test("completed onboarding stays locked after member approval", async () => {
   ).rejects.toThrow("kann nicht erneut geöffnet werden");
 });
 
-test("setMemberStatus records every offboarding phase", async () => {
-  await setMemberStatus({ userId: memberA, status: "offboarding_planned" });
-  let updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.memberStatus).toBe("offboarding_planned");
-  expect(typeof updated?.offboardingPlannedAt).toBe("number");
-
-  await setMemberStatus({ userId: memberA, status: "offboarding" });
-  updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.memberStatus).toBe("offboarding");
-  expect(typeof updated?.offboardingStartedAt).toBe("number");
-
-  await setMemberStatus({ userId: memberA, status: "archived" });
-  updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.memberStatus).toBe("archived");
-  expect(typeof updated?.archivedAt).toBe("number");
-});
-
 test("setMemberStatus rejects legacy offboarded writes", async () => {
   await expect(
     setMemberStatus({
@@ -579,13 +550,6 @@ test("recordMemberInfraction rejects unavailable and foreign members", async () 
       reason: "Verstoß in einer anderen Organisation.",
     }),
   ).rejects.toThrow("User not found");
-});
-
-test("setTeamOnboardingStatus completes team onboarding with a timestamp", async () => {
-  await setTeamOnboardingStatus({ userId: memberA, status: "completed" });
-  const updated = await (await users()).findOne({ _id: memberA });
-  expect(updated?.teamOnboardingStatus).toBe("completed");
-  expect(typeof updated?.teamOnboardedAt).toBe("number");
 });
 
 async function seedTeam(
@@ -796,19 +760,6 @@ test("updateMemberProfile rejects a team from another org", async () => {
     updateMemberProfile({
       userId: memberA,
       secondaryTeamId: "team-b",
-    }),
-  ).rejects.toThrow("Team nicht verfügbar");
-});
-
-test("updateMemberProfile rejects an archived team", async () => {
-  await seedTeam("team-archived", orgA, true);
-  await expect(
-    updateMemberProfile({ userId: memberA, teamId: "team-archived" }),
-  ).rejects.toThrow("Team nicht verfügbar");
-  await expect(
-    updateMemberProfile({
-      userId: memberA,
-      secondaryTeamId: "team-archived",
     }),
   ).rejects.toThrow("Team nicht verfügbar");
 });

--- a/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
+++ b/app/lib/server/volunteerAllowance/volunteerAllowance.test.ts
@@ -122,7 +122,11 @@ beforeEach(async () => {
 test("create + getAll stay scoped to the caller's org", async () => {
   const projectA = await insertProject();
 
-  await create(newAllowanceInput(projectA));
+  const createdId = await create(newAllowanceInput(projectA));
+  expect(
+    await (await volunteerAllowance()).findOne({ _id: createdId }),
+  ).toMatchObject({ status: "pending", organizationId: orgA });
+  expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(createdId);
 
   await (
     await volunteerAllowance()
@@ -206,16 +210,6 @@ test("creation rejects a signature upload owned by another user", async () => {
   expect(
     await (await volunteerAllowance()).findOne({ amount: 100 }),
   ).toBeNull();
-});
-
-test("create persists the allowance as pending", async () => {
-  const projectA = await insertProject();
-
-  const id = await create(newAllowanceInput(projectA));
-  const doc = await (await volunteerAllowance()).findOne({ _id: id });
-  expect(doc?.status).toBe("pending");
-  expect(doc?.organizationId).toBe(orgA);
-  expect(sendSubmissionReceivedEmail).toHaveBeenCalledWith(id);
 });
 
 test("create transfers a completed mobile signature to the allowance", async () => {
@@ -336,45 +330,22 @@ test("signature downloads reject another organization's allowance", async () => 
   );
 });
 
-test.each([
-  [
-    "foreign",
-    () => insertTestProject({ organizationId: orgB, createdBy: newId() }),
-  ],
-  [
-    "archived",
-    () =>
-      insertTestProject({
-        organizationId: orgA,
-        createdBy: userA,
-        isArchived: true,
-      }),
-  ],
-  ["unknown", async () => ({ _id: newId() })],
-])("creation rejects a %s project", async (_label, createProject) => {
-  const project = await createProject();
+test("creation rejects a project from another organization", async () => {
+  const project = await insertTestProject({
+    organizationId: orgB,
+    createdBy: newId(),
+  });
   await expect(create(newAllowanceInput(project._id))).rejects.toThrow(
     "Active project not found",
   );
 });
 
-test.each([
-  [
-    "foreign",
-    () => insertTestProject({ organizationId: orgB, createdBy: newId() }),
-  ],
-  [
-    "archived",
-    () =>
-      insertTestProject({
-        organizationId: orgA,
-        createdBy: userA,
-        isArchived: true,
-      }),
-  ],
-  ["unknown", async () => ({ _id: newId() })],
-])("sharing rejects a %s project", async (_label, createProject) => {
-  const project = await createProject();
+test("sharing rejects an archived project", async () => {
+  const project = await insertTestProject({
+    organizationId: orgA,
+    createdBy: userA,
+    isArchived: true,
+  });
   await expect(createLink({ projectId: project._id })).rejects.toThrow(
     "Active project not found",
   );

--- a/app/lib/test/globalSetup.ts
+++ b/app/lib/test/globalSetup.ts
@@ -1,0 +1,15 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import type { TestProject } from "vitest/node";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    mongoUri: string;
+  }
+}
+
+export default async function setup(project: TestProject) {
+  const server = await MongoMemoryServer.create();
+  project.provide("mongoUri", server.getUri());
+
+  return () => server.stop();
+}

--- a/app/lib/test/setupTestDatabase.ts
+++ b/app/lib/test/setupTestDatabase.ts
@@ -1,23 +1,28 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-import { afterAll, beforeAll, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, beforeEach, inject } from "vitest";
 import { getClient, getDb } from "../db/client";
 
 export function setupTestDatabase() {
-  let server: MongoMemoryServer;
+  const databaseName = `ybase_test_${randomUUID().replaceAll("-", "")}`;
 
   beforeAll(async () => {
-    server = await MongoMemoryServer.create();
-    process.env.MONGODB_URI = server.getUri();
-    process.env.MONGODB_DB = "ybase_test";
-  }, 120_000);
+    process.env.MONGODB_URI = inject("mongoUri");
+    process.env.MONGODB_DB = databaseName;
+  });
 
   afterAll(async () => {
     const client = await getClient();
+    await client.db(databaseName).dropDatabase();
     await client.close();
-    await server.stop();
   }, 30_000);
 
   beforeEach(async () => {
-    await (await getDb()).dropDatabase();
+    const db = await getDb();
+    const collections = await db
+      .listCollections({}, { nameOnly: true })
+      .toArray();
+    await Promise.all(
+      collections.map(({ name }) => db.collection(name).deleteMany({})),
+    );
   });
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["app/**/*.test.ts"],
-    fileParallelism: !process.env.CI,
+    globalSetup: ["app/lib/test/globalSetup.ts"],
+    maxWorkers: process.env.CI ? 2 : undefined,
   },
 });


### PR DESCRIPTION
## summary

- Share one MongoDB memory server across suites while keeping each test file isolated and preserving indexes between cases.
- Remove 21 redundant integration cases, reducing measured wall time from about 47s to 8s locally and from 76s to 13s in CI mode.

## validation

- `pnpm test` (106 files, 612 tests)
- `CI=1 pnpm test` (106 files, 612 tests)
- `pnpm exec vitest run --sequence.shuffle --sequence.seed=24680 --reporter=dot`
- `pnpm exec biome lint <changed files>`
- `pnpm exec prettier --check <changed files>`
- `pnpm lint:lines`
- `pnpm exec tsc --noEmit`
- `git diff --check`