### PR TITLE
fix(onboarding): support manually added members

### DIFF
--- a/app/lib/db/membership.ts
+++ b/app/lib/db/membership.ts
@@ -56,7 +56,7 @@ export interface Membership {
   _creationTime: number;
   organizationId: string;
   userId: string;
-  applicationId: string;
+  applicationId?: string;
   membershipNumber: string;
   isCurrent: boolean;
   legalStatus: MembershipLegalStatus;

--- a/app/lib/db/membershipIndexes.test.ts
+++ b/app/lib/db/membershipIndexes.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, expect, test } from "vitest";
 import { setupTestDatabase } from "../test/setupTestDatabase";
+import { getDb } from "./client";
 import {
   documentExecutions,
   membershipEvents,
@@ -71,6 +72,36 @@ test("allows a new membership episode after an earlier membership ended", async 
     collection.insertOne(
       membership(organizationId, newId(), { memberPlatformUserId }),
     ),
+  ).rejects.toMatchObject({ code: 11_000 });
+});
+
+test("migrates the legacy application index for manual memberships", async () => {
+  const collection = (await getDb()).collection<Membership>("memberships");
+  await collection.dropIndex("applicationId_1");
+  await collection.createIndex({ applicationId: 1 }, { unique: true });
+
+  await ensureIndexes();
+
+  const applicationIndex = (await collection.indexes()).find(
+    (index) => index.name === "applicationId_1",
+  );
+  expect(applicationIndex).toMatchObject({ unique: true, sparse: true });
+});
+
+test("allows manual memberships without weakening application uniqueness", async () => {
+  const collection = await memberships();
+  const firstManual = membership(newId(), newId());
+  const secondManual = membership(newId(), newId());
+  delete firstManual.applicationId;
+  delete secondManual.applicationId;
+  await collection.insertMany([firstManual, secondManual]);
+
+  const applicationId = newId();
+  await collection.insertOne(
+    membership(newId(), newId(), { applicationId }),
+  );
+  await expect(
+    collection.insertOne(membership(newId(), newId(), { applicationId })),
   ).rejects.toMatchObject({ code: 11_000 });
 });
 

