### PR TITLE
feat(documents): add safe document editing

### DIFF
--- a/app/(protected)/settings/documents/DepartmentTargets.tsx
+++ b/app/(protected)/settings/documents/DepartmentTargets.tsx
@@ -18,7 +18,8 @@ export function DepartmentTargets({
   const { departments, isLoading } = useDepartments();
 
   return (
-    <div className="space-y-2">
+    <fieldset className="space-y-3 border bg-muted/20 p-4">
+      <legend className="sr-only">Ziel-Departments</legend>
       <p className="text-sm font-medium">
         Ziel-Departments{required ? "*" : " (optional)"}
       </p>
@@ -38,7 +39,7 @@ export function DepartmentTargets({
           ))}
         </div>
       )}
-      <div className="grid gap-2 sm:grid-cols-2">
+      <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
         {departments.map((department) => (
           <div key={department._id} className="flex items-center gap-2">
             <Checkbox
@@ -57,6 +58,6 @@ export function DepartmentTargets({
           </div>
         ))}
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/app/(protected)/settings/documents/DocumentDetails.tsx
+++ b/app/(protected)/settings/documents/DocumentDetails.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import { MEMBERSHIP_DOCUMENT_LABELS } from "@/lib/members/documents";
+import type { MembershipDocumentVersionSummary } from "@/lib/server/memberships/documentPublication";
+import { Building2 } from "lucide-react";
+
+const DATE_FORMAT = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+export function DocumentDetails({
+  version,
+  departmentNames,
+  active = false,
+}: {
+  version: MembershipDocumentVersionSummary;
+  departmentNames: Map<string, string>;
+  active?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="font-semibold">{version.title}</h3>
+        {active && <Badge variant="primary">Aktiv</Badge>}
+        <Badge variant="outline">Version {version.versionLabel}</Badge>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        {MEMBERSHIP_DOCUMENT_LABELS[version.kind]} · veröffentlicht am{" "}
+        {DATE_FORMAT.format(version.publishedAt)}
+      </p>
+      <p className="mt-2 flex items-start gap-1.5 text-xs text-muted-foreground">
+        <Building2 aria-hidden="true" className="mt-px size-3.5 shrink-0" />
+        {version.targetDepartmentIds.length > 0
+          ? version.targetDepartmentIds
+              .map((id) => departmentNames.get(id) ?? id)
+              .join(", ")
+          : "Alle Departments"}
+      </p>
+      <p className="mt-2 font-mono text-[11px] text-muted-foreground">
+        SHA-256 {version.sha256.slice(0, 16)}…
+      </p>
+    </div>
+  );
+}

--- a/app/(protected)/settings/documents/DocumentEditNotice.tsx
+++ b/app/(protected)/settings/documents/DocumentEditNotice.tsx
@@ -1,0 +1,17 @@
+import { CircleAlert } from "lucide-react";
+
+export function DocumentEditNotice() {
+  return (
+    <div className="flex gap-3 border-l-4 border-l-primary bg-primary/10 px-4 py-3 text-sm">
+      <CircleAlert aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="font-medium">Bestehende Nachweise bleiben geschützt</p>
+        <p className="mt-1 text-muted-foreground">
+          Diese Unterlage wurde bereits zugewiesen. Beim Speichern wird
+          automatisch eine neue Version veröffentlicht und die bisherige
+          archiviert.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/settings/documents/DocumentPreview.tsx
+++ b/app/(protected)/settings/documents/DocumentPreview.tsx
@@ -3,23 +3,29 @@
 import { DocumentContent } from "@/components/Documents/DocumentContent";
 import { Button } from "@/components/ui/button";
 import { getMembershipDocumentContent } from "@/lib/server/memberships/documentPublication";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import toast from "react-hot-toast";
 
 export function DocumentPreview({ versionId }: { versionId: string }) {
   const [content, setContent] = useState<string>();
+  const [isOpen, setIsOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   function toggle() {
+    if (isOpen) {
+      setIsOpen(false);
+      return;
+    }
     if (content !== undefined) {
-      setContent(undefined);
+      setIsOpen(true);
       return;
     }
     startTransition(async () => {
       try {
         const version = await getMembershipDocumentContent({ versionId });
         setContent(version.content);
+        setIsOpen(true);
       } catch (error) {
         toast.error(
           error instanceof Error
@@ -31,15 +37,27 @@ export function DocumentPreview({ versionId }: { versionId: string }) {
   }
 
   return (
-    <div className="mt-3">
-      <Button type="button" variant="ghost" size="sm" onClick={toggle}>
+    <div className="mt-4 border-t pt-3">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-expanded={isOpen}
+        onClick={toggle}
+      >
         {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
-        {content === undefined ? "Text anzeigen" : "Text ausblenden"}
+        {!isPending && (
+          <ChevronDown
+            aria-hidden="true"
+            className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
+          />
+        )}
+        {isOpen ? "Inhalt ausblenden" : "Inhalt anzeigen"}
       </Button>
-      {content !== undefined && (
+      {isOpen && content !== undefined && (
         <DocumentContent
           html={content}
-          className="mt-3 max-h-[60vh] overflow-y-auto border-2 border-input bg-card p-6"
+          className="mt-3 max-h-[60vh] overflow-y-auto border bg-muted/20 p-5 sm:p-6"
         />
       )}
     </div>

--- a/app/(protected)/settings/documents/DocumentVersionsList.tsx
+++ b/app/(protected)/settings/documents/DocumentVersionsList.tsx
@@ -2,72 +2,171 @@
 
 import { Button } from "@/components/ui/button";
 import { useDepartments } from "@/lib/client/departments/hooks/useDepartments";
-import { MEMBERSHIP_DOCUMENT_LABELS } from "@/lib/members/documents";
 import type { MembershipDocumentVersionSummary } from "@/lib/server/memberships/documentPublication";
+import { Archive, ChevronRight, FileText, Loader2, Pencil } from "lucide-react";
+import { DocumentDetails } from "./DocumentDetails";
 import { DocumentPreview } from "./DocumentPreview";
+
+type Props = {
+  versions: MembershipDocumentVersionSummary[];
+  loadingVersionId?: string;
+  onEdit: (versionId: string) => Promise<void>;
+  onDeactivate: (versionId: string) => Promise<void>;
+};
 
 export function DocumentVersionsList({
   versions,
+  loadingVersionId,
+  onEdit,
   onDeactivate,
-}: {
-  versions: MembershipDocumentVersionSummary[];
-  onDeactivate: (versionId: string) => Promise<void>;
-}) {
+}: Props) {
   const { departments } = useDepartments();
   const names = new Map(
     departments.map((department) => [department._id, department.name]),
   );
+  const activeVersions = versions.filter((version) => version.isActive);
+  const archivedVersions = versions.filter((version) => !version.isActive);
 
   if (versions.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
-        Noch keine Unterlagen veröffentlicht. Ohne Datenschutzerklärung, Satzung
-        und Code of Conduct kann kein Mitglied das Onboarding starten.
-      </p>
+      <div className="border-2 border-dashed px-6 py-12 text-center">
+        <FileText
+          aria-hidden="true"
+          className="mx-auto size-9 text-muted-foreground"
+        />
+        <h3 className="mt-4 font-semibold">Noch keine Unterlagen</h3>
+        <p className="mx-auto mt-2 max-w-lg text-sm text-muted-foreground">
+          Veröffentliche die benötigten Unterlagen, bevor neue Mitglieder das
+          Onboarding starten.
+        </p>
+      </div>
     );
   }
 
   return (
-    <ul className="space-y-3">
-      {versions.map((version) => (
-        <li
-          key={version.id}
-          className="rounded-xl border bg-card p-4 text-sm shadow-sm"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <p className="font-medium">{version.title}</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {MEMBERSHIP_DOCUMENT_LABELS[version.kind]} · Version{" "}
-                {version.versionLabel} ·{" "}
-                {version.isActive ? "aktiv" : "deaktiviert"}
-              </p>
-              {version.targetDepartmentIds.length > 0 && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Departments:{" "}
-                  {version.targetDepartmentIds
-                    .map((id) => names.get(id) ?? id)
-                    .join(", ")}
-                </p>
+    <div className="space-y-7">
+      <section aria-labelledby="active-documents-heading">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 id="active-documents-heading" className="font-semibold">
+            Aktive Unterlagen
+          </h2>
+          <span className="text-xs text-muted-foreground">
+            {activeVersions.length}{" "}
+            {activeVersions.length === 1 ? "Fassung" : "Fassungen"}
+          </span>
+        </div>
+        {activeVersions.length > 0 ? (
+          <ul className="divide-y border-2">
+            {activeVersions.map((version) => (
+              <DocumentRow
+                key={version.id}
+                version={version}
+                departmentNames={names}
+                isLoading={loadingVersionId === version.id}
+                onEdit={onEdit}
+                onDeactivate={onDeactivate}
+              />
+            ))}
+          </ul>
+        ) : (
+          <p className="border border-dashed px-5 py-8 text-center text-sm text-muted-foreground">
+            Zurzeit ist keine Unterlage aktiv.
+          </p>
+        )}
+      </section>
+
+      {archivedVersions.length > 0 && (
+        <details className="group border-t pt-4">
+          <summary className="flex list-none cursor-pointer items-center gap-2 font-medium marker:hidden">
+            <ChevronRight
+              aria-hidden="true"
+              className="size-4 transition-transform group-open:rotate-90"
+            />
+            Frühere Fassungen
+            <span className="text-xs font-normal text-muted-foreground">
+              ({archivedVersions.length})
+            </span>
+          </summary>
+          <ul className="mt-3 divide-y border bg-muted/20">
+            {archivedVersions.map((version) => (
+              <ArchivedDocumentRow
+                key={version.id}
+                version={version}
+                departmentNames={names}
+              />
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function DocumentRow({
+  version,
+  departmentNames,
+  isLoading,
+  onEdit,
+  onDeactivate,
+}: {
+  version: MembershipDocumentVersionSummary;
+  departmentNames: Map<string, string>;
+  isLoading: boolean;
+  onEdit: Props["onEdit"];
+  onDeactivate: Props["onDeactivate"];
+}) {
+  return (
+    <li className="border-l-4 border-l-primary bg-background p-5 text-sm">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <DocumentDetails
+          version={version}
+          departmentNames={departmentNames}
+          active
+        />
+        <div className="flex shrink-0 flex-wrap items-center gap-1">
+          {version.kind !== "optional_consent" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isLoading}
+              onClick={() => void onEdit(version.id)}
+            >
+              {isLoading ? (
+                <Loader2 aria-hidden="true" className="animate-spin" />
+              ) : (
+                <Pencil aria-hidden="true" />
               )}
-              <p className="mt-1 font-mono text-xs text-muted-foreground">
-                SHA-256 {version.sha256.slice(0, 16)}…
-              </p>
-            </div>
-            {version.isActive && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => void onDeactivate(version.id)}
-              >
-                Deaktivieren
-              </Button>
-            )}
-          </div>
-          <DocumentPreview versionId={version.id} />
-        </li>
-      ))}
-    </ul>
+              Bearbeiten
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void onDeactivate(version.id)}
+          >
+            <Archive aria-hidden="true" />
+            Archivieren
+          </Button>
+        </div>
+      </div>
+      <DocumentPreview versionId={version.id} />
+    </li>
+  );
+}
+
+function ArchivedDocumentRow({
+  version,
+  departmentNames,
+}: {
+  version: MembershipDocumentVersionSummary;
+  departmentNames: Map<string, string>;
+}) {
+  return (
+    <li className="p-4 text-sm">
+      <DocumentDetails version={version} departmentNames={departmentNames} />
+      <DocumentPreview versionId={version.id} />
+    </li>
   );
 }

--- a/app/(protected)/settings/documents/DocumentVersionsSkeleton.tsx
+++ b/app/(protected)/settings/documents/DocumentVersionsSkeleton.tsx
@@ -5,9 +5,12 @@ const SKELETON_ROWS = ["one", "two", "three"];
 export function DocumentVersionsSkeleton() {
   return (
     <ul className="space-y-3" aria-busy="true">
-      <span className="sr-only">Unterlagen werden geladen</span>
+      <li className="sr-only">Unterlagen werden geladen</li>
       {SKELETON_ROWS.map((row) => (
-        <li key={row} className="rounded-xl border bg-card p-4 shadow-sm">
+        <li
+          key={row}
+          className="border-l-4 border-l-muted border-y border-r bg-background p-5"
+        >
           <Skeleton className="h-4 w-56" />
           <Skeleton className="mt-2 h-3 w-72" />
           <Skeleton className="mt-2 h-3 w-40" />

--- a/app/(protected)/settings/documents/DocumentsClient.tsx
+++ b/app/(protected)/settings/documents/DocumentsClient.tsx
@@ -4,20 +4,25 @@ import { PageHeader } from "@/components/Layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
   deactivateMembershipDocument,
+  getMembershipDocumentForEditing,
   listMembershipDocumentVersions,
   type MembershipDocumentVersionSummary,
 } from "@/lib/server/memberships/documentPublication";
-import { Plus } from "lucide-react";
+import { FilePlus2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { DocumentVersionsList } from "./DocumentVersionsList";
 import { DocumentVersionsSkeleton } from "./DocumentVersionsSkeleton";
+import type { EditableMembershipDocument } from "./documentForm";
 import { PublishDocumentForm } from "./PublishDocumentForm";
 
 export function DocumentsClient() {
   const [versions, setVersions] =
     useState<MembershipDocumentVersionSummary[]>();
   const [showForm, setShowForm] = useState(false);
+  const [editingDocument, setEditingDocument] =
+    useState<EditableMembershipDocument>();
+  const [loadingVersionId, setLoadingVersionId] = useState<string>();
 
   const reload = useCallback(async () => {
     try {
@@ -38,39 +43,92 @@ export function DocumentsClient() {
     try {
       await deactivateMembershipDocument({ versionId });
       await reload();
-      toast.success("Version deaktiviert.");
+      toast.success("Version archiviert.");
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Deaktivieren fehlgeschlagen",
+        error instanceof Error ? error.message : "Archivieren fehlgeschlagen",
       );
     }
   }
 
+  async function edit(versionId: string) {
+    setLoadingVersionId(versionId);
+    try {
+      const document = await getMembershipDocumentForEditing({ versionId });
+      if (document.kind === "optional_consent") {
+        throw new Error(
+          "Freiwillige Einwilligungen können nicht bearbeitet werden.",
+        );
+      }
+      setEditingDocument({ ...document, kind: document.kind });
+      setShowForm(true);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Unterlage konnte nicht geöffnet werden.",
+      );
+    } finally {
+      setLoadingVersionId(undefined);
+    }
+  }
+
+  function closeForm() {
+    setShowForm(false);
+    setEditingDocument(undefined);
+  }
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-7">
       <PageHeader
         title="Unterlagen"
         subtitle="Pflichtunterlagen für das Mitglieds-Onboarding"
       />
       {showForm ? (
         <PublishDocumentForm
-          onCancel={() => setShowForm(false)}
-          onPublished={async () => {
-            setShowForm(false);
+          key={editingDocument?.id ?? "new"}
+          document={editingDocument}
+          onCancel={closeForm}
+          onSaved={async () => {
+            closeForm();
             await reload();
           }}
         />
       ) : (
-        <Button type="button" onClick={() => setShowForm(true)}>
-          <Plus aria-hidden="true" />
-          Version veröffentlichen
-        </Button>
+        <div className="flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="max-w-2xl">
+            <h2 className="font-semibold">Dokumentenverwaltung</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Inhalte bearbeiten, Zielgruppen festlegen und frühere Fassungen
+              nachvollziehen.
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            type="button"
+            onClick={() => {
+              setEditingDocument(undefined);
+              setShowForm(true);
+            }}
+          >
+            <FilePlus2 aria-hidden="true" />
+            Unterlage hinzufügen
+          </Button>
+        </div>
       )}
 
       {versions ? (
-        <DocumentVersionsList versions={versions} onDeactivate={deactivate} />
+        <DocumentVersionsList
+          versions={versions}
+          loadingVersionId={loadingVersionId}
+          onEdit={edit}
+          onDeactivate={deactivate}
+        />
       ) : (
         <DocumentVersionsSkeleton />
+      )}
+      {loadingVersionId && (
+        <output className="sr-only">Unterlage wird geöffnet</output>
       )}
     </div>
   );

--- a/app/(protected)/settings/documents/PublishDocumentForm.tsx
+++ b/app/(protected)/settings/documents/PublishDocumentForm.tsx
@@ -11,29 +11,46 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { MembershipDocumentKind } from "@/lib/db/types";
 import {
   MEMBERSHIP_DOCUMENT_LABELS,
   MEMBERSHIP_DOCUMENT_ORDER,
+  type PublishableMembershipDocumentKind,
 } from "@/lib/members/documents";
+import { updateMembershipDocument } from "@/lib/server/memberships/documentEditing";
 import { publishMembershipDocument } from "@/lib/server/memberships/documentPublication";
 import { Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import toast from "react-hot-toast";
 import { DepartmentTargets } from "./DepartmentTargets";
+import { DocumentEditNotice } from "./DocumentEditNotice";
+import {
+  type EditableMembershipDocument,
+  suggestNextVersionLabel,
+} from "./documentForm";
 
 export function PublishDocumentForm({
+  document,
   onCancel,
-  onPublished,
+  onSaved,
 }: {
+  document?: EditableMembershipDocument;
   onCancel: () => void;
-  onPublished: () => Promise<void>;
+  onSaved: () => Promise<void>;
 }) {
-  const [kind, setKind] = useState<MembershipDocumentKind>("privacy_notice");
-  const [title, setTitle] = useState("");
-  const [versionLabel, setVersionLabel] = useState("");
-  const [content, setContent] = useState("");
-  const [departmentIds, setDepartmentIds] = useState<string[]>([]);
+  const isEditing = Boolean(document);
+  const [kind, setKind] = useState<PublishableMembershipDocumentKind>(
+    document?.kind ?? "privacy_notice",
+  );
+  const [title, setTitle] = useState(document?.title ?? "");
+  const [versionLabel, setVersionLabel] = useState(
+    document?.hasAssignments
+      ? suggestNextVersionLabel(document.versionLabel)
+      : (document?.versionLabel ?? ""),
+  );
+  const [content, setContent] = useState(document?.content ?? "");
+  const [departmentIds, setDepartmentIds] = useState<string[]>(
+    document?.targetDepartmentIds ?? [],
+  );
   const [isPending, startTransition] = useTransition();
   const departmentsRequired = kind === "usage_rights";
 
@@ -53,89 +70,121 @@ export function PublishDocumentForm({
     }
     startTransition(async () => {
       try {
-        await publishMembershipDocument({
+        const values = {
           kind,
           title,
           versionLabel,
           content,
+          targetTeamIds: document?.targetTeamIds ?? [],
           targetDepartmentIds: departmentIds,
-        });
-        await onPublished();
-        toast.success("Version veröffentlicht.");
+        };
+        const result = document
+          ? await updateMembershipDocument({
+              versionId: document.id,
+              ...values,
+            })
+          : await publishMembershipDocument(values);
+        await onSaved();
+        toast.success(
+          "mode" in result && result.mode === "updated"
+            ? "Unterlage aktualisiert."
+            : isEditing
+              ? "Änderungen als neue Version veröffentlicht."
+              : "Version veröffentlicht.",
+        );
       } catch (error) {
         toast.error(
-          error instanceof Error
-            ? error.message
-            : "Veröffentlichen fehlgeschlagen",
+          error instanceof Error ? error.message : "Speichern fehlgeschlagen",
         );
       }
     });
   }
 
   return (
-    <form
-      className="space-y-5 rounded-xl border bg-card p-5 shadow-sm"
-      onSubmit={submit}
-    >
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div className="space-y-2">
-          <Label htmlFor="document-kind">Art*</Label>
-          <Select
-            value={kind}
-            onValueChange={(value) => setKind(value as MembershipDocumentKind)}
-          >
-            <SelectTrigger id="document-kind" className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {MEMBERSHIP_DOCUMENT_ORDER.map((option) => (
-                <SelectItem key={option} value={option}>
-                  {MEMBERSHIP_DOCUMENT_LABELS[option]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="document-title">Titel*</Label>
-          <Input
-            id="document-title"
-            required
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="document-version">Version*</Label>
-          <Input
-            id="document-version"
-            required
-            placeholder="2026-01"
-            value={versionLabel}
-            onChange={(event) => setVersionLabel(event.target.value)}
-          />
-        </div>
+    <form className="border bg-background" onSubmit={submit}>
+      <div className="border-b bg-muted/40 px-5 py-4">
+        <p className="font-semibold">
+          {isEditing
+            ? "Unterlage bearbeiten"
+            : "Neue Unterlage veröffentlichen"}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {isEditing
+            ? MEMBERSHIP_DOCUMENT_LABELS[kind]
+            : "Titel, Gültigkeitsbereich und Inhalt festlegen."}
+        </p>
       </div>
 
-      <DepartmentTargets
-        selected={departmentIds}
-        onToggle={toggleDepartment}
-        required={departmentsRequired}
-      />
+      <div className="space-y-6 p-5">
+        {document?.hasAssignments && <DocumentEditNotice />}
 
-      <div className="space-y-2">
-        <p className="text-sm font-medium">Dokumententext*</p>
-        <RichTextEditor
-          value={content}
-          onChange={setContent}
-          ariaLabel="Dokumententext"
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="space-y-2">
+            <Label htmlFor="document-kind">Art*</Label>
+            <Select
+              value={kind}
+              disabled={isEditing}
+              onValueChange={(value) =>
+                setKind(value as PublishableMembershipDocumentKind)
+              }
+            >
+              <SelectTrigger id="document-kind" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MEMBERSHIP_DOCUMENT_ORDER.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {MEMBERSHIP_DOCUMENT_LABELS[option]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="document-title">Titel*</Label>
+            <Input
+              id="document-title"
+              required
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="document-version">Version*</Label>
+            <Input
+              id="document-version"
+              required
+              placeholder="2026-01"
+              value={versionLabel}
+              onChange={(event) => setVersionLabel(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <DepartmentTargets
+          selected={departmentIds}
+          onToggle={toggleDepartment}
+          required={departmentsRequired}
         />
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Dokumententext*</p>
+          <RichTextEditor
+            value={content}
+            onChange={setContent}
+            ariaLabel="Dokumententext"
+          />
+        </div>
       </div>
 
-      <div className="flex flex-wrap gap-3">
-        <Button type="submit" disabled={isPending || !content}>
+      <div className="flex flex-wrap gap-3 border-t bg-muted/20 px-5 py-4">
+        <Button
+          variant="primary"
+          type="submit"
+          disabled={isPending || !content}
+        >
           {isPending && <Loader2 aria-hidden="true" className="animate-spin" />}
-          Veröffentlichen
+          {isEditing ? "Änderungen speichern" : "Veröffentlichen"}
         </Button>
         <Button type="button" variant="outline" onClick={onCancel}>
           Abbrechen

--- a/app/(protected)/settings/documents/documentForm.ts
+++ b/app/(protected)/settings/documents/documentForm.ts
@@ -1,0 +1,19 @@
+import type { PublishableMembershipDocumentKind } from "@/lib/members/documents";
+
+export type EditableMembershipDocument = {
+  id: string;
+  kind: PublishableMembershipDocumentKind;
+  title: string;
+  versionLabel: string;
+  content: string;
+  targetTeamIds: string[];
+  targetDepartmentIds: string[];
+  hasAssignments: boolean;
+};
+
+export function suggestNextVersionLabel(current: string): string {
+  const match = current.match(/^(.*?)(\d+)$/);
+  if (!match) return `${current}-2`;
+  const [, prefix, digits] = match;
+  return `${prefix}${String(Number(digits) + 1).padStart(digits.length, "0")}`;
+}

--- a/app/lib/members/documents.ts
+++ b/app/lib/members/documents.ts
@@ -9,6 +9,9 @@ export const MEMBERSHIP_DOCUMENT_ORDER = [
   "bylaws",
 ] as const satisfies readonly MembershipDocumentKind[];
 
+export type PublishableMembershipDocumentKind =
+  (typeof MEMBERSHIP_DOCUMENT_ORDER)[number];
+
 export const DOCUMENT_EXECUTION_TYPE = {
   privacy_notice: "acknowledgement",
   usage_rights: "signature",

--- a/app/lib/server/memberships/documentEditing.ts
+++ b/app/lib/server/memberships/documentEditing.ts
@@ -1,0 +1,105 @@
+"use server";
+
+import type { z } from "zod";
+import { requirePermission } from "../../auth/session";
+import { documentExecutions, documentVersions } from "../../db/collections";
+import { newId } from "../../db/ids";
+import { DOCUMENT_EXECUTION_TYPE } from "../../members/documents";
+import { membershipDocumentDirectory } from "../../s3/keys";
+import {
+  contentStorageKey,
+  normalizeDocumentContent,
+  storeDocumentContent,
+} from "./documentContent";
+import { documentUpdateSchema } from "./documentPublicationSchema";
+
+export async function updateMembershipDocument(
+  input: z.input<typeof documentUpdateSchema>,
+): Promise<{ id: string; mode: "updated" | "replaced" }> {
+  const actor = await requirePermission("manage_members");
+  const {
+    versionId,
+    content: html,
+    ...parsed
+  } = documentUpdateSchema.parse(input);
+  const versions = await documentVersions();
+  const source = await versions.findOne({
+    _id: versionId,
+    organizationId: actor.organizationId,
+  });
+  if (!source) throw new Error("Dokumentversion nicht gefunden.");
+  if (!source.isActive) {
+    throw new Error("Nur aktive Unterlagen können bearbeitet werden.");
+  }
+  if (source.kind !== parsed.kind) {
+    throw new Error(
+      "Die Dokumentart kann beim Bearbeiten nicht geändert werden.",
+    );
+  }
+
+  const { content, sha256 } = normalizeDocumentContent(html);
+  const assignmentCount = await (
+    await documentExecutions()
+  ).countDocuments({
+    organizationId: actor.organizationId,
+    documentVersionId: source._id,
+  });
+  if (assignmentCount === 0) {
+    const storageKey = `${membershipDocumentDirectory(
+      actor.organizationId,
+      source._id,
+    )}/content-${sha256}.html`;
+    await storeDocumentContent(storageKey, content);
+    const result = await versions.updateOne(
+      {
+        _id: source._id,
+        organizationId: actor.organizationId,
+        sha256: source.sha256,
+      },
+      {
+        $set: {
+          ...parsed,
+          contentStorageKey: storageKey,
+          sha256,
+          executionType: DOCUMENT_EXECUTION_TYPE[parsed.kind],
+        },
+      },
+    );
+    if (result.matchedCount !== 1) {
+      throw new Error(
+        "Die Unterlage wurde parallel geändert. Bitte lade die Seite neu.",
+      );
+    }
+    return { id: source._id, mode: "updated" };
+  }
+
+  if (parsed.versionLabel === source.versionLabel) {
+    throw new Error(
+      "Für eine bereits zugewiesene Unterlage ist eine neue Versionsnummer erforderlich.",
+    );
+  }
+
+  const id = newId();
+  const now = Date.now();
+  const storageKey = contentStorageKey(
+    membershipDocumentDirectory(actor.organizationId, id),
+  );
+  await storeDocumentContent(storageKey, content);
+  await versions.insertOne({
+    _id: id,
+    _creationTime: now,
+    organizationId: actor.organizationId,
+    ...parsed,
+    contentStorageKey: storageKey,
+    sha256,
+    publishedAt: now,
+    publishedBy: actor._id,
+    executionType: DOCUMENT_EXECUTION_TYPE[parsed.kind],
+    isActive: true,
+  });
+  await versions.updateOne(
+    { _id: source._id, organizationId: actor.organizationId },
+    { $set: { isActive: false } },
+  );
+  return { id, mode: "replaced" };
+}

--- a/app/lib/server/memberships/documentPublication.test.ts
+++ b/app/lib/server/memberships/documentPublication.test.ts
@@ -8,10 +8,11 @@ vi.mock("../../s3/storage", () => ({
 }));
 
 import { requirePermission } from "../../auth/session";
-import { documentVersions } from "../../db/collections";
+import { documentExecutions, documentVersions } from "../../db/collections";
 import { putObject } from "../../s3/storage";
 import { createTestActor } from "../../test/fixtures";
 import { setupTestDatabase } from "../../test/setupTestDatabase";
+import { updateMembershipDocument } from "./documentEditing";
 import { publishMembershipDocument } from "./documentPublication";
 
 setupTestDatabase();
@@ -110,4 +111,132 @@ test("rejects a text too short to be a legal document", async () => {
   ).rejects.toThrow("zu kurz");
 
   expect(putObject).not.toHaveBeenCalled();
+});
+
+test("rejects the retired voluntary consent document kind", async () => {
+  await expect(
+    publishMembershipDocument({
+      kind: "optional_consent" as never,
+      title: "Freiwillige Einwilligung",
+      versionLabel: "2026-01",
+      content: CONTENT,
+    }),
+  ).rejects.toThrow();
+
+  expect(putObject).not.toHaveBeenCalled();
+  expect(await (await documentVersions()).countDocuments()).toBe(0);
+});
+
+test("updates an unassigned document without creating a new version", async () => {
+  const published = await publishMembershipDocument({
+    kind: "privacy_notice",
+    title: "Interne Datenschutzerklärung",
+    versionLabel: "2026-01",
+    content: CONTENT,
+  });
+
+  const updatedContent = `${CONTENT}<p>Ergänzung für neue Mitglieder.</p>`;
+  const result = await updateMembershipDocument({
+    versionId: published.id,
+    kind: "privacy_notice",
+    title: "Datenschutzhinweise",
+    versionLabel: "2026-01",
+    content: updatedContent,
+  });
+
+  expect(result).toEqual({ id: published.id, mode: "updated" });
+  expect(await (await documentVersions()).countDocuments()).toBe(1);
+  expect(
+    await (await documentVersions()).findOne({ _id: published.id }),
+  ).toMatchObject({
+    title: "Datenschutzhinweise",
+    versionLabel: "2026-01",
+    isActive: true,
+  });
+  expect(vi.mocked(putObject).mock.calls.at(-1)?.[0]).toContain(`/content-`);
+});
+
+test("replaces an assigned document and preserves the frozen version", async () => {
+  const published = await publishMembershipDocument({
+    kind: "privacy_notice",
+    title: "Interne Datenschutzerklärung",
+    versionLabel: "2026-01",
+    content: CONTENT,
+  });
+  await (
+    await documentExecutions()
+  ).insertOne({
+    _id: "execution-1",
+    _creationTime: Date.now(),
+    organizationId: "organization-1",
+    documentVersionId: published.id,
+    documentHash: published.sha256,
+    membershipId: "membership-1",
+    userId: "user-1",
+    executionType: "acknowledgement",
+    status: "assigned",
+    assignedAt: Date.now(),
+  });
+
+  const result = await updateMembershipDocument({
+    versionId: published.id,
+    kind: "privacy_notice",
+    title: "Datenschutzhinweise",
+    versionLabel: "2026-02",
+    content: `${CONTENT}<p>Überarbeitete Fassung.</p>`,
+  });
+
+  expect(result.mode).toBe("replaced");
+  expect(result.id).not.toBe(published.id);
+  expect(await (await documentVersions()).countDocuments()).toBe(2);
+  expect(
+    await (await documentVersions()).findOne({ _id: published.id }),
+  ).toMatchObject({
+    title: "Interne Datenschutzerklärung",
+    versionLabel: "2026-01",
+    sha256: published.sha256,
+    isActive: false,
+  });
+  expect(
+    await (await documentVersions()).findOne({ _id: result.id }),
+  ).toMatchObject({
+    title: "Datenschutzhinweise",
+    versionLabel: "2026-02",
+    isActive: true,
+  });
+});
+
+test("requires a new label when replacing an assigned document", async () => {
+  const published = await publishMembershipDocument({
+    kind: "privacy_notice",
+    title: "Interne Datenschutzerklärung",
+    versionLabel: "2026-01",
+    content: CONTENT,
+  });
+  await (
+    await documentExecutions()
+  ).insertOne({
+    _id: "execution-1",
+    _creationTime: Date.now(),
+    organizationId: "organization-1",
+    documentVersionId: published.id,
+    documentHash: published.sha256,
+    membershipId: "membership-1",
+    userId: "user-1",
+    executionType: "acknowledgement",
+    status: "assigned",
+    assignedAt: Date.now(),
+  });
+
+  await expect(
+    updateMembershipDocument({
+      versionId: published.id,
+      kind: "privacy_notice",
+      title: "Datenschutzhinweise",
+      versionLabel: "2026-01",
+      content: `${CONTENT}<p>Überarbeitete Fassung.</p>`,
+    }),
+  ).rejects.toThrow("neue Versionsnummer");
+
+  expect(await (await documentVersions()).countDocuments()).toBe(1);
 });

--- a/app/lib/server/memberships/documentPublication.ts
+++ b/app/lib/server/memberships/documentPublication.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 import { requirePermission } from "../../auth/session";
-import { documentVersions } from "../../db/collections";
+import { documentExecutions, documentVersions } from "../../db/collections";
 import { newId } from "../../db/ids";
 import { DOCUMENT_EXECUTION_TYPE } from "../../members/documents";
 import { membershipDocumentDirectory } from "../../s3/keys";
@@ -12,35 +12,7 @@ import {
   normalizeDocumentContent,
   storeDocumentContent,
 } from "./documentContent";
-
-const publicationSchema = z
-  .object({
-    kind: z.enum([
-      "bylaws",
-      "privacy_notice",
-      "usage_rights",
-      "optional_consent",
-    ]),
-    title: z.string().trim().min(2).max(150),
-    versionLabel: z.string().trim().min(1).max(50),
-    content: z.string().min(1),
-    targetTeamIds: z.array(z.string().min(1)).default([]),
-    targetDepartmentIds: z.array(z.string().min(1)).default([]),
-  })
-  .superRefine((document, context) => {
-    if (
-      document.kind === "usage_rights" &&
-      document.targetTeamIds.length === 0 &&
-      document.targetDepartmentIds.length === 0
-    ) {
-      context.addIssue({
-        code: "custom",
-        path: ["targetDepartmentIds"],
-        message:
-          "Die Sondervereinbarung braucht mindestens ein Ziel-Department oder Team.",
-      });
-    }
-  });
+import { publicationSchema } from "./documentPublicationSchema";
 
 export async function publishMembershipDocument(
   input: z.input<typeof publicationSchema>,
@@ -107,6 +79,34 @@ export async function getMembershipDocumentContent(input: {
       version.contentStorageKey,
       version.sha256,
     ),
+  };
+}
+
+export async function getMembershipDocumentForEditing(input: {
+  versionId: string;
+}) {
+  const { versionId } = z.object({ versionId: z.string().min(1) }).parse(input);
+  const actor = await requirePermission("manage_members");
+  const version = await (
+    await documentVersions()
+  ).findOne({ _id: versionId, organizationId: actor.organizationId });
+  if (!version) throw new Error("Dokumentversion nicht gefunden.");
+  const [content, assignmentCount] = await Promise.all([
+    loadDocumentContent(version.contentStorageKey, version.sha256),
+    (await documentExecutions()).countDocuments({
+      organizationId: actor.organizationId,
+      documentVersionId: version._id,
+    }),
+  ]);
+  return {
+    id: version._id,
+    kind: version.kind,
+    title: version.title,
+    versionLabel: version.versionLabel,
+    content,
+    targetTeamIds: version.targetTeamIds,
+    targetDepartmentIds: version.targetDepartmentIds,
+    hasAssignments: assignmentCount > 0,
   };
 }
 

--- a/app/lib/server/memberships/documentPublicationSchema.ts
+++ b/app/lib/server/memberships/documentPublicationSchema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { MEMBERSHIP_DOCUMENT_ORDER } from "../../members/documents";
+
+const documentFields = {
+  kind: z.enum(MEMBERSHIP_DOCUMENT_ORDER),
+  title: z.string().trim().min(2).max(150),
+  versionLabel: z.string().trim().min(1).max(50),
+  content: z.string().min(1),
+  targetTeamIds: z.array(z.string().min(1)).default([]),
+  targetDepartmentIds: z.array(z.string().min(1)).default([]),
+};
+
+function validateTargets(
+  document: {
+    kind: string;
+    targetTeamIds: string[];
+    targetDepartmentIds: string[];
+  },
+  context: z.RefinementCtx,
+) {
+  if (
+    document.kind === "usage_rights" &&
+    document.targetTeamIds.length === 0 &&
+    document.targetDepartmentIds.length === 0
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["targetDepartmentIds"],
+      message:
+        "Die Sondervereinbarung braucht mindestens ein Ziel-Department oder Team.",
+    });
+  }
+}
+
+export const publicationSchema = z
+  .object(documentFields)
+  .superRefine(validateTargets);
+
+export const documentUpdateSchema = z
+  .object({ versionId: z.string().min(1), ...documentFields })
+  .superRefine(validateTargets);


### PR DESCRIPTION
## summary

- redesign the document settings around flat, border-based active and archived version lists
- add safe editing that updates unassigned documents in place and preserves assigned evidence through automatic replacement versions
- prevent the retired voluntary consent kind from being published or edited while keeping historical records readable

## validation

- `pnpm exec prettier --check <changed document files>`
- `pnpm exec biome lint <changed document files>`
- `pnpm exec vitest run <document publication, assignment, execution, and onboarding tests>` (22 passed)
- `pnpm exec tsc --noEmit` (blocked by the pre-existing `origin/main` `handoverTasks` type error in `onboardingMembership.ts`)
- `pnpm lint:lines` (blocked by the pre-existing 257-line `onboardingMembership.ts` on `origin/main`)
- `pnpm build` (compilation passed, then blocked by the same pre-existing `origin/main` type error)
