### PR TITLE
ci: Cleanup-Job soll den Lauf nicht rot faerben

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
     # damit alte Versionen sich nicht ansammeln.
     needs: build-and-deploy
     if: always()
+    # Aufraeumen darf den Lauf nie rot faerben: ein erfolgreiches Deployment
+    # soll nicht wie ein Fehlschlag aussehen, nur weil die Retention haengt.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Beim ersten Prod-Deploy über GitHub Actions lief `build-and-deploy` erfolgreich durch, der nachgelagerte Retention-Job wurde aber während der Actions-Störung abgebrochen — der Lauf sah dadurch rot aus, obwohl die Produktion sauber deployed war.

`continue-on-error` auf Step-Ebene fängt ein `cancelled` nicht ab, deshalb steht es jetzt auf Job-Ebene. Aufräumen darf nie wie ein fehlgeschlagenes Rollout aussehen.

Bewusst nicht dringend: ybase-Prod und -Stage laufen bereits korrekt über GHCR. Kann jederzeit mitgenommen werden.