### PR TITLE
fix(documents): hide voluntary consent publication option

### DIFF
--- a/app/lib/members/documents.ts
+++ b/app/lib/members/documents.ts
@@ -7,7 +7,6 @@ export const MEMBERSHIP_DOCUMENT_ORDER = [
   "privacy_notice",
   "usage_rights",
   "bylaws",
-  "optional_consent",
 ] as const satisfies readonly MembershipDocumentKind[];
 
 export const DOCUMENT_EXECUTION_TYPE = {
@@ -25,5 +24,8 @@ export const MEMBERSHIP_DOCUMENT_LABELS = {
 } as const satisfies Record<MembershipDocumentKind, string>;
 
 export function documentOrderIndex(kind: MembershipDocumentKind): number {
-  return MEMBERSHIP_DOCUMENT_ORDER.indexOf(kind);
+  const index = (
+    MEMBERSHIP_DOCUMENT_ORDER as readonly MembershipDocumentKind[]
+  ).indexOf(kind);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
 }


### PR DESCRIPTION
## summary

- remove voluntary consent from the document publication type selector
- keep existing voluntary consent workflows ordered after publishable documents

## validation

- `pnpm exec prettier --check app/lib/members/documents.ts`
- `pnpm exec biome lint app/lib/members/documents.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run app/lib/server/memberships/onboardingData.test.ts`