### PR TITLE
ci: Container-Builds nach GitHub Actions auslagern (Prod)

### DIFF
--- a/.github/scripts/coolify-deploy.sh
+++ b/.github/scripts/coolify-deploy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Setzt das frisch gebaute Image in Coolify, stösst das Deployment an und
+# wartet, bis es abgeschlossen ist. Bricht mit Exit-Code != 0 ab, wenn das
+# Deployment fehlschlaegt oder das Zeitlimit reisst.
+#
+# Erwartete Umgebung:
+#   COOLIFY_URL       z.B. https://coolify.youngfounders.network
+#   COOLIFY_TOKEN     API-Token mit Deploy-Berechtigung
+#   COOLIFY_APP_UUID  UUID der Anwendung in Coolify
+#   IMAGE_TAG         eindeutiger Tag des neuen Images, z.B. sha-a1b2c3d
+#   TAG_MODE          "image" -> Tag in docker_registry_image_tag schreiben
+#                     "env"   -> Tag in die Env-Variable IMAGE_TAG schreiben
+#   DEPLOY_TIMEOUT    optional, Sekunden bis zum Abbruch (Standard 900)
+
+set -euo pipefail
+
+: "${COOLIFY_URL:?COOLIFY_URL fehlt}"
+: "${COOLIFY_TOKEN:?COOLIFY_TOKEN fehlt}"
+: "${COOLIFY_APP_UUID:?COOLIFY_APP_UUID fehlt}"
+: "${IMAGE_TAG:?IMAGE_TAG fehlt}"
+: "${TAG_MODE:?TAG_MODE fehlt}"
+
+TIMEOUT="${DEPLOY_TIMEOUT:-900}"
+API="${COOLIFY_URL%/}/api/v1"
+AUTH="Authorization: Bearer ${COOLIFY_TOKEN}"
+
+# Fuehrt einen API-Aufruf aus und trennt Body von HTTP-Status.
+# Gibt den Body auf stdout aus; schlaegt bei Status >= 400 fehl.
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local out status
+  if [ -n "$body" ]; then
+    out=$(curl -sS -X "$method" -H "$AUTH" -H "Content-Type: application/json" \
+      -d "$body" -w $'\n%{http_code}' "${API}${path}")
+  else
+    out=$(curl -sS -X "$method" -H "$AUTH" -w $'\n%{http_code}' "${API}${path}")
+  fi
+  status="${out##*$'\n'}"
+  body="${out%$'\n'*}"
+  if [ "$status" -ge 400 ]; then
+    echo "::error::Coolify ${method} ${path} antwortete HTTP ${status}: ${body}" >&2
+    return 1
+  fi
+  printf '%s' "$body"
+}
+
+echo "==> Setze Image-Tag ${IMAGE_TAG} (Modus: ${TAG_MODE})"
+case "$TAG_MODE" in
+  image)
+    api PATCH "/applications/${COOLIFY_APP_UUID}" \
+      "$(printf '{"docker_registry_image_tag":"%s"}' "$IMAGE_TAG")" >/dev/null
+    ;;
+  env)
+    # PATCH legt die Variable an, falls sie noch nicht existiert.
+    api PATCH "/applications/${COOLIFY_APP_UUID}/envs" \
+      "$(printf '{"key":"IMAGE_TAG","value":"%s","is_literal":false}' "$IMAGE_TAG")" >/dev/null
+    ;;
+  *)
+    echo "::error::Unbekannter TAG_MODE: ${TAG_MODE} (erlaubt: image, env)" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Starte Deployment"
+deploy_response=$(api GET "/deploy?uuid=${COOLIFY_APP_UUID}&force=false")
+deployment_uuid=$(printf '%s' "$deploy_response" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+items = data.get("deployments") or []
+if not items:
+    sys.exit("Coolify hat kein Deployment gestartet: " + json.dumps(data))
+print(items[0]["deployment_uuid"])
+')
+echo "    Deployment-UUID: ${deployment_uuid}"
+
+echo "==> Warte auf Abschluss (Zeitlimit ${TIMEOUT}s)"
+elapsed=0
+interval=10
+last_status=""
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  sleep "$interval"
+  elapsed=$((elapsed + interval))
+
+  status=$(api GET "/deployments/${deployment_uuid}" | python3 -c '
+import json, sys
+print(json.load(sys.stdin).get("status", "unknown"))
+')
+
+  if [ "$status" != "$last_status" ]; then
+    echo "    [${elapsed}s] ${status}"
+    last_status="$status"
+  fi
+
+  case "$status" in
+    finished)
+      echo "==> Deployment erfolgreich (${elapsed}s)"
+      exit 0
+      ;;
+    failed|cancelled-by-user)
+      echo "::error::Deployment endete mit Status '${status}'. Logs: ${COOLIFY_URL}/project" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "::error::Zeitlimit von ${TIMEOUT}s erreicht, letzter Status: '${last_status}'." >&2
+echo "Das Deployment laeuft in Coolify moeglicherweise weiter." >&2
+exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+name: Build & Deploy
+
+# Baut das Container-Image auf GitHub-Runnern und laesst Coolify es nur noch
+# ziehen. Auf dem Server wird kein Quellcode mehr kompiliert.
+
+on:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+# Deployments derselben Umgebung laufen nacheinander. Ein bereits gestartetes
+# Deployment wird nicht abgebrochen, damit der Server nie halb aktualisiert bleibt.
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/yfndev/ybase
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tag aus Commit ableiten
+        id: meta
+        run: echo "tag=sha-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image bauen und pushen
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          # Der bewegliche Branch-Tag dient als lesbare Referenz, deployed wird
+          # ueber den eindeutigen SHA-Tag.
+          tags: |
+            ${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_POSTHOG_KEY=${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+
+      - name: In Coolify ausrollen
+        env:
+          COOLIFY_URL: ${{ vars.COOLIFY_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_APP_UUID: ${{ vars.COOLIFY_APP_UUID }}
+          IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          TAG_MODE: image
+        run: ./.github/scripts/coolify-deploy.sh
+
+  cleanup:
+    # Haelt den GHCR-Verbrauch klein. Laeuft auch, wenn das Deployment scheitert,
+    # damit alte Versionen sich nicht ansammeln.
+    needs: build-and-deploy
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-name: ybase
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG NEXT_PUBLIC_POSTHOG_KEY
 ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+# Next.js ersetzt NEXT_PUBLIC_*-Zugriffe zur Build-Zeit, auch im Servercode.
+# Die Variable muss daher schon hier gesetzt sein, nicht erst zur Laufzeit.
+ARG NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 


### PR DESCRIPTION
## Prod-Umstellung

Zieht die bereits auf `develop` laufende Umstellung nach `main`. Ab dem Merge baut GitHub Actions das Produktions-Image und Coolify zieht es nur noch — auf `yfn-1` wird kein Quellcode mehr kompiliert.

## Voraussetzung vor dem Merge

Die zugehörige Coolify-App muss vorher auf das vorgebaute Image umgestellt und Auto-Deploy abgeschaltet sein. Sonst startet Coolify beim Push ein Server-Build mit dem alten Weg. **Das erledige ich unmittelbar vor dem Merge — bitte nicht ungeprüft mergen.**

## Nachweis auf Stage

ybase-Stage läuft seit der Umstellung über `ghcr.io/yfndev/ybase:sha-…`; Domain unverändert erreichbar, kein `buildkit`-Prozess auf dem Server.

## Rollback

Coolify-Image-Tag bzw. `IMAGE_TAG` auf einen früheren `sha-<short>` setzen und neu deployen. Ein vollständiger DB-Dump von vor der Umstellung liegt gesichert vor, dazu fertige Rollback-SQL.