### PR TITLE
ci: Cleanup-Job soll den Lauf nicht rot faerben (develop)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,9 @@ jobs:
     # damit alte Versionen sich nicht ansammeln.
     needs: build-and-deploy
     if: always()
+    # Aufraeumen darf den Lauf nie rot faerben: ein erfolgreiches Deployment
+    # soll nicht wie ein Fehlschlag aussehen, nur weil die Retention haengt.
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Gleicht `develop` an `main` an — dort ist der Fix bereits drin (#270). Ohne ihn haben die beiden Branches unterschiedliche Workflows.