--- a/app/lib/db/membershipIndexes.test.ts
+++ b/app/lib/db/membershipIndexes.test.ts
@@ -97,9 +97,7 @@ test("allows manual memberships without weakening application uniqueness", async
   await collection.insertMany([firstManual, secondManual]);
 
   const applicationId = newId();
-  await collection.insertOne(
-    membership(newId(), newId(), { applicationId }),
-  );
+  await collection.insertOne(membership(newId(), newId(), { applicationId }));
   await expect(
     collection.insertOne(membership(newId(), newId(), { applicationId })),
   ).rejects.toMatchObject({ code: 11_000 });

--- a/app/lib/db/membershipIndexes.ts
+++ b/app/lib/db/membershipIndexes.ts
@@ -1,14 +1,15 @@
 import type { Db } from "mongodb";
 
 export async function ensureMembershipIndexes(db: Db): Promise<void> {
-  await db.collection("memberships").createIndexes([
+  const membershipCollection = db.collection("memberships");
+  await ensureApplicationIndexAllowsManualMemberships(db);
+  await membershipCollection.createIndexes([
     {
       key: { organizationId: 1, userId: 1 },
       unique: true,
       partialFilterExpression: { isCurrent: true },
     },
     { key: { organizationId: 1, membershipNumber: 1 }, unique: true },
-    { key: { applicationId: 1 }, unique: true },
     {
       key: { memberPlatformUserId: 1 },
       unique: true,
@@ -68,4 +69,33 @@ export async function ensureMembershipIndexes(db: Db): Promise<void> {
       partialFilterExpression: { idempotencyKey: { $type: "string" } },
     },
   ]);
+}
+
+async function ensureApplicationIndexAllowsManualMemberships(
+  db: Db,
+): Promise<void> {
+  const collection = db.collection("memberships");
+  const collectionExists = await db
+    .listCollections({ name: "memberships" }, { nameOnly: true })
+    .hasNext();
+  if (!collectionExists) {
+    await collection.createIndex(
+      { applicationId: 1 },
+      { unique: true, sparse: true },
+    );
+    return;
+  }
+
+  const applicationIndex = (await collection.indexes()).find(
+    (index) =>
+      index.key.applicationId === 1 && Object.keys(index.key).length === 1,
+  );
+  if (applicationIndex?.unique && applicationIndex.sparse) return;
+  if (applicationIndex?.name) {
+    await collection.dropIndex(applicationIndex.name);
+  }
+  await collection.createIndex(
+    { applicationId: 1 },
+    { unique: true, sparse: true },
+  );
 }

--- a/app/lib/server/memberships/membershipApplication.test.ts
+++ b/app/lib/server/memberships/membershipApplication.test.ts
@@ -182,6 +182,30 @@ test("stores the signed application and activates the account", async () => {
   });
 });
 
+test("activates a manually added member without an application record", async () => {
+  delete actor.applicationId;
+  await Promise.all([
+    (await users()).updateOne(
+      { _id: actor._id },
+      { $unset: { applicationId: "" } },
+    ),
+    (await memberships()).updateOne(
+      { _id: membershipId },
+      { $unset: { applicationId: "" } },
+    ),
+    (await applications()).deleteMany({ organizationId: actor.organizationId }),
+  ]);
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(actor);
+  await completeAllDocuments();
+
+  await expect(submitOwnMembershipApplication(FORM)).resolves.toEqual({
+    activated: true,
+  });
+  await expect(
+    (await users()).findOne({ _id: actor._id }),
+  ).resolves.toMatchObject({ memberStatus: "active" });
+});
+
 test("rejects a submission without a usable signature", async () => {
   await completeAllDocuments();
 

--- a/app/lib/server/memberships/onboardingCompletion.ts
+++ b/app/lib/server/memberships/onboardingCompletion.ts
@@ -40,20 +40,23 @@ export async function activateMembershipOnboardingIfComplete(
     return user?.memberStatus === "active";
   }
 
-  await Promise.all([
-    (await applications()).updateOne(
-      {
-        _id: membership.applicationId,
-        onboardingCompletedAt: { $exists: false },
-      },
-      {
-        $set: {
-          onboardingCompletedAt: now,
-          onboardingCompletedBy: membership.userId,
-          updatedAt: now,
+  const applicationUpdate = membership.applicationId
+    ? (await applications()).updateOne(
+        {
+          _id: membership.applicationId,
+          onboardingCompletedAt: { $exists: false },
         },
-      },
-    ),
+        {
+          $set: {
+            onboardingCompletedAt: now,
+            onboardingCompletedBy: membership.userId,
+            updatedAt: now,
+          },
+        },
+      )
+    : Promise.resolve();
+  await Promise.all([
+    applicationUpdate,
     appendMembershipEvent({
       organizationId: membership.organizationId,
       membershipId: membership._id,

--- a/app/lib/server/memberships/onboardingData.test.ts
+++ b/app/lib/server/memberships/onboardingData.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 vi.mock("../../auth/session", () => ({ requireAuthenticatedUser: vi.fn() }));
 vi.mock("./documentContent", () => ({ loadDocumentContent: vi.fn() }));
+vi.mock("../applications/memberPlatformCandidates", () => ({
+  loadApplicationMemberPlatformSnapshot: vi.fn(),
+}));
 
 import { requireAuthenticatedUser } from "../../auth/session";
 import {
@@ -20,6 +23,7 @@ import type {
   User,
 } from "../../db/types";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { loadApplicationMemberPlatformSnapshot } from "../applications/memberPlatformCandidates";
 import { loadDocumentContent } from "./documentContent";
 import {
   getOwnMembershipOnboardingContext,
@@ -134,6 +138,35 @@ test("creates the legal record and returns the documents in reading order", asyn
       await documentExecutions()
     ).countDocuments({ membershipId: membership?._id }),
   ).toBe(3);
+});
+
+test("creates the legal record for a manually added member without an application", async () => {
+  const manualActor = { ...actor, applicationId: undefined };
+  delete manualActor.applicationId;
+  await (await users()).updateOne(
+    { _id: actor._id },
+    { $unset: { applicationId: "" } },
+  );
+  vi.mocked(requireAuthenticatedUser).mockResolvedValue(manualActor);
+  vi.mocked(loadApplicationMemberPlatformSnapshot).mockResolvedValue({
+    memberPlatformUserId: "member-platform-profile",
+    memberPlatformSyncedAt: Date.now(),
+    dateOfBirth: "2004-01-01",
+  });
+
+  const context = await loadContext();
+
+  expect(context.documents).toHaveLength(3);
+  expect(context.profile).toMatchObject({
+    firstName: "Alex",
+    lastName: "Beispiel",
+    dateOfBirth: "2004-01-01",
+  });
+  const membership = await (await memberships()).findOne({ userId: actor._id });
+  expect(membership).toMatchObject({
+    memberPlatformUserId: actor.memberPlatformUserId,
+  });
+  expect(membership).not.toHaveProperty("applicationId");
 });
 
 test("delivers the frozen text inline for open documents only", async () => {

--- a/app/lib/server/memberships/onboardingData.test.ts
+++ b/app/lib/server/memberships/onboardingData.test.ts
@@ -143,10 +143,9 @@ test("creates the legal record and returns the documents in reading order", asyn
 test("creates the legal record for a manually added member without an application", async () => {
   const manualActor = { ...actor, applicationId: undefined };
   delete manualActor.applicationId;
-  await (await users()).updateOne(
-    { _id: actor._id },
-    { $unset: { applicationId: "" } },
-  );
+  await (
+    await users()
+  ).updateOne({ _id: actor._id }, { $unset: { applicationId: "" } });
   vi.mocked(requireAuthenticatedUser).mockResolvedValue(manualActor);
   vi.mocked(loadApplicationMemberPlatformSnapshot).mockResolvedValue({
     memberPlatformUserId: "member-platform-profile",

--- a/app/lib/server/memberships/onboardingMembership.ts
+++ b/app/lib/server/memberships/onboardingMembership.ts
@@ -7,16 +7,17 @@ import {
 import { isDuplicateKeyError } from "../../db/errors";
 import { newId } from "../../db/ids";
 import type { Application, Membership, User } from "../../db/types";
+import { loadApplicationMemberPlatformSnapshot } from "../applications/memberPlatformCandidates";
 import {
-  assignRequiredDocuments,
   assertRequiredDocumentConfiguration,
+  assignRequiredDocuments,
 } from "./documentAssignments";
 import { appendMembershipEvent } from "./events";
 
 export async function ensureAcceptedApplicantMembership(
   user: User,
 ): Promise<Membership> {
-  if (!user.organizationId || !user.applicationId) {
+  if (!user.organizationId) {
     throw new Error(
       "Die Mitgliedschaft kann diesem Konto nicht zugeordnet werden.",
     );
@@ -29,18 +30,16 @@ export async function ensureAcceptedApplicantMembership(
     return existing;
   }
 
-  const application = await (
-    await applications()
-  ).findOne({
-    _id: user.applicationId,
-    organizationId: user.organizationId,
-    status: "accepted",
-  });
-  if (!application) {
-    throw new Error("Die angenommene Bewerbung wurde nicht gefunden.");
-  }
-
-  const membership = buildMembership(user, application);
+  const membership = user.applicationId
+    ? await buildAcceptedApplicantMembership({
+        ...user,
+        organizationId: user.organizationId,
+        applicationId: user.applicationId,
+      })
+    : await buildManualMembership({
+        ...user,
+        organizationId: user.organizationId,
+      });
   await assertRequiredDocumentConfiguration(membership, user);
 
   try {
@@ -83,6 +82,57 @@ export async function ensureAcceptedApplicantMembership(
 
   await recordAdmission(membership);
   return membership;
+}
+
+async function buildAcceptedApplicantMembership(
+  user: User & { organizationId: string; applicationId: string },
+): Promise<Membership> {
+  const application = await (
+    await applications()
+  ).findOne({
+    _id: user.applicationId,
+    organizationId: user.organizationId,
+    status: "accepted",
+  });
+  if (!application) {
+    throw new Error("Die angenommene Bewerbung wurde nicht gefunden.");
+  }
+  return buildMembership(user, application);
+}
+
+async function buildManualMembership(
+  user: User & { organizationId: string },
+): Promise<Membership> {
+  if (!user.memberPlatformUserId) {
+    throw new Error("Das Member-Profil ist noch nicht verknüpft.");
+  }
+  const privateEmail = user.privateEmail?.trim().toLowerCase();
+  if (!privateEmail) {
+    throw new Error("Die private E-Mail-Adresse fehlt.");
+  }
+  const snapshot = await loadApplicationMemberPlatformSnapshot(
+    user.memberPlatformUserId,
+  );
+  const now = Date.now();
+  const { firstName, lastName } = splitMemberName(user.name);
+  return {
+    _id: newId(),
+    _creationTime: now,
+    organizationId: user.organizationId,
+    userId: user._id,
+    membershipNumber: newMembershipNumber(now),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt: user.registeredAt ?? user._creationTime,
+    privateEmail,
+    firstName,
+    lastName,
+    dateOfBirth: snapshot.dateOfBirth,
+    ...(user.phone?.trim() ? { phone: user.phone.trim() } : {}),
+    memberPlatformUserId: snapshot.memberPlatformUserId,
+    handoverTasks: [],
+    updatedAt: now,
+  };
 }
 
 async function recordAdmission(membership: Membership): Promise<void> {
@@ -142,17 +192,10 @@ function buildMembership(user: User, application: Application): Membership {
     throw new Error("Geburtsdatum oder Member-Profil fehlen.");
   }
   const now = Date.now();
-  const [firstName, ...lastNameParts] = (
+  const { firstName, lastName } = splitMemberName(
     application.applicantName ??
-    user.name ??
-    ""
-  )
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
-  if (!firstName || lastNameParts.length === 0) {
-    throw new Error("Der vollständige Name fehlt in der Bewerbung.");
-  }
+      user.name,
+  );
   const guardian = application.guardianConsent;
   return {
     _id: newId(),
@@ -160,9 +203,7 @@ function buildMembership(user: User, application: Application): Membership {
     organizationId: application.organizationId,
     userId: user._id,
     applicationId: application._id,
-    membershipNumber: `YFN-${new Date(now).getUTCFullYear()}-${newId()
-      .slice(0, 6)
-      .toUpperCase()}`,
+    membershipNumber: newMembershipNumber(now),
     isCurrent: true,
     legalStatus: "active",
     admittedAt:
@@ -185,7 +226,7 @@ function buildMembership(user: User, application: Application): Membership {
       : {}),
     privateEmail: application.applicantEmailNormalized,
     firstName,
-    lastName: lastNameParts.join(" "),
+    lastName,
     dateOfBirth: application.dateOfBirth,
     ...(application.applicantPhone?.trim()
       ? { phone: application.applicantPhone.trim() }
@@ -194,4 +235,24 @@ function buildMembership(user: User, application: Application): Membership {
     handoverTasks: [],
     updatedAt: now,
   };
+}
+
+function splitMemberName(name?: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const [firstName, ...lastNameParts] = name
+    ?.trim()
+    .split(/\s+/)
+    .filter(Boolean) ?? [undefined];
+  if (!firstName || lastNameParts.length === 0) {
+    throw new Error("Der vollständige Name fehlt.");
+  }
+  return { firstName, lastName: lastNameParts.join(" ") };
+}
+
+function newMembershipNumber(now: number): string {
+  return `YFN-${new Date(now).getUTCFullYear()}-${newId()
+    .slice(0, 6)
+    .toUpperCase()}`;
 }

--- a/app/lib/server/memberships/onboardingMembership.ts
+++ b/app/lib/server/memberships/onboardingMembership.ts
@@ -193,8 +193,7 @@ function buildMembership(user: User, application: Application): Membership {
   }
   const now = Date.now();
   const { firstName, lastName } = splitMemberName(
-    application.applicantName ??
-      user.name,
+    application.applicantName ?? user.name,
   );
   const guardian = application.guardianConsent;
   return {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -62,7 +62,7 @@ erDiagram
         boolean isTeamLead
         boolean isSecondaryTeamLead
         object boardMembership "departmentId, isChair"
-        string applicationId
+        string applicationId "only for application-based admissions"
         string membershipId
         string memberStatus
         string teamOnboardingStatus
@@ -77,7 +77,7 @@ erDiagram
         string _id
         string organizationId
         string userId
-        string applicationId
+        string applicationId "only for application-based admissions"
         string membershipNumber
         boolean isCurrent
         string legalStatus
@@ -250,6 +250,10 @@ first matching Google login links the application to the onboarding user,
 copies team and position from the job posting, and sets `cleanupEligibleAt` for
 the retention workflow. Link conflicts stay on the application for correction
 by P&C.
+
+Members added manually have no recruiting application. Their membership uses
+the confirmed member-platform profile for the birth-date snapshot and is linked
+directly to the YBase user before the same onboarding documents are assigned.
 
 For new ordinary YFN members, `memberships` is the legal source of truth.
 A membership is created at the recorded admission time and contains the durable


### PR DESCRIPTION
## summary

- Enable manually added members to create application-less membership records after confirming their member-platform profile and receive the scoped onboarding documents.
- Preserve completion and uniqueness guarantees with an optional application link, a sparse index migration, and regression coverage.

## validation

- `pnpm test` (616 tests)
- `pnpm vitest run app/lib/server/memberships/onboardingData.test.ts app/lib/server/memberships/membershipApplication.test.ts app/lib/db/membershipIndexes.test.ts app/lib/server/memberPlatform/linking.test.ts app/lib/server/memberPlatform/sync.test.ts` (23 tests)
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check <changed files>`
- `pnpm exec biome lint <changed files>`
- `pnpm lint` (passes with three pre-existing warnings)
- `pnpm build` (passes with existing dependency warnings)
- `git diff --check`