### PR TITLE
fix(onboarding): remove duplicate signing details

### DIFF
--- a/app/(protected)/membership-onboarding/MembershipApplicationFields.tsx
+++ b/app/(protected)/membership-onboarding/MembershipApplicationFields.tsx
@@ -24,7 +24,6 @@ export interface ApplicationValues {
   postalCode: string;
   city: string;
   country: string;
-  place: string;
 }
 
 export function MembershipApplicationFields({

--- a/app/(protected)/membership-onboarding/MembershipApplicationStep.tsx
+++ b/app/(protected)/membership-onboarding/MembershipApplicationStep.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { submitOwnMembershipApplication } from "@/lib/server/memberships/membershipApplication";
 import type { MembershipOnboardingContext } from "@/lib/server/memberships/onboardingData";
 import { Loader2 } from "lucide-react";
@@ -29,7 +28,6 @@ export function MembershipApplicationStep({
     postalCode: profile.address.postalCode,
     city: profile.address.city,
     country: profile.address.country,
-    place: profile.address.city,
   });
   const [signature, setSignature] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -77,20 +75,6 @@ export function MembershipApplicationStep({
           values={values}
           update={update}
         />
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          <Field label="Ort" htmlFor="membership-place">
-            <Input
-              id="membership-place"
-              required
-              value={values.place}
-              onChange={(event) => update("place", event.target.value)}
-            />
-          </Field>
-          <Field label="Datum">
-            <Input value={new Date().toLocaleDateString("de-DE")} disabled />
-          </Field>
-        </div>
 
         <Field label="Unterschrift Mitglied">
           <OnboardingSignatureField

--- a/app/lib/db/membership.ts
+++ b/app/lib/db/membership.ts
@@ -20,7 +20,6 @@ export interface PostalAddress {
 export type MembershipGender = "female" | "male" | "diverse";
 
 export interface MembershipApplicationSignature {
-  place: string;
   signedAt: number;
   signatureStorageKey: string;
   ipAddress?: string;

--- a/app/lib/server/memberships/membershipApplication.test.ts
+++ b/app/lib/server/memberships/membershipApplication.test.ts
@@ -49,7 +49,6 @@ const FORM = {
   postalCode: "10115",
   city: "Berlin",
   country: "Deutschland",
-  place: "Berlin",
   signatureStorageKey: SIGNATURE_STORAGE_KEY,
 } as const;
 
@@ -167,7 +166,6 @@ test("stores the signed application and activates the account", async () => {
     address: { street: "Beispielstraße 12", city: "Berlin" },
     admissionEvidenceStorageKey: `${directory}/membership-application.pdf`,
     applicationSignature: {
-      place: "Berlin",
       ipAddress: "192.0.2.1",
       signatureStorageKey: SIGNATURE_STORAGE_KEY,
     },

--- a/app/lib/server/memberships/membershipApplication.ts
+++ b/app/lib/server/memberships/membershipApplication.ts
@@ -22,7 +22,6 @@ const applicationSchema = z.object({
   postalCode: z.string().trim().min(3).max(20),
   city: z.string().trim().min(2).max(100),
   country: z.string().trim().min(2).max(100),
-  place: z.string().trim().min(2).max(100),
   signatureStorageKey: z.string().min(1),
 });
 
@@ -67,7 +66,6 @@ export async function submitOwnMembershipApplication(
     phone: parsed.phone,
     privateEmail,
     address,
-    place: parsed.place,
     signedAt,
     signaturePng: signature,
     guardianConsent: membership.guardianConsent,
@@ -96,7 +94,6 @@ export async function submitOwnMembershipApplication(
         gender: parsed.gender,
         address,
         applicationSignature: {
-          place: parsed.place,
           signedAt,
           signatureStorageKey: parsed.signatureStorageKey,
           ...(await membershipRequestMetadata()),

--- a/app/lib/server/memberships/membershipApplicationPdf.ts
+++ b/app/lib/server/memberships/membershipApplicationPdf.ts
@@ -24,7 +24,6 @@ export interface MembershipApplicationPdfInput {
   phone: string;
   privateEmail: string;
   address: PostalAddress;
-  place: string;
   signedAt: number;
   signaturePng: Uint8Array;
   guardianConsent?: GuardianConsentEvidence;
@@ -49,11 +48,6 @@ export async function createMembershipApplicationPdf(
   }
 
   writeGap(writer, 20);
-  writeText(
-    writer,
-    `Ort: ${input.place}    Datum: ${formatDate(input.signedAt)}`,
-    { size: 10, gap: 12 },
-  );
   writeText(writer, "Unterschrift Mitglied", { size: 10, bold: true, gap: 8 });
   await drawSignatureImage(writer, input.signaturePng);
 


### PR DESCRIPTION
## summary

- remove the duplicate signing place and date fields so only the signature follows the member details
- keep the signing timestamp as automatic evidence while dropping the unused place value from the API, stored signature shape, and generated PDF

## validation

- `pnpm exec biome lint <changed files>`
- `pnpm exec vitest run app/lib/server/memberships/membershipApplication.test.ts`
- `pnpm exec tsc --noEmit`