### PR TITLE
fix(onboarding): simplify membership application form

### DIFF
--- a/app/(protected)/membership-onboarding/MembershipApplicationStep.tsx
+++ b/app/(protected)/membership-onboarding/MembershipApplicationStep.tsx
@@ -12,15 +12,7 @@ import {
   MembershipApplicationFields,
 } from "./MembershipApplicationFields";
 import { OnboardingSignatureField } from "./OnboardingSignatureField";
-import { Confirmation, Field } from "./ProfileFields";
-
-const CONFIRMATION_TEXTS = {
-  profile:
-    "Ich bestätige, dass meine oben angegebenen persönlichen Daten vollständig und richtig sind.",
-  privacy:
-    "Ich habe die Datenschutzgrundverordnung gelesen und akzeptiere sie.",
-  purposes: "Ich unterstütze die in der Satzung festgelegten Vereinszwecke.",
-};
+import { Field } from "./ProfileFields";
 
 export function MembershipApplicationStep({
   profile,
@@ -40,13 +32,7 @@ export function MembershipApplicationStep({
     place: profile.address.city,
   });
   const [signature, setSignature] = useState("");
-  const [confirmed, setConfirmed] = useState({
-    profile: false,
-    privacy: false,
-    purposes: false,
-  });
   const [isPending, startTransition] = useTransition();
-  const allConfirmed = Object.values(confirmed).every(Boolean);
 
   function update(field: keyof ApplicationValues, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
@@ -69,9 +55,6 @@ export function MembershipApplicationStep({
           ...values,
           gender,
           signatureStorageKey: signature,
-          profileDataConfirmed: true,
-          privacyAccepted: true,
-          supportsAssociationPurposes: true,
         });
         await onComplete();
         toast.success("Mitgliedsantrag unterschrieben.");
@@ -95,21 +78,6 @@ export function MembershipApplicationStep({
           update={update}
         />
 
-        <div className="space-y-4 border-2 border-input bg-muted/40 p-4">
-          {Object.entries(CONFIRMATION_TEXTS).map(([key, text]) => (
-            <Confirmation
-              key={key}
-              id={`membership-confirm-${key}`}
-              checked={confirmed[key as keyof typeof confirmed]}
-              onCheckedChange={(checked) =>
-                setConfirmed((current) => ({ ...current, [key]: checked }))
-              }
-            >
-              {text}
-            </Confirmation>
-          ))}
-        </div>
-
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="Ort" htmlFor="membership-place">
             <Input
@@ -131,7 +99,7 @@ export function MembershipApplicationStep({
           />
         </Field>
 
-        <Button type="submit" disabled={isPending || !allConfirmed}>
+        <Button type="submit" disabled={isPending}>
           {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
           Mitgliedsantrag unterschreiben
         </Button>

--- a/app/(protected)/membership-onboarding/MembershipOnboarding.tsx
+++ b/app/(protected)/membership-onboarding/MembershipOnboarding.tsx
@@ -39,12 +39,15 @@ export function MembershipOnboarding() {
         {context && !error && current && (
           <DocumentStep document={current} onComplete={reload} />
         )}
-        {context && !error && !current && !context.profile.confirmed && (
-          <MembershipApplicationStep
-            profile={context.profile}
-            onComplete={reload}
-          />
-        )}
+        {context &&
+          !error &&
+          !current &&
+          !context.profile.applicationSigned && (
+            <MembershipApplicationStep
+              profile={context.profile}
+              onComplete={reload}
+            />
+          )}
         {done && (
           <p className="max-w-[46rem] text-sm text-muted-foreground">
             Deine Unterlagen und dein Mitgliedsantrag sind vollständig. Dein

--- a/app/(protected)/membership-onboarding/OnboardingContext.tsx
+++ b/app/(protected)/membership-onboarding/OnboardingContext.tsx
@@ -62,14 +62,19 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     error,
     reload,
     current: context?.documents.find(({ status }) => status === "assigned"),
-    done: Boolean(context?.documentsComplete && context.profile.confirmed),
+    done: Boolean(
+      context?.documentsComplete && context.profile.applicationSigned,
+    ),
     steps: context
       ? [
           ...context.documents.map((document) => ({
             label: document.title,
             complete: document.status === "completed",
           })),
-          { label: "Mitgliedsantrag", complete: context.profile.confirmed },
+          {
+            label: "Mitgliedsantrag",
+            complete: context.profile.applicationSigned,
+          },
         ]
       : [],
   };

--- a/app/(protected)/membership-onboarding/ProfileFields.tsx
+++ b/app/(protected)/membership-onboarding/ProfileFields.tsx
@@ -1,5 +1,3 @@
-import { Checkbox } from "@/components/ui/checkbox";
-
 export function Field({
   label,
   htmlFor,
@@ -12,38 +10,13 @@ export function Field({
   return (
     <div className="space-y-2">
       {htmlFor ? (
-        <label htmlFor={htmlFor} className="text-sm font-medium">
+        <label htmlFor={htmlFor} className="block text-sm font-medium">
           {label}
         </label>
       ) : (
         <p className="text-sm font-medium">{label}</p>
       )}
       {children}
-    </div>
-  );
-}
-
-export function Confirmation({
-  id,
-  checked,
-  onCheckedChange,
-  children,
-}: {
-  id: string;
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-start gap-3">
-      <Checkbox
-        id={id}
-        checked={checked}
-        onCheckedChange={(value) => onCheckedChange(value === true)}
-      />
-      <label htmlFor={id} className="text-sm leading-5">
-        {children}
-      </label>
     </div>
   );
 }

--- a/app/lib/db/membership.ts
+++ b/app/lib/db/membership.ts
@@ -73,8 +73,6 @@ export interface Membership {
   address?: PostalAddress;
   memberPlatformUserId?: string;
   applicationSignature?: MembershipApplicationSignature;
-  profileConfirmedAt?: number;
-  purposesConfirmedAt?: number;
   resignationReceivedAt?: number;
   scheduledEndAt?: number;
   scheduledEndReason?: Extract<

--- a/app/lib/server/memberships/membershipApplication.test.ts
+++ b/app/lib/server/memberships/membershipApplication.test.ts
@@ -51,9 +51,6 @@ const FORM = {
   country: "Deutschland",
   place: "Berlin",
   signatureStorageKey: SIGNATURE_STORAGE_KEY,
-  profileDataConfirmed: true,
-  privacyAccepted: true,
-  supportsAssociationPurposes: true,
 } as const;
 
 let actor: User & { organizationId: string };
@@ -145,7 +142,7 @@ test("blocks the membership form until every document is completed", async () =>
   expect(putObject).not.toHaveBeenCalled();
   expect(
     await (await memberships()).findOne({ _id: membershipId }),
-  ).not.toHaveProperty("profileConfirmedAt");
+  ).not.toHaveProperty("applicationSignature");
 });
 
 test("stores the signed application and activates the account", async () => {
@@ -174,8 +171,6 @@ test("stores the signed application and activates the account", async () => {
       ipAddress: "192.0.2.1",
       signatureStorageKey: SIGNATURE_STORAGE_KEY,
     },
-    profileConfirmedAt: expect.any(Number),
-    purposesConfirmedAt: expect.any(Number),
   });
   expect(await (await users()).findOne({ _id: actor._id })).toMatchObject({
     memberStatus: "active",

--- a/app/lib/server/memberships/membershipApplication.ts
+++ b/app/lib/server/memberships/membershipApplication.ts
@@ -24,9 +24,6 @@ const applicationSchema = z.object({
   country: z.string().trim().min(2).max(100),
   place: z.string().trim().min(2).max(100),
   signatureStorageKey: z.string().min(1),
-  profileDataConfirmed: z.literal(true),
-  privacyAccepted: z.literal(true),
-  supportsAssociationPurposes: z.literal(true),
 });
 
 export async function submitOwnMembershipApplication(
@@ -105,8 +102,6 @@ export async function submitOwnMembershipApplication(
           ...(await membershipRequestMetadata()),
         },
         admissionEvidenceStorageKey: evidenceStorageKey,
-        profileConfirmedAt: signedAt,
-        purposesConfirmedAt: signedAt,
         updatedAt: signedAt,
       },
     },

--- a/app/lib/server/memberships/membershipApplicationPdf.ts
+++ b/app/lib/server/memberships/membershipApplicationPdf.ts
@@ -12,12 +12,6 @@ import {
   writeText,
 } from "./pdfLayout";
 
-const CONFIRMATIONS = [
-  "Ich habe die Datenschutzgrundverordnung gelesen und akzeptiere sie.",
-  "Ich unterstütze die in der Satzung festgelegten Vereinszwecke.",
-  "Ich bestätige, dass meine oben angegebenen persönlichen Daten vollständig und richtig sind.",
-];
-
 export interface MembershipApplicationPdfInput {
   organization: Organization;
   membershipNumber: string;
@@ -52,12 +46,6 @@ export async function createMembershipApplicationPdf(
   writeGap(writer, 20);
   for (const [label, value] of applicantFields(input)) {
     writeText(writer, `${label}: ${value}`, { size: 10, gap: 4 });
-  }
-
-  writeGap(writer, 18);
-  writeText(writer, "DSGVO und Vereinszweck", { size: 13, bold: true, gap: 8 });
-  for (const confirmation of CONFIRMATIONS) {
-    writeText(writer, `• ${confirmation}`, { size: 10, indent: 8, gap: 4 });
   }
 
   writeGap(writer, 20);

--- a/app/lib/server/memberships/onboardingCompletion.ts
+++ b/app/lib/server/memberships/onboardingCompletion.ts
@@ -16,7 +16,7 @@ export async function activateMembershipOnboardingIfComplete(
     isCurrent: true,
     legalStatus: { $in: ["active", "resigning"] },
   });
-  if (!membership?.profileConfirmedAt || !membership.purposesConfirmedAt) {
+  if (!membership?.applicationSignature) {
     return false;
   }
   const assignedDocuments = await (

--- a/app/lib/server/memberships/onboardingData.test.ts
+++ b/app/lib/server/memberships/onboardingData.test.ts
@@ -111,7 +111,7 @@ test("creates the legal record and returns the documents in reading order", asyn
     firstName: "Alex",
     lastName: "Beispiel",
     dateOfBirth: "2004-01-01",
-    confirmed: false,
+    applicationSigned: false,
   });
   expect(first.documents.map(({ kind }) => kind)).toEqual([
     "privacy_notice",

--- a/app/lib/server/memberships/onboardingData.ts
+++ b/app/lib/server/memberships/onboardingData.ts
@@ -32,7 +32,7 @@ export interface MembershipOnboardingContext {
     privateEmail: string;
     phone: string;
     address: PostalAddress;
-    confirmed: boolean;
+    applicationSigned: boolean;
   };
   documents: MembershipOnboardingDocument[];
 }
@@ -91,9 +91,7 @@ export async function getOwnMembershipOnboardingContext(): Promise<
         city: "",
         country: "Deutschland",
       },
-      confirmed: Boolean(
-        membership.profileConfirmedAt && membership.purposesConfirmedAt,
-      ),
+      applicationSigned: Boolean(membership.applicationSignature),
     },
     documents,
   };


### PR DESCRIPTION
## summary

- remove redundant privacy, bylaws, and profile confirmation checkboxes from the signed membership application and generated PDF
- remove the duplicate signing place and date fields so only the signature follows the member details
- use the application signature as the completion evidence and normalize editable field label spacing

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm exec vitest run app/lib/server/memberships/membershipApplication.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`