### PR TITLE
fix(members): restore membership onboarding build

### DIFF
--- a/app/lib/server/memberships/onboardingData.test.ts
+++ b/app/lib/server/memberships/onboardingData.test.ts
@@ -166,6 +166,7 @@ test("creates the legal record for a manually added member without an applicatio
     memberPlatformUserId: actor.memberPlatformUserId,
   });
   expect(membership).not.toHaveProperty("applicationId");
+  expect(membership).not.toHaveProperty("handoverTasks");
 });
 
 test("delivers the frozen text inline for open documents only", async () => {

--- a/app/lib/server/memberships/onboardingMembership.ts
+++ b/app/lib/server/memberships/onboardingMembership.ts
@@ -1,18 +1,15 @@
-import {
-  applications,
-  documentExecutions,
-  memberships,
-  users,
-} from "../../db/collections";
+import { documentExecutions, memberships, users } from "../../db/collections";
 import { isDuplicateKeyError } from "../../db/errors";
-import { newId } from "../../db/ids";
-import type { Application, Membership, User } from "../../db/types";
-import { loadApplicationMemberPlatformSnapshot } from "../applications/memberPlatformCandidates";
+import type { Membership, User } from "../../db/types";
 import {
   assertRequiredDocumentConfiguration,
   assignRequiredDocuments,
 } from "./documentAssignments";
 import { appendMembershipEvent } from "./events";
+import {
+  buildAcceptedApplicantMembership,
+  buildManualMembership,
+} from "./onboardingMembershipBuilders";
 
 export async function ensureAcceptedApplicantMembership(
   user: User,
@@ -84,57 +81,6 @@ export async function ensureAcceptedApplicantMembership(
   return membership;
 }
 
-async function buildAcceptedApplicantMembership(
-  user: User & { organizationId: string; applicationId: string },
-): Promise<Membership> {
-  const application = await (
-    await applications()
-  ).findOne({
-    _id: user.applicationId,
-    organizationId: user.organizationId,
-    status: "accepted",
-  });
-  if (!application) {
-    throw new Error("Die angenommene Bewerbung wurde nicht gefunden.");
-  }
-  return buildMembership(user, application);
-}
-
-async function buildManualMembership(
-  user: User & { organizationId: string },
-): Promise<Membership> {
-  if (!user.memberPlatformUserId) {
-    throw new Error("Das Member-Profil ist noch nicht verknüpft.");
-  }
-  const privateEmail = user.privateEmail?.trim().toLowerCase();
-  if (!privateEmail) {
-    throw new Error("Die private E-Mail-Adresse fehlt.");
-  }
-  const snapshot = await loadApplicationMemberPlatformSnapshot(
-    user.memberPlatformUserId,
-  );
-  const now = Date.now();
-  const { firstName, lastName } = splitMemberName(user.name);
-  return {
-    _id: newId(),
-    _creationTime: now,
-    organizationId: user.organizationId,
-    userId: user._id,
-    membershipNumber: newMembershipNumber(now),
-    isCurrent: true,
-    legalStatus: "active",
-    admittedAt: user.registeredAt ?? user._creationTime,
-    privateEmail,
-    firstName,
-    lastName,
-    dateOfBirth: snapshot.dateOfBirth,
-    ...(user.phone?.trim() ? { phone: user.phone.trim() } : {}),
-    memberPlatformUserId: snapshot.memberPlatformUserId,
-    handoverTasks: [],
-    updatedAt: now,
-  };
-}
-
 async function recordAdmission(membership: Membership): Promise<void> {
   await appendMembershipEvent({
     organizationId: membership.organizationId,
@@ -185,72 +131,4 @@ async function linkAndAssignMembership(
   if (result.matchedCount !== 1) {
     throw new Error("Die Mitgliedschaft ist bereits anders verknüpft.");
   }
-}
-
-function buildMembership(user: User, application: Application): Membership {
-  if (!application.dateOfBirth || !application.memberPlatformUserId) {
-    throw new Error("Geburtsdatum oder Member-Profil fehlen.");
-  }
-  const now = Date.now();
-  const { firstName, lastName } = splitMemberName(
-    application.applicantName ?? user.name,
-  );
-  const guardian = application.guardianConsent;
-  return {
-    _id: newId(),
-    _creationTime: now,
-    organizationId: application.organizationId,
-    userId: user._id,
-    applicationId: application._id,
-    membershipNumber: newMembershipNumber(now),
-    isCurrent: true,
-    legalStatus: "active",
-    admittedAt:
-      application.admissionDecision?.decidedAt ??
-      application.onboardingStartedAt ??
-      application.updatedAt ??
-      now,
-    ...(guardian?.signedAt
-      ? {
-          guardianConsent: {
-            representativeName: guardian.representativeName,
-            representativeEmail: guardian.representativeEmail,
-            signedAt: guardian.signedAt,
-            signatureStorageKey: guardian.signatureStorageKey,
-            completedPdfStorageKey: guardian.completedPdfStorageKey,
-            ipAddress: guardian.ipAddress,
-            userAgent: guardian.userAgent,
-          },
-        }
-      : {}),
-    privateEmail: application.applicantEmailNormalized,
-    firstName,
-    lastName,
-    dateOfBirth: application.dateOfBirth,
-    ...(application.applicantPhone?.trim()
-      ? { phone: application.applicantPhone.trim() }
-      : {}),
-    memberPlatformUserId: application.memberPlatformUserId,
-    updatedAt: now,
-  };
-}
-
-function splitMemberName(name?: string): {
-  firstName: string;
-  lastName: string;
-} {
-  const [firstName, ...lastNameParts] = name
-    ?.trim()
-    .split(/\s+/)
-    .filter(Boolean) ?? [undefined];
-  if (!firstName || lastNameParts.length === 0) {
-    throw new Error("Der vollständige Name fehlt.");
-  }
-  return { firstName, lastName: lastNameParts.join(" ") };
-}
-
-function newMembershipNumber(now: number): string {
-  return `YFN-${new Date(now).getUTCFullYear()}-${newId()
-    .slice(0, 6)
-    .toUpperCase()}`;
 }

--- a/app/lib/server/memberships/onboardingMembershipBuilders.ts
+++ b/app/lib/server/memberships/onboardingMembershipBuilders.ts
@@ -1,0 +1,122 @@
+import { applications } from "../../db/collections";
+import { newId } from "../../db/ids";
+import type { Application, Membership, User } from "../../db/types";
+import { loadApplicationMemberPlatformSnapshot } from "../applications/memberPlatformCandidates";
+
+export async function buildAcceptedApplicantMembership(
+  user: User & { organizationId: string; applicationId: string },
+): Promise<Membership> {
+  const application = await (
+    await applications()
+  ).findOne({
+    _id: user.applicationId,
+    organizationId: user.organizationId,
+    status: "accepted",
+  });
+  if (!application) {
+    throw new Error("Die angenommene Bewerbung wurde nicht gefunden.");
+  }
+  return buildMembership(user, application);
+}
+
+export async function buildManualMembership(
+  user: User & { organizationId: string },
+): Promise<Membership> {
+  if (!user.memberPlatformUserId) {
+    throw new Error("Das Member-Profil ist noch nicht verknüpft.");
+  }
+  const privateEmail = user.privateEmail?.trim().toLowerCase();
+  if (!privateEmail) {
+    throw new Error("Die private E-Mail-Adresse fehlt.");
+  }
+  const snapshot = await loadApplicationMemberPlatformSnapshot(
+    user.memberPlatformUserId,
+  );
+  const now = Date.now();
+  const { firstName, lastName } = splitMemberName(user.name);
+  return {
+    _id: newId(),
+    _creationTime: now,
+    organizationId: user.organizationId,
+    userId: user._id,
+    membershipNumber: newMembershipNumber(now),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt: user.registeredAt ?? user._creationTime,
+    privateEmail,
+    firstName,
+    lastName,
+    dateOfBirth: snapshot.dateOfBirth,
+    ...(user.phone?.trim() ? { phone: user.phone.trim() } : {}),
+    memberPlatformUserId: snapshot.memberPlatformUserId,
+    updatedAt: now,
+  };
+}
+
+function buildMembership(user: User, application: Application): Membership {
+  if (!application.dateOfBirth || !application.memberPlatformUserId) {
+    throw new Error("Geburtsdatum oder Member-Profil fehlen.");
+  }
+  const now = Date.now();
+  const { firstName, lastName } = splitMemberName(
+    application.applicantName ?? user.name,
+  );
+  const guardian = application.guardianConsent;
+  return {
+    _id: newId(),
+    _creationTime: now,
+    organizationId: application.organizationId,
+    userId: user._id,
+    applicationId: application._id,
+    membershipNumber: newMembershipNumber(now),
+    isCurrent: true,
+    legalStatus: "active",
+    admittedAt:
+      application.admissionDecision?.decidedAt ??
+      application.onboardingStartedAt ??
+      application.updatedAt ??
+      now,
+    ...(guardian?.signedAt
+      ? {
+          guardianConsent: {
+            representativeName: guardian.representativeName,
+            representativeEmail: guardian.representativeEmail,
+            signedAt: guardian.signedAt,
+            signatureStorageKey: guardian.signatureStorageKey,
+            completedPdfStorageKey: guardian.completedPdfStorageKey,
+            ipAddress: guardian.ipAddress,
+            userAgent: guardian.userAgent,
+          },
+        }
+      : {}),
+    privateEmail: application.applicantEmailNormalized,
+    firstName,
+    lastName,
+    dateOfBirth: application.dateOfBirth,
+    ...(application.applicantPhone?.trim()
+      ? { phone: application.applicantPhone.trim() }
+      : {}),
+    memberPlatformUserId: application.memberPlatformUserId,
+    updatedAt: now,
+  };
+}
+
+function splitMemberName(name?: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const [firstName, ...lastNameParts] = name
+    ?.trim()
+    .split(/\s+/)
+    .filter(Boolean) ?? [undefined];
+  if (!firstName || lastNameParts.length === 0) {
+    throw new Error("Der vollständige Name fehlt.");
+  }
+  return { firstName, lastName: lastNameParts.join(" ") };
+}
+
+function newMembershipNumber(now: number): string {
+  return `YFN-${new Date(now).getUTCFullYear()}-${newId()
+    .slice(0, 6)
+    .toUpperCase()}`;
+}


### PR DESCRIPTION
## summary

- remove the stale `handoverTasks` property from manually created memberships so the production typecheck passes
- split membership builders into a focused module to satisfy the source-file line limit and cover the regression
- unblock deployment of the merged document editing UI

## validation

- `pnpm exec prettier --check app/lib/server/memberships/onboardingMembership.ts app/lib/server/memberships/onboardingMembershipBuilders.ts app/lib/server/memberships/onboardingData.test.ts`
- `pnpm exec biome lint app/lib/server/memberships/onboardingMembership.ts app/lib/server/memberships/onboardingMembershipBuilders.ts app/lib/server/memberships/onboardingData.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint:lines`
- `pnpm test`
- `pnpm build